### PR TITLE
Implement DrawList#addCallback

### DIFF
--- a/imgui-core/src/main/kotlin/imgui/classes/DrawList.kt
+++ b/imgui-core/src/main/kotlin/imgui/classes/DrawList.kt
@@ -784,7 +784,7 @@ class DrawList(sharedData: DrawListSharedData?) {
     // -----------------------------------------------------------------------------------------------------------------
     /** Your rendering function must check for 'UserCallback' in ImDrawCmd and call the function instead of rendering
     triangles.  */
-    fun addCallback(callback: DrawCallback, callbackData: ByteBuffer?) {
+    fun addCallback(callback: DrawCallback, callbackData: ByteBuffer? = null) {
         var currentCmd = cmdBuffer.peek()
         if (currentCmd == null || currentCmd.elemCount != 0 || currentCmd.userCallback != null) {
             addDrawCmd()
@@ -793,7 +793,7 @@ class DrawList(sharedData: DrawListSharedData?) {
 
         currentCmd.userCallback = callback
         currentCmd.userCallbackData = callbackData
-        addDrawCmd()
+        addDrawCmd() // Force a new command after us (see comment below)
     }
 
     /** This is useful if you need to forcefully create a new draw call (to allow for dependent rendering / blending).

--- a/imgui-core/src/main/kotlin/imgui/classes/DrawList.kt
+++ b/imgui-core/src/main/kotlin/imgui/classes/DrawList.kt
@@ -784,7 +784,17 @@ class DrawList(sharedData: DrawListSharedData?) {
     // -----------------------------------------------------------------------------------------------------------------
     /** Your rendering function must check for 'UserCallback' in ImDrawCmd and call the function instead of rendering
     triangles.  */
-    fun addCallback(/*ImDrawCallback callback, void* callback_data*/): Nothing = TODO()
+    fun addCallback(callback: DrawCallback, callbackData: ByteBuffer?) {
+        var currentCmd = cmdBuffer.peek()
+        if (currentCmd == null || currentCmd.elemCount != 0 || currentCmd.userCallback != null) {
+            addDrawCmd()
+            currentCmd = cmdBuffer.peek()
+        }
+
+        currentCmd.userCallback = callback
+        currentCmd.userCallbackData = callbackData
+        addDrawCmd()
+    }
 
     /** This is useful if you need to forcefully create a new draw call (to allow for dependent rendering / blending).
     Otherwise primitives are merged into the same draw-call as much as possible */


### PR DESCRIPTION
This PR implements the draw list `addCallback` function.

I could get callbacks to work using `windowDrawList`:
```kotlin
windowDrawList.addCallback({ list: DrawList, cmd: DrawCmd ->
    println("Callback called!")
}, null)
```

but **not** using `foregroundDrawList`:
```kotlin
foregroundDrawList.addCallback({ list: DrawList, cmd: DrawCmd ->
    println("Callback called!")
}, null)
```
This wouldn't print anything in the console. The previous example did.

Is this intentional?