### PR TITLE
Docking bugfixes

### DIFF
--- a/core/src/main/kotlin/imgui/internal/classes/TabBar.kt
+++ b/core/src/main/kotlin/imgui/internal/classes/TabBar.kt
@@ -341,7 +341,7 @@ class TabBar {
         tab.window = dockedWindow
 
         // Append name with zero-terminator
-        if (flags has TabBarFlag._DockNode) {
+        if (this.flags has TabBarFlag._DockNode) {
             assert(tab.window != null)
             tab.nameOffset = -1
         } else {
@@ -920,4 +920,3 @@ class TabBar {
         }
     }
 }
-

--- a/core/src/main/kotlin/imgui/static/dockNode.kt
+++ b/core/src/main/kotlin/imgui/static/dockNode.kt
@@ -823,8 +823,9 @@ fun dockNodeUpdateTabBar(node: DockNode, hostWindow: Window) {
             if (tabBar.flags has TabBarFlag.NoCloseWithMiddleMouseButton)
                 tabItemFlags = tabItemFlags or TabItemFlag.NoCloseWithMiddleMouseButton
 
-            val tabOpen = ::_b
-            tabOpen.set(false)
+            val tabOpen = ::_b.also {
+                it.set(true)
+            }
             tabBar.tabItemEx(window.name, if (window.hasCloseButton) tabOpen else null, tabItemFlags, window)
             if (!tabOpen())
                 node.wantCloseTabId = window.id


### PR DESCRIPTION
This PR aims to fix a handful of small bugs in the docking branch.

Feel free to review, but I will probably be pushing more to this PR, so please do not merge yet.

- [X] Docked tabs close themselves immediately after creation
- [X] Tab name offset would often be `-1` as when they were initialised, the wrong flags were checked (causing an index out of bounds exception when trying to access the name)
- [ ] The window border of a window with docked tabs is offset to the bottom right
![image](https://user-images.githubusercontent.com/27009727/92507810-d88c7d00-f207-11ea-954f-37229a607b28.png)
- [ ] The first window in a window with docked windows does not appear to have a tab (also visible in image above)

Also see #140 for issues to fix