### PR TITLE
Added return T on invoke for MutableProperty0

### DIFF
--- a/src/test/java/imgui/MutableProperty0.java
+++ b/src/test/java/imgui/MutableProperty0.java
@@ -49,7 +49,7 @@ public class MutableProperty0<T> implements KMutableProperty0<T> {
 
     @Override
     public T invoke() {
-        return null;
+        return t;
     }
 
     @Override


### PR DESCRIPTION
In some cases like when using 'inputScalar' under 'ImGui' `MutableProperty0#invoke` is called more often the `MutableProperty0#get`. This will lead to "null" in the user input box when using MutableProperty0 over an Array.