### PR TITLE
Fix bugs in demo's keyboard/mouse/nav state widget

### DIFF
--- a/imgui-core/src/main/kotlin/imgui/api/inputUtilitiesMouse.kt
+++ b/imgui-core/src/main/kotlin/imgui/api/inputUtilitiesMouse.kt
@@ -10,7 +10,6 @@ import imgui.MOUSE_INVALID
 import imgui.MouseButton
 import imgui.MouseCursor
 import imgui.internal.classes.Rect
-
 /** Inputs Utilities: Mouse
  *  - To refer to a mouse button, you may use named enums in your code e.g. ImGuiMouseButton_Left, ImGuiMouseButton_Right.
  *  - You can also use regular integer: it is forever guaranteed that 0=Left, 1=Right, 2=Middle.
@@ -25,6 +24,8 @@ interface inputUtilitiesMouse {
 
     /** did mouse button clicked? (went from !Down to Down) */
     fun isMouseClicked(button: MouseButton, repeat: Boolean = false): Boolean {
+        if (button == MouseButton.None)
+            return false // The None button is never clicked.
 
         assert(button.i in io.mouseDown.indices)
         val t = io.mouseDownDuration[button.i]
@@ -41,12 +42,21 @@ interface inputUtilitiesMouse {
     }
 
     /** did mouse button released? (went from Down to !Down) */
-    fun isMouseReleased(button: MouseButton): Boolean =
-            io.mouseReleased[button.i]
+    fun isMouseReleased(button: MouseButton): Boolean {
+        if (button == MouseButton.None)
+            return false // The None button is never clicked.
+
+        return io.mouseReleased[button.i]
+    }
+
 
     /** did mouse button double-clicked? A double-click returns false in IsMouseClicked(). uses io.MouseDoubleClickTime.    */
-    fun isMouseDoubleClicked(button: MouseButton): Boolean =
-            io.mouseDoubleClicked[button.i]
+    fun isMouseDoubleClicked(button: MouseButton): Boolean {
+        if (button == MouseButton.None)
+            return false // The None button is never clicked.
+
+        return io.mouseDoubleClicked[button.i]
+    }
 
     /** Test if mouse cursor is hovering given rectangle
      *  NB- Rectangle is clipped by our current clip setting
@@ -102,12 +112,11 @@ interface inputUtilitiesMouse {
      *
      *  return the delta from the initial clicking position while the mouse button is pressed or was just released. This is locked and return 0.0f until the mouse moves past a distance threshold at least once (if lock_threshold < -1.0f, uses io.MouseDraggingThreshold) */
     fun getMouseDragDelta(button: MouseButton = MouseButton.Left, lockThreshold_: Float = -1f): Vec2 {
-
         assert(button.i in io.mouseDown.indices)
         var lockThreshold = lockThreshold_
         if (lockThreshold < 0f)
             lockThreshold = io.mouseDragThreshold
-        if (io.mouseDown[button.i] || io.mouseReleased[button.i])
+        if (button != MouseButton.None && (io.mouseDown[button.i] || io.mouseReleased[button.i]))
             if (io.mouseDragMaxDistanceSqr[button.i] >= lockThreshold * lockThreshold)
                 if (isMousePosValid(io.mousePos) && isMousePosValid(io.mouseClickedPos[button.i]))
                     return io.mousePos - io.mouseClickedPos[button.i]

--- a/imgui-core/src/main/kotlin/imgui/demo/showDemoWindowMisc.kt
+++ b/imgui-core/src/main/kotlin/imgui/demo/showDemoWindowMisc.kt
@@ -132,7 +132,7 @@ object showDemoWindowMisc {
                 io.inputQueueCharacters.forEach { c ->
                     // UTF-8 will represent some characters using multiple bytes, so we join them here
                     // example: 'ç' becomes "0xC3, 0xA7"
-                    val bytes = c.toString().toByteArray(Charsets.UTF_8).map { String.format("0x%X", it) }.joinToString()
+                    val bytes = c.toString().toByteArray().joinToString { "0x%X".format(it) }
                     sameLine();  text("\'%c\' (%s)", if(c > ' ' && c.i <= 255) c else '?', bytes)
                 }
 

--- a/imgui-core/src/main/kotlin/imgui/demo/showDemoWindowMisc.kt
+++ b/imgui-core/src/main/kotlin/imgui/demo/showDemoWindowMisc.kt
@@ -130,8 +130,11 @@ object showDemoWindowMisc {
                 text("Keys mods: $ctrl$shift$alt$super_")
                 text("Chars queue:")
                 io.inputQueueCharacters.forEach { c ->
-                    sameLine();  text("\'%c\' (0x%04X)", if(c > ' ' && c.i <= 255) c else '?', c)
-                } // FIXME: We should convert 'c' to UTF-8 here but the functions are not public.
+                    // UTF-8 will represent some characters using multiple bytes, so we join them here
+                    // example: 'ç' becomes "0xC3, 0xA7"
+                    val bytes = c.toString().toByteArray(Charsets.UTF_8).map { String.format("0x%X", it) }.joinToString()
+                    sameLine();  text("\'%c\' (%s)", if(c > ' ' && c.i <= 255) c else '?', bytes)
+                }
 
                 text("NavInputs down:")
                 io.navInputs.filter { it > 0f }.forEachIndexed { i, it -> sameLine(); text("[$i] %.2f", it) }


### PR DESCRIPTION
This PR fixes two bugs at once, both preventing the 'Keyboard, Mouse & Navigation State' tree node from being viewed in the demo window.

1. Because the `None` button's state was being queried, I added the assumption that the `None` button will never be pressed, released or dragged. (Otherwise, this would try to get `mouseDownDuration[-1]`)
This is a prettier fix in my opinion than just removing the query in the demo window. It will also save other programmers from the same mistake the demo window made.
There is an `assert` doing the same check in `getMouseDragDelta`, but assertions will only work if the `-ea` VM flag is present. (And will crash as well, anyways)

2. The 'chars queue' would previously try to format a number (`0x%04X`) but pass a character, leading to a crash.
I fixed this by doing what the FIXME accompanying the format requested, and opted for the UTF-8 representation instead.

Now everything works nicely again.
![image](https://user-images.githubusercontent.com/27009727/71648792-42639700-2d09-11ea-8607-cc7ac6330d1e.png)