### PR TITLE
Store any object for drag & drop payloads instead of using a ByteBuffer

### DIFF
--- a/imgui-core/src/main/kotlin/imgui/api/widgetsColorEditorPicker.kt
+++ b/imgui-core/src/main/kotlin/imgui/api/widgetsColorEditorPicker.kt
@@ -265,13 +265,14 @@ interface widgetsColorEditorPicker {
         if (window.dc.lastItemStatusFlags has ItemStatusFlag.HoveredRect && beginDragDropTarget()) {
             var acceptedDragDrop = false
             acceptDragDropPayload(PAYLOAD_TYPE_COLOR_3F)?.let {
+                val data = it.data!! as Vec4
                 for (j in 0..2)  // Preserve alpha if any
-                    col[j] = it.data!!.asFloatBuffer()[j]
+                    col[j] = data.array[j]
                 acceptedDragDrop = true
                 valueChanged = true
             }
             acceptDragDropPayload(PAYLOAD_TYPE_COLOR_4F)?.let {
-                val floats = it.data!!.asFloatBuffer()
+                val floats = (it.data!! as Vec4).array
                 for (j in 0 until components)
                     col[j] = floats[j]
                 acceptedDragDrop = true
@@ -753,9 +754,9 @@ interface widgetsColorEditorPicker {
         if (g.activeId == id && flags hasnt Cef.NoDragDrop && beginDragDropSource()) {
 
             if (flags has Cef.NoAlpha)
-                setDragDropPayload(PAYLOAD_TYPE_COLOR_3F, colRgb, Vec3.size, Cond.Once)
+                setDragDropPayload(PAYLOAD_TYPE_COLOR_3F, colRgb, Cond.Once)
             else
-                setDragDropPayload(PAYLOAD_TYPE_COLOR_4F, colRgb, Vec4.size, Cond.Once)
+                setDragDropPayload(PAYLOAD_TYPE_COLOR_4F, colRgb, Cond.Once)
             colorButton(descId, col, flags)
             sameLine()
             textEx("Color")

--- a/imgui-core/src/main/kotlin/imgui/classes/misc.kt
+++ b/imgui-core/src/main/kotlin/imgui/classes/misc.kt
@@ -75,8 +75,9 @@ class OnceUponAFrame {
 class Payload {
     // Members
 
-    /** Data (copied and owned by dear imgui) */
-    var data: ByteBuffer? = null
+    // /** Data (copied and owned by dear imgui) */
+    /** Data provided by setDragDropSource */
+    var data: Any? = null
     /** Data size */
     var dataSize = 0
 

--- a/imgui-core/src/main/kotlin/imgui/demo/showDemoWindowWidgets.kt
+++ b/imgui-core/src/main/kotlin/imgui/demo/showDemoWindowWidgets.kt
@@ -7,6 +7,7 @@ import glm_.i
 import glm_.s
 import glm_.vec2.Vec2
 import glm_.vec2.operators.div
+import glm_.vec3.Vec3
 import glm_.vec4.Vec4
 import imgui.*
 import imgui.ImGui.acceptDragDropPayload
@@ -988,10 +989,10 @@ object showDemoWindowWidgets {
                             // (Note that ColorButton is already a drag source by default, unless using ImGuiColorEditFlags_NoDragDrop)
                             if (beginDragDropTarget()) {
                                 acceptDragDropPayload(PAYLOAD_TYPE_COLOR_3F)?.let {
-                                    for (i in 0..2) savedPalette[n][i] = it.data!!.getFloat(i)
+                                    for (i in 0..2) savedPalette[n][i] = (it.data!! as Vec3).array[i]
                                 }
                                 acceptDragDropPayload(PAYLOAD_TYPE_COLOR_4F)?.let {
-                                    for (i in 0..3) savedPalette[n][i] = it.data!!.getFloat(i)
+                                    for (i in 0..3) savedPalette[n][i] = (it.data!! as Vec4).array[i]
                                 }
                                 endDragDropTarget()
                             }
@@ -1277,7 +1278,7 @@ object showDemoWindowWidgets {
 
                     // Our buttons are both drag sources and drag targets here!
                     if (beginDragDropSource(DragDropFlag.None)) {
-                        setDragDropPayload("DND_DEMO_CELL", n, Int.BYTES)        // Set payload to carry the index of our item (could be anything)
+                        setDragDropPayload("DND_DEMO_CELL", n)        // Set payload to carry the index of our item (could be anything)
                         when (mode) {
                             // Display preview (could be anything, e.g. when dragging an image we could decide to display the filename and a small preview of the image, etc.)
                             Mode.Copy -> text("Copy $name")
@@ -1289,7 +1290,7 @@ object showDemoWindowWidgets {
                     if (beginDragDropTarget()) {
                         acceptDragDropPayload("DND_DEMO_CELL")?.let { payload ->
                             assert(payload.dataSize == Int.BYTES)
-                            val payloadN = payload.data!!.getInt(0)
+                            val payloadN = payload.data!! as Int
                             when (mode) {
                                 Mode.Copy -> names[n] = names[payloadN]
                                 Mode.Move -> {


### PR DESCRIPTION
This PR removes being limited to primitive numbers and vectors for drag & drop payloads, depending on casting types instead.

Example usage:
```kotlin
data class Person(
        val name: String,
        val age: Int,
        val dead: Boolean = false
)

button("Drag source")
if (beginDragDropSource()) {
    setDragDropPayload("CUSTOM_PAYLOAD", Person("Henry", 17))
    endDragDropSource()
}

button("Drag target")
if (beginDragDropTarget()) {
    acceptDragDropPayload("CUSTOM_PAYLOAD")?.let {
        val data = it.data!! as Person
        println("Received a person: $data")
    }
    endDragDropTarget()
}
```