### PR TITLE
Iterate over tabbars buffer instead of using get by id

### DIFF
--- a/imgui-core/src/main/kotlin/imgui/api/demoDebugInformations.kt
+++ b/imgui-core/src/main/kotlin/imgui/api/demoDebugInformations.kt
@@ -218,8 +218,8 @@ interface demoDebugInformations {
         }
 
         if (treeNode("TabBars", "Tab Bars (${g.tabBars.size})")) {
-            for (n in 0 until g.tabBars.size)
-                Funcs.nodeTabBar(g.tabBars[n]!!)
+            for (n in 0 until g.tabBars.buf.size)
+                Funcs.nodeTabBar(g.tabBars.buf[n]!!)
             treePop()
         }
 


### PR DESCRIPTION
This PR fixes a NPE bug where the Metrics 'TabBars' tree would cause a null pointer assertion exception when a tab bar was available.

`g.tabBars.get()` works by-ID here instead of index. Instead, we just loop over the underlying buffer in which we can loop by index.