### PR TITLE
Remove kotlin-graphics/kotlin-unsigned, rely on stdlib

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext{
     gln_version = '880960aeaf813f72242f03458cf44e606d4c05f0'
     gli_version = '57d313a2c7691b3b65168fe21eb50433a1358656'
     glm_version = '1b4ac18dd1a3c23440d3f33596688aac60bc0141'
-    unsigned_version = '18131d0fe0b7465a145a4502d31452c5ae0e59a1'
+    // unsigned_version = '18131d0fe0b7465a145a4502d31452c5ae0e59a1'
     kool_version = 'fcf04b2c03b8949d9d9a8b0a580082e927903510'
     lwjgl_version = "3.2.3"
     lwjgl_natives = current() == WINDOWS ? "windows" : current() == LINUX ? "linux" : "macos"

--- a/imgui-core/build.gradle
+++ b/imgui-core/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation "$kx:gli:$gli_version"
     implementation "${kx}.glm:glm:$glm_version"
     implementation "$kx:kool:$kool_version"
-    implementation "$kx:kotlin-unsigned:$unsigned_version"
+    //implementation "$kx:kotlin-unsigned:$unsigned_version"
 
     ["", "-jemalloc", "-stb"].each {
         String base = "org.lwjgl:lwjgl$it:$lwjgl_version"

--- a/imgui-core/src/main/java/module-info.java
+++ b/imgui-core/src/main/java/module-info.java
@@ -9,7 +9,6 @@ module com.github.kotlin_graphics.imgui_core {
     requires com.github.kotlin_graphics.gli;
     requires com.github.kotlin_graphics.glm;
     requires com.github.kotlin_graphics.kool;
-    requires com.github.kotlin_graphics.kotlin_unsigned;
 
     requires org.lwjgl;
     requires org.lwjgl.stb;

--- a/imgui-core/src/main/kotlin/imgui/demo/showDemoWindowWidgets.kt
+++ b/imgui-core/src/main/kotlin/imgui/demo/showDemoWindowWidgets.kt
@@ -158,7 +158,6 @@ import imgui.dsl.withStyleVar
 import imgui.dsl.withTextWrapPos
 import imgui.or
 import kool.BYTES
-import unsigned.Ubyte
 import kotlin.math.cos
 import kotlin.math.floor
 import imgui.ColorEditFlag as Cef
@@ -300,7 +299,7 @@ object showDemoWindowWidgets {
     /* Data Types */
     // State
     var s8_v = 127.b
-    var u8_v = Ubyte(255)
+    var u8_v = 255u
     var s16_v = 32767.s
     //    static ImU16  u16_v = 65535;
     var s32_v = -1
@@ -363,6 +362,7 @@ object showDemoWindowWidgets {
     var dummyStr = "This is a dummy field to be able to tab-out of the widgets above.".toCharArray()
     var testWindow = false
 
+    @ExperimentalUnsignedTypes
     operator fun invoke() {
 
         if (!collapsingHeader("Widgets"))
@@ -1076,11 +1076,11 @@ object showDemoWindowWidgets {
             val s8_fifty: Byte = 50.b;
             val s8_min: Byte = (-128).b;
             val s8_max: Byte = 127.b
-            val u8_zero: Ubyte = Ubyte(0);
-            val u8_one: Ubyte = Ubyte(1);
-            val u8_fifty: Ubyte = Ubyte(50);
-            val u8_min: Ubyte = Ubyte(0);
-            val u8_max: Ubyte = Ubyte(255)
+            val u8_zero: UByte = 0u;
+            val u8_one: UByte = 1u;
+            val u8_fifty: UByte = 50u;
+            val u8_min: UByte = 0u;
+            val u8_max: UByte = 255u;
             val s16_zero: Short = 0.s;
             val s16_one: Short = 1.s;
             val s16_fifty: Short = 50.s;

--- a/imgui-core/src/main/kotlin/imgui/font/FontAtlas.kt
+++ b/imgui-core/src/main/kotlin/imgui/font/FontAtlas.kt
@@ -18,7 +18,6 @@ import org.lwjgl.stb.*
 import uno.convert.decode85
 import uno.kotlin.plusAssign
 import uno.stb.stb
-import unsigned.toULong
 import java.nio.ByteBuffer
 import kotlin.math.floor
 import kotlin.math.sqrt
@@ -325,9 +324,10 @@ class FontAtlas {
     }
 
     /** Id needs to be >= 0x110000. Id >= 0x80000000 are reserved for ImGui and DrawList   */
+    @ExperimentalUnsignedTypes
     fun addCustomRectRegular(id: Int, width: Int, height: Int): Int {
         // Breaking change on 2019/11/21 (1.74): ImFontAtlas::AddCustomRectRegular() now requires an ID >= 0x110000 (instead of >= 0x10000)
-        assert(id.toULong() >= 0x110000 && width in 0..0xFFFF && height in 0..0xFFFF)
+        assert(id.toULong() >= 0x110000u && width in 0..0xFFFF && height in 0..0xFFFF)
         val r = CustomRect()
         r.id = id
         r.width = width

--- a/imgui-core/src/main/kotlin/imgui/internal/api/dataTypeHelpers.kt
+++ b/imgui-core/src/main/kotlin/imgui/internal/api/dataTypeHelpers.kt
@@ -8,10 +8,6 @@ import imgui.internal.addClampOverflow
 import imgui.internal.subClampOverflow
 import uno.kotlin.getValue
 import uno.kotlin.setValue
-import unsigned.Ubyte
-import unsigned.Uint
-import unsigned.Ulong
-import unsigned.Ushort
 import kotlin.reflect.KMutableProperty0
 
 /** Data type helpers */
@@ -20,6 +16,7 @@ internal interface dataTypeHelpers {
     //    IMGUI_API const ImGuiDataTypeInfo*  DataTypeGetInfo(ImGuiDataType data_type);
 
     /** DataTypeFormatString */
+    @ExperimentalUnsignedTypes
     fun KMutableProperty0<*>.format(dataType: DataType, format: String, size: Int = 0): CharArray {
         // useless
 //    val value: Number = when (dataType) {
@@ -30,20 +27,14 @@ internal interface dataTypeHelpers {
 //        else -> throw Error()
 //    }
         val t = this()
-        val string = format.format(style.locale, when (t) {
-            // we need to intervene since java printf cant handle %u
-            is Ubyte -> t.i
-            is Ushort -> t.i
-            is Uint -> t.L
-            is Ulong -> t.toBigInt()
-            else -> t // normal scalar
-        })
+        val string = format.format(style.locale, t)
         return when (size) {
             0 -> string.toCharArray()
             else -> string.toCharArray(CharArray(size))
         }
     }
 
+    @ExperimentalUnsignedTypes
     fun <N : Number> dataTypeApplyOp(dataType: DataType, op: Char, value1: N, value2: N): N {
         assert(op == '+' || op == '-')
         return when (dataType) {
@@ -57,8 +48,8 @@ internal interface dataTypeHelpers {
                 else -> throw Error()
             }
             DataType.Ubyte -> when (op) {
-                '+' -> Ubyte(addClampOverflow((value1 as Ubyte).i, (value2 as Ubyte).i, U8_MIN, U8_MAX)) as N
-                '-' -> Ubyte(subClampOverflow((value1 as Ubyte).i, (value2 as Ubyte).i, U8_MIN, U8_MAX)) as N
+                '+' -> addClampOverflow(value1.i, value2.i, U8_MIN, U8_MAX) as N
+                '-' -> subClampOverflow(value1.i, value2.i, U8_MIN, U8_MAX) as N
                 else -> throw Error()
             }
             DataType.Short -> when (op) {
@@ -67,8 +58,8 @@ internal interface dataTypeHelpers {
                 else -> throw Error()
             }
             DataType.Ushort -> when (op) {
-                '+' -> Ushort(addClampOverflow((value1 as Ushort).i, (value2 as Ushort).i, U16_MIN, U16_MAX)) as N
-                '-' -> Ushort(subClampOverflow((value1 as Ushort).i, (value2 as Ushort).i, U16_MIN, U16_MAX)) as N
+                '+' -> addClampOverflow(value1.i, value2.i, U16_MIN, U16_MAX) as N
+                '-' -> subClampOverflow(value1.i, value2.i, U16_MIN, U16_MAX) as N
                 else -> throw Error()
             }
             DataType.Int -> when (op) {
@@ -77,8 +68,8 @@ internal interface dataTypeHelpers {
                 else -> throw Error()
             }
             DataType.Uint -> when (op) {
-                '+' -> Uint(addClampOverflow((value1 as Uint).L, (value2 as Uint).L, 0L, Uint.MAX_VALUE)) as N
-                '-' -> Uint(subClampOverflow((value1 as Uint).L, (value2 as Uint).L, 0L, Uint.MAX_VALUE)) as N
+                '+' -> addClampOverflow(value1.L, value2.L, 0L, UInt.MAX_VALUE.toLong()) as N
+                '-' -> subClampOverflow(value1.L, value2.L, 0L, UInt.MAX_VALUE.toLong()) as N
                 else -> throw Error()
             }
             DataType.Long -> when (op) {
@@ -87,8 +78,8 @@ internal interface dataTypeHelpers {
                 else -> throw Error()
             }
             DataType.Ulong -> when (op) {
-                '+' -> Ulong(addClampOverflow((value1 as Ulong).toBigInt(), (value2 as Ulong).toBigInt(), Ulong.MIN_VALUE, Ulong.MAX_VALUE)) as N
-                '-' -> Ulong(subClampOverflow((value1 as Ulong).toBigInt(), (value2 as Ulong).toBigInt(), Ulong.MIN_VALUE, Ulong.MAX_VALUE)) as N
+                '+' -> addClampOverflow(value1.toLong().toBigInteger(), value2.toLong().toBigInteger(), ULong.MIN_VALUE.toLong().toBigInteger(), ULong.MAX_VALUE.toLong().toBigInteger()) as N
+                '-' -> subClampOverflow(value1.toLong().toBigInteger(), value2.toLong().toBigInteger(), ULong.MIN_VALUE.toLong().toBigInteger(), ULong.MAX_VALUE.toLong().toBigInteger()) as N
                 else -> throw Error()
             }
             DataType.Float -> when (op) {

--- a/imgui-core/src/main/kotlin/imgui/internal/generic helpers.kt
+++ b/imgui-core/src/main/kotlin/imgui/internal/generic helpers.kt
@@ -10,8 +10,6 @@ import imgui.minus
 import imgui.plus
 import kool.BYTES
 import kool.rem
-import unsigned.toBigInt
-import unsigned.toUInt
 import java.math.BigInteger
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
@@ -84,15 +82,17 @@ val GCrc32LookupTable = longArrayOf(
 /** Known size hash
  *  It is ok to call ImHashData on a string with known length but the ### operator won't be supported.
  *  FIXME-OPT: Replace with e.g. FNV1a hash? CRC32 pretty much randomly access 1KB. Need to do proper measurements. */
+@ExperimentalUnsignedTypes
 fun hash(data: ByteBuffer, seed: Int = 0): Int {
     var crc = seed.inv()
     val crc32Lut = GCrc32LookupTable
     var dataSize = data.rem
     while (dataSize-- != 0)
-        crc = (crc ushr 8) xor crc32Lut[(crc and 0xFF) xor data.get().toUInt()]
+        crc = (crc ushr 8) xor crc32Lut[(crc and 0xFF) xor data.get().toUInt().toInt()]
     return crc.inv()
 }
 
+@ExperimentalUnsignedTypes
 fun hash(data: String, dataSize_: Int = 0, seed_: Int = 0): Int {
 
     /*
@@ -124,7 +124,7 @@ fun hash(data: String, dataSize_: Int = 0, seed_: Int = 0): Int {
 //            val d = crc and 0xFF
 //            val e = d xor c.b.toUnsignedInt
 //            crc = b xor crc32Lut[e]
-            crc = (crc ushr 8) xor crc32Lut[(crc and 0xFF) xor c.b.toUInt()] // unsigned -> avoid negative values being passed as indices
+            crc = (crc ushr 8) xor crc32Lut[(crc and 0xFF) xor c.b.toUInt().toInt()] // unsigned -> avoid negative values being passed as indices
         }
     return crc.inv()
 }
@@ -274,14 +274,14 @@ fun subClampOverflow(a: Long, b: Long, mn: Long, mx: Long): Long = when {
 
 /** Ulong versions */
 fun addClampOverflow(a: BigInteger, b: BigInteger, mn: BigInteger, mx: BigInteger): BigInteger = when {
-    b < 0.toBigInt() && (a < mn - b) -> mn
-    b > 0.toBigInt() && (a > mx - b) -> mx
+    b < 0.toBigInteger() && (a < mn - b) -> mn
+    b > 0.toBigInteger() && (a > mx - b) -> mx
     else -> a + b
 }
 
 fun subClampOverflow(a: BigInteger, b: BigInteger, mn: BigInteger, mx: BigInteger): BigInteger = when {
-    b > 0.toBigInt() && (a < mn + b) -> mn
-    b < 0.toBigInt() && (a > mx + b) -> mx
+    b > 0.toBigInteger() && (a < mn + b) -> mn
+    b < 0.toBigInteger() && (a > mx + b) -> mx
     else -> a - b
 }
 

--- a/imgui-gl/build.gradle
+++ b/imgui-gl/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     implementation "${kx}.glm:glm:$glm_version"
     implementation "$kx:gln:$gln_version"
     implementation "$kx:kool:$kool_version"
-    implementation "$kx:kotlin-unsigned:$unsigned_version"
+    // implementation "$kx:kotlin-unsigned:$unsigned_version"
     ["core", "gl"].each {
         implementation "${kx}.uno-sdk:uno-$it:$uno_version"
     }

--- a/imgui-gl/src/main/java/module-info.java
+++ b/imgui-gl/src/main/java/module-info.java
@@ -10,7 +10,6 @@ module com.github.kotlin_graphics.imgui_gl {
     requires com.github.kotlin_graphics.glm;
     requires com.github.kotlin_graphics.gln;
     requires com.github.kotlin_graphics.kool;
-    requires com.github.kotlin_graphics.kotlin_unsigned;
 
     requires org.lwjgl.opengl;
     requires org.lwjgl.glfw;


### PR DESCRIPTION
[Unsigned integers and literals](https://kotlinlang.org/docs/reference/basic-types.html#unsigned-integers) were introduced to Kotlin in version 1.3 and are currently experimental.

This PR aims to remove the legacy [kotlin-unsigned](https://github.com/kotlin-graphics/kotlin-unsigned) library and depend on stdlib's unsigned values instead.

I wasn't sure about some conversions here, so please carefully check the code for unwanted side effects!