### PR TITLE
Remove 32 character limit on drag & drop types

### DIFF
--- a/imgui-core/src/main/kotlin/imgui/api/demoDebugInformations.kt
+++ b/imgui-core/src/main/kotlin/imgui/api/demoDebugInformations.kt
@@ -259,7 +259,7 @@ interface demoDebugInformations {
             text("NavActivateId: 0x%08X, NavInputId: 0x%08X", g.navActivateId, g.navInputId)
             text("NavDisableHighlight: ${g.navDisableHighlight}, NavDisableMouseHover: ${g.navDisableMouseHover}")
             text("NavWindowingTarget: '${g.navWindowingTarget?.name}'")
-            text("DragDrop: ${g.dragDropActive}, SourceId = 0x%08X, Payload \"${g.dragDropPayload.dataTypeS}\" " +
+            text("DragDrop: ${g.dragDropActive}, SourceId = 0x%08X, Payload \"${g.dragDropPayload.dataType}\" " +
                     "(${g.dragDropPayload.dataSize} bytes)", g.dragDropPayload.sourceId)
             treePop()
         }

--- a/imgui-core/src/main/kotlin/imgui/api/dragAndDrop.kt
+++ b/imgui-core/src/main/kotlin/imgui/api/dragAndDrop.kt
@@ -136,7 +136,7 @@ interface dragAndDrop {
         val cond = if (cond_ == Cond.None) Cond.Always else cond_
 
         assert(type.isNotEmpty())
-        assert(type.length < 32) { "Payload type can be at most 32 characters long" }
+//        assert(type.length < 32) { "Payload type can be at most 32 characters long" }
 //        assert((data != NULL && data_size > 0) || (data == NULL && data_size == 0))
         assert(cond == Cond.Always || cond == Cond.Once)
         assert(payload.sourceId != 0) { "Not called between beginDragDropSource() and endDragDropSource()" }
@@ -170,7 +170,7 @@ interface dragAndDrop {
 
         if (cond == Cond.Always || payload.dataFrameCount == -1) {
             // Copy payload
-            type.toCharArray(payload.dataType)
+            payload.dataType = type
             g.dragDropPayloadBufHeap = ByteBuffer.allocate(0)
             when {
                 size > g.dragDropPayloadBufLocal.rem -> { // Store in heap

--- a/imgui-core/src/main/kotlin/imgui/classes/misc.kt
+++ b/imgui-core/src/main/kotlin/imgui/classes/misc.kt
@@ -88,9 +88,8 @@ class Payload {
     var sourceParentId: ID = 0
     /** Data timestamp */
     var dataFrameCount = -1
-    /** Data type tag (short user-supplied string, 32 characters max) */
-    val dataType = CharArray(32)
-    val dataTypeS get() = String(dataType)
+    /** Data type tag (short user-supplied string, 32 characters max) */ // JVM: No character limit
+    var dataType: String? = null
     /** Set when AcceptDragDropPayload() was called and mouse has been hovering the target item (nb: handle overlapping drag targets) */
     var preview = false
     /** Set when AcceptDragDropPayload() was called and mouse button is released over the target item. */
@@ -101,13 +100,13 @@ class Payload {
         sourceId = 0
         data = null
         dataSize = 0
-        dataType.fill(NUL)
+        dataType = null
         dataFrameCount = -1
         delivery = false
         preview = false
     }
 
-    fun isDataType(type: String): Boolean = dataFrameCount != -1 && type cmp dataType
+    fun isDataType(type: String): Boolean = dataFrameCount != -1 && type == dataType
 }
 
 class SizeCallbackData(


### PR DESCRIPTION
This removes the 32 character limit on drag & drop types by switching from using a `CharArray` internally to just a `String?`.

Considering you mentioned earlier you use comments to navigate code, I left the comment mentioning the 32 character limit in.