### PR TITLE
Build and upload fat jars through actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       run: mkdir shadowJars && mv */build/libs/imgui-*.jar shadowJars
     - uses: actions/upload-artifact@v1
       with:
-        name: ImGui artifacts (linux)
+        name: ImGui linux artifacts
         path: 'shadowJars'
 
   windows: 
@@ -38,6 +38,14 @@ jobs:
           java-version: 11
       - name: Build with Gradle
         run: .\gradlew.bat build
+      - name: Build fat jars
+        run: ./gradlew shadowJar
+      - name: Move jars
+        run: mkdir shadowJars; mv */build/libs/imgui-*.jar shadowJars
+      - uses: actions/upload-artifact@v1
+        with:
+          name: ImGui windows artifacts
+          path: 'shadowJars'
                 
   mac: 
     name: 'Mac OS'
@@ -53,3 +61,11 @@ jobs:
         run: chmod +x gradlew
       - name: Build with Gradle
         run: ./gradlew build
+      - name: Build fat jars
+        run: ./gradlew shadowJar
+      - name: Move jars
+        run: mkdir shadowJars && mv */build/libs/imgui-*.jar shadowJars
+      - uses: actions/upload-artifact@v1
+        with:
+          name: ImGui macOS artifacts
+          path: 'shadowJars'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,15 @@ jobs:
       run: chmod +x gradlew
     - name: Build with Gradle
       run: ./gradlew build
-      
+    - name: Build fat jars
+      run: ./gradlew shadowJar
+    - name: Move jars
+      run: mkdir shadowJars && mv */build/libs/imgui-*.jar shadowJars
+    - uses: actions/upload-artifact@v1
+      with:
+        name: ImGui artifacts (linux)
+        path: 'shadowJars'
+
   windows: 
     name: 'Windows'
     runs-on: windows-latest


### PR DESCRIPTION
Closes #126 

This will build and upload all fat jars (of all modules) on each actions build.
I don't know if the binaries are any different between linux, windows and mac OS. They're separate now. If you're wondering what this looks like, take a look at [this](https://github.com/zeroeightysix/imgui/commit/1bcf707e0f788c1519d9b0dabd51def43db6b91f/checks?check_suite_id=410812036) build. Click the '_Artifacts (3)_' button in the top right.