### PR TITLE
Remove fallback for tooltips

### DIFF
--- a/imgui-core/src/main/kotlin/imgui/api/main.kt
+++ b/imgui-core/src/main/kotlin/imgui/api/main.kt
@@ -311,11 +311,11 @@ interface main {
         }
 
         // Drag and Drop: Fallback for source tooltip. This is not ideal but better than nothing.
-        if (g.dragDropActive && g.dragDropSourceFrameCount < g.frameCount) {
-            g.dragDropWithinSourceOrTarget = true
-            setTooltip("...")
-            g.dragDropWithinSourceOrTarget = false
-        }
+//        if (g.dragDropActive && g.dragDropSourceFrameCount < g.frameCount) {
+//            g.dragDropWithinSourceOrTarget = true
+//            setTooltip("...")
+//            g.dragDropWithinSourceOrTarget = false
+//        }
 
         // End frame
         g.withinFrameScope = false


### PR DESCRIPTION
Closes #116.
Probably this isn't the best way to fix, but it's a fix. Why was this fallback for tooltips implemented? (And why is it always falling back?)

Removing it transforms the tooltip for dragging from this:
![image](https://user-images.githubusercontent.com/27009727/71637382-83dd3f00-2c42-11ea-976b-ed4e239b5b4d.png)

to this:

![image](https://user-images.githubusercontent.com/27009727/71637533-81301900-2c45-11ea-9eda-6b8c88e3d00a.png)

![image](https://user-images.githubusercontent.com/27009727/71637536-a2910500-2c45-11ea-8064-d7c1a737d8f8.png)