### PR TITLE
Target the correct flag for noBackground

### DIFF
--- a/imgui-core/src/main/kotlin/imgui/demo/ExampleApp.kt
+++ b/imgui-core/src/main/kotlin/imgui/demo/ExampleApp.kt
@@ -109,7 +109,7 @@ object ExampleApp {
         if (noResize) windowFlags = windowFlags or Wf.NoResize
         if (noCollapse) windowFlags = windowFlags or Wf.NoCollapse
         if (noNav) windowFlags = windowFlags or Wf.NoNav
-        if (noBackground) windowFlags = windowFlags or Wf.NoNav
+        if (noBackground) windowFlags = windowFlags or Wf.NoBackground
         if (noBringToFront) windowFlags = windowFlags or Wf.NoBringToFrontOnFocus
         if (noClose) open = null // Don't pass our bool* to Begin
         /*  We specify a default position/size in case there's no data in the .ini file. Typically this isn't required!


### PR DESCRIPTION
Previously the demo window would target the wrong flag for its `No background` checkbox:

```kotlin
if (noBackground) windowFlags = windowFlags or NoNav
```

This PR corrects that mistake.

![image](https://user-images.githubusercontent.com/27009727/71637969-f1916700-2c52-11ea-8b5b-d14d306633c1.png)