### PR TITLE
Fix dependencies on native libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,13 +58,18 @@ dependencies {
     compile "org.lwjgl:lwjgl-openal:${lwjglVersion}"
     compile "org.lwjgl:lwjgl-opengl:${lwjglVersion}"
     compile "org.lwjgl:lwjgl-stb:${lwjglVersion}"
-    runtime "org.lwjgl:lwjgl:${lwjglVersion}:${lwjglNatives}"
-    runtime "org.lwjgl:lwjgl-glfw:${lwjglVersion}:${lwjglNatives}"
-    runtime "org.lwjgl:lwjgl-jemalloc:${lwjglVersion}:${lwjglNatives}"
-    runtime "org.lwjgl:lwjgl-openal:${lwjglVersion}:${lwjglNatives}"
-    runtime "org.lwjgl:lwjgl-opengl:${lwjglVersion}:${lwjglNatives}"
-    runtime "org.lwjgl:lwjgl-stb:${lwjglVersion}:${lwjglNatives}"
-
+    [
+        "org.lwjgl:lwjgl:${lwjglVersion}:${lwjglNatives}",
+        "org.lwjgl:lwjgl-glfw:${lwjglVersion}:${lwjglNatives}",
+        "org.lwjgl:lwjgl-jemalloc:${lwjglVersion}:${lwjglNatives}",
+        "org.lwjgl:lwjgl-openal:${lwjglVersion}:${lwjglNatives}",
+        "org.lwjgl:lwjgl-opengl:${lwjglVersion}:${lwjglNatives}",
+        "org.lwjgl:lwjgl-stb:${lwjglVersion}:${lwjglNatives}"
+    ].each {
+        testRuntime it
+        shadow it
+    }
+    
     compile files("${System.properties['java.home']}/../lib/tools.jar")
 }
 
@@ -88,4 +93,8 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 artifacts {
     archives sourcesJar
     archives javadocJar
+}
+
+shadowJar {
+    exclude 'module-info.class'
 }


### PR DESCRIPTION
This should fix #11 by changing the dependency scope of platform specific binaries to `testCompile` again and handle #16 correctly by adding those dependencies to the `shadow` configuration.

Additionally, this ensures that `module-info.class` files are excluded from the shadow task. (The `imgui-all.jar` previously contained the module declaration of LWJGL's GLFW natives.)