### PR TITLE
Change DrawCmd.userCallbackData type to Any

### DIFF
--- a/imgui-core/src/main/kotlin/imgui/api/demoDebugInformations.kt
+++ b/imgui-core/src/main/kotlin/imgui/api/demoDebugInformations.kt
@@ -67,6 +67,7 @@ import imgui.internal.classes.Window
 import kool.BYTES
 import kool.lim
 import kool.rem
+import java.nio.ByteBuffer
 import kotlin.reflect.KMutableProperty0
 import imgui.WindowFlag as Wf
 
@@ -531,7 +532,7 @@ interface demoDebugInformations {
                     if (cb == null && cmd.elemCount == 0)
                         continue
                     if (cb != null) {
-                        bulletText("Callback %s, UserData %s", cb.toString(), String(cmd.userCallbackData!!.array()))
+                        bulletText("Callback %s, UserData %s", cb.toString(), String((cmd.userCallbackData as ByteBuffer).array()))
                         continue
                     }
 

--- a/imgui-core/src/main/kotlin/imgui/classes/DrawList.kt
+++ b/imgui-core/src/main/kotlin/imgui/classes/DrawList.kt
@@ -834,7 +834,7 @@ class DrawList(sharedData: DrawListSharedData?) {
     // -----------------------------------------------------------------------------------------------------------------
     /** Your rendering function must check for 'UserCallback' in ImDrawCmd and call the function instead of rendering
     triangles.  */
-    fun addCallback(callback: DrawCallback, callbackData: ByteBuffer? = null) {
+    fun addCallback(callback: DrawCallback, callbackData: Any? = null) {
         var currentCmd = cmdBuffer.peek()
         if (currentCmd == null || currentCmd.elemCount != 0 || currentCmd.userCallback != null) {
             addDrawCmd()

--- a/imgui-core/src/main/kotlin/imgui/internal/draw.kt
+++ b/imgui-core/src/main/kotlin/imgui/internal/draw.kt
@@ -65,7 +65,7 @@ class DrawCmd {
      *  (e.g. changing shader/blending settings before an Image call). */
     var resetRenderState = false
 
-    var userCallbackData: ByteBuffer? = null
+    var userCallbackData: Any? = null
 //    void*           UserCallbackData;       // The draw callback code can access this.
 
     infix fun put(drawCmd: DrawCmd) {


### PR DESCRIPTION
Change the type of `userCallbackData` to `Any` so we can send in any class instance we desire for the custom render. Serialising whatever data we need for the customer renderer into a ByteBuffer is slow and difficult to use.