### PR TITLE
Change imgui-core dependency on glm and uno-sdk to api...

### DIFF
--- a/imgui-core/build.gradle.kts
+++ b/imgui-core/build.gradle.kts
@@ -13,9 +13,9 @@ dependencies {
     val kx = "com.github.kotlin-graphics"
     implementation("$kx:kotlin-unsigned:${findProperty("unsignedVersion")}")
     implementation("$kx:kool:${findProperty("koolVersion")}")
-    implementation("$kx:glm:${findProperty("glmVersion")}")
+    api("$kx:glm:${findProperty("glmVersion")}")
     implementation("$kx:gli:${findProperty("gliVersion")}")
-    implementation("$kx:uno-sdk:${findProperty("unoVersion")}")
+    api("$kx:uno-sdk:${findProperty("unoVersion")}")
 
     val lwjglNatives = when (current()) {
         WINDOWS -> "windows"


### PR DESCRIPTION
...to allow proper use of APIs.
Related to issues #143 and #112 