### PR TITLE
Fix password font not popping after push

### DIFF
--- a/imgui-core/src/main/kotlin/imgui/internal/api/inputText.kt
+++ b/imgui-core/src/main/kotlin/imgui/internal/api/inputText.kt
@@ -233,7 +233,7 @@ internal interface inputText {
         val isDisplayingHint = hint != null && (if (bufDisplayFromState) state_!!.textA else buf)[0] == NUL
 
         // Password pushes a temporary font with only a fallback glyph
-        if (isPassword)
+        if (isPassword && !isDisplayingHint)
             g.inputTextPasswordFont.apply {
                 val glyph = g.font.findGlyph('*')!!
                 fontSize = g.font.fontSize


### PR DESCRIPTION
Quite humorously, the 'one glyph' password font wouldn't be popped from the stack after being pushed if the password hint was displayed. This would cause the password font to 'leak' into other widgets:
![image](https://user-images.githubusercontent.com/27009727/71638051-b5abd100-2c55-11ea-87e6-b603660da204.png)
This PR fixes that:
![image](https://user-images.githubusercontent.com/27009727/71638055-d3793600-2c55-11ea-915e-9bfbc7fd3570.png)
