### PR TITLE
Fix docking preview

### DIFF
--- a/imgui-core/src/main/kotlin/imgui/internal/api/docking.kt
+++ b/imgui-core/src/main/kotlin/imgui/internal/api/docking.kt
@@ -341,9 +341,10 @@ interface docking {
         val payloadWindow = payload.data as Window
         acceptDragDropPayload(IMGUI_PAYLOAD_TYPE_WINDOW, DragDropFlag.AcceptBeforeDelivery or DragDropFlag.AcceptNoDrawDefaultRect)?.let {
             // Select target node
+            var allowNullTargetNode = false
             val node: DockNode? = window.dockNodeAsHost?.let {
                 dockNodeTreeFindNodeByPos(window.dockNodeAsHost!!, g.io.mousePos)
-            } ?: window.dockNode
+            } ?: window.dockNode ?: (null.also {allowNullTargetNode = true})
 
             val explicitTargetRect = node?.let { n -> n.tabBar?.let { t -> if (!n.isHiddenTabBar && !n.isNoTabBar) Rect(t.barRect) else null } }
                     ?: Rect(window.pos, window.pos + Vec2(window.size.x, frameHeight))
@@ -352,7 +353,7 @@ interface docking {
             // Preview docking request and find out split direction/ratio
             //const bool do_preview = true;     // Ignore testing for payload->IsPreview() which removes one frame of delay, but breaks overlapping drop targets within the same window.
             val doPreview = payload.preview || payload.delivery
-            if (doPreview) {
+            if (doPreview && (node != null || allowNullTargetNode)) {
                 val splitInner = DockPreviewData()
                 val splitOuter = DockPreviewData()
                 var splitData = splitInner

--- a/imgui-core/src/main/kotlin/imgui/internal/api/docking.kt
+++ b/imgui-core/src/main/kotlin/imgui/internal/api/docking.kt
@@ -341,18 +341,10 @@ interface docking {
         val payloadWindow = payload.data as Window
         acceptDragDropPayload(IMGUI_PAYLOAD_TYPE_WINDOW, DragDropFlag.AcceptBeforeDelivery or DragDropFlag.AcceptNoDrawDefaultRect)?.let {
             // Select target node
-            var node: DockNode? = null
-            var allowNullTargetNode = false
-            window.dockNodeAsHost.let { host ->
-                if (host != null)
-                    node = dockNodeTreeFindNodeByPos(host, io.mousePos)
-                else window.dockNode.let {
-                    if (it != null) // && window->DockIsActive)
-                        node = it
-                    else
-                        allowNullTargetNode = true // Dock into a regular window
-                }
-            }
+            val node: DockNode? = window.dockNodeAsHost?.let {
+                dockNodeTreeFindNodeByPos(window.dockNodeAsHost!!, g.io.mousePos)
+            } ?: window.dockNode
+
             val explicitTargetRect = node?.let { n -> n.tabBar?.let { t -> if (!n.isHiddenTabBar && !n.isNoTabBar) Rect(t.barRect) else null } }
                     ?: Rect(window.pos, window.pos + Vec2(window.size.x, frameHeight))
             val isExplicitTarget = io.configDockingWithShift || isMouseHoveringRect(explicitTargetRect.min, explicitTargetRect.max)
@@ -360,7 +352,7 @@ interface docking {
             // Preview docking request and find out split direction/ratio
             //const bool do_preview = true;     // Ignore testing for payload->IsPreview() which removes one frame of delay, but breaks overlapping drop targets within the same window.
             val doPreview = payload.preview || payload.delivery
-            if (doPreview && (node != null || allowNullTargetNode)) {
+            if (doPreview) {
                 val splitInner = DockPreviewData()
                 val splitOuter = DockPreviewData()
                 var splitData = splitInner

--- a/imgui-core/src/main/kotlin/imgui/static/dockNode.kt
+++ b/imgui-core/src/main/kotlin/imgui/static/dockNode.kt
@@ -1089,7 +1089,7 @@ fun dockNodePreviewDockRender(hostWindow: Window, hostNode: DockNode?, rootPaylo
     // In case the two windows involved are on different viewports, we will draw the overlay on each of them.
     val overlayDrawLists = mutableListOf(getForegroundDrawList(hostWindow.viewport!!))
     if (hostWindow.viewport !== rootPayload.viewport && !isTransparentPayload)
-        overlayDrawLists.add(getForegroundDrawList(rootPayload.viewport!!))
+        overlayDrawLists += getForegroundDrawList(rootPayload.viewport!!)
 
     // Draw main preview rectangle
     val overlayColTabs = Col.TabActive.u32

--- a/imgui-core/src/main/kotlin/imgui/static/dockNode.kt
+++ b/imgui-core/src/main/kotlin/imgui/static/dockNode.kt
@@ -1115,13 +1115,16 @@ fun dockNodePreviewDockRender(hostWindow: Window, hostNode: DockNode?, rootPaylo
         val tabBarRect = Rect()
         dockNodeCalcTabBarLayout(data.futureNode, null, tabBarRect, null)
         val tabPos = Vec2(tabBarRect.min)
-        hostNode?.tabBar?.let {
-            tabPos.x += when {
-                // We don't use OffsetNewTab because when using non-persistent-order tab bar it is incremented with each Tab submission.
-                !hostNode.isHiddenTabBar && !hostNode.isNoTabBar -> it.offsetMax + style.itemInnerSpacing.x
-                else -> style.itemInnerSpacing.x + tabItemCalcSize(hostNode.windows[0].name, hostNode.windows[0].hasCloseButton).x
-            } // Account for slight offset which will be added when changing from title bar to tab bar
-        }
+        if (hostNode?.tabBar != null) {
+            hostNode.tabBar?.let {
+                tabPos.x += when {
+                    // We don't use OffsetNewTab because when using non-persistent-order tab bar it is incremented with each Tab submission.
+                    !hostNode.isHiddenTabBar && !hostNode.isNoTabBar -> it.offsetMax + style.itemInnerSpacing.x
+                    else -> style.itemInnerSpacing.x + tabItemCalcSize(hostNode.windows[0].name, hostNode.windows[0].hasCloseButton).x
+                }
+            }
+        } else if (hostWindow.flags hasnt Wf._DockNodeHost)
+            tabPos.x += style.itemInnerSpacing.x + tabItemCalcSize(hostWindow.name, hostWindow.hasCloseButton).x // Account for slight offset which will be added when changing from title bar to tab bar
 
         // Draw tab shape/label preview (payload may be a loose window or a host window carrying multiple tabbed windows)
         rootPayload.dockNodeAsHost?.let {


### PR DESCRIPTION
Fixed a few bugs in the rendering of the docking preview that would cause a fatal crash.

1. Fixed array creation

A rather obvious `IndexOutOfBoundsException` would happen here:
```kotlin
var overlayDrawListsCount = 0
val overlayDrawLists = ArrayList<DrawList>()
overlayDrawLists[overlayDrawListsCount++] = getForegroundDrawList(hostWindow.viewport!!)
```
```
Exception in thread "main" java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0
	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64)
	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70)
	at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:248)
	at java.base/java.util.Objects.checkIndex(Objects.java:372)
	at java.base/java.util.ArrayList.set(ArrayList.java:472)
	at imgui.static.DockNodeKt.dockNodePreviewDockRender(dockNode.kt:1092)
```

2. Fixed null-assertion with `hostNode`:

The original C++ library checks if `host_node` is null:
```c++
if (host_node && host_node->TabBar)
{
    if (!host_node->IsHiddenTabBar() && !host_node->IsNoTabBar())
        tab_pos.x += host_node->TabBar->OffsetMax + g.Style.ItemInnerSpacing.x; // We don't use OffsetNewTab because when using non-persistent-order tab bar it is incremented with each Tab submission.
    else
        tab_pos.x += g.Style.ItemInnerSpacing.x + TabItemCalcSize(host_node->Windows[0]->Name, host_node->Windows[0]->HasCloseButton).x;
}
```
while the kotlin version performed a crashable null-assertion:
```kotlin
hostNode!!.tabBar.let {
    if (it != null)
        tabPos.x += when {
            // We don't use OffsetNewTab because when using non-persistent-order tab bar it is incremented with each Tab submission.
            !hostNode.isHiddenTabBar && !hostNode.isNoTabBar -> it.offsetMax + style.itemInnerSpacing.x
            else -> style.itemInnerSpacing.x + tabItemCalcSize(hostNode.windows[0].name, hostNode.windows[0].hasCloseButton).x
        }
    else if (hostWindow.flags hasnt Wf._DockNodeHost)
        tabPos.x += style.itemInnerSpacing.x + tabItemCalcSize(hostWindow.name, hostWindow.hasCloseButton).x // Account for slight offset which will be added when changing from title bar to tab bar
}
```
