### PR TITLE
Introduce Flag interface to reduce duplication of byte-manipulating functions

### DIFF
--- a/core/src/main/kotlin/imgui/api/columns.kt
+++ b/core/src/main/kotlin/imgui/api/columns.kt
@@ -15,13 +15,12 @@ import imgui.ImGui.popItemWidth
 import imgui.ImGui.pushItemWidth
 import imgui.ImGui.setWindowClipRectBeforeSetChannel
 import imgui.ImGui.style
-import imgui.internal.*
-import imgui.internal.sections.OldColumns
-import imgui.internal.sections.OldColumnsFlags
 import imgui.has
 import imgui.hasnt
-import imgui.internal.sections.has
-import imgui.internal.sections.hasnt
+import imgui.internal.floor
+import imgui.internal.lerp
+import imgui.internal.sections.OldColumns
+import imgui.internal.sections.OldColumnsFlags
 import kotlin.math.max
 import kotlin.math.min
 import imgui.internal.sections.OldColumnsFlag as Cf

--- a/core/src/main/kotlin/imgui/api/cursorLayout.kt
+++ b/core/src/main/kotlin/imgui/api/cursorLayout.kt
@@ -11,9 +11,12 @@ import imgui.ImGui.itemAdd
 import imgui.ImGui.itemSize
 import imgui.ImGui.separatorEx
 import imgui.ImGui.style
+import imgui.div
 import imgui.internal.classes.GroupData
 import imgui.internal.classes.Rect
-import imgui.internal.sections.*
+import imgui.internal.sections.ItemFlag
+import imgui.internal.sections.ItemStatusFlag
+import imgui.internal.sections.SeparatorFlag
 import imgui.internal.sections.LayoutType as Lt
 
 

--- a/core/src/main/kotlin/imgui/api/demoDebugInformations.kt
+++ b/core/src/main/kotlin/imgui/api/demoDebugInformations.kt
@@ -92,7 +92,6 @@ import imgui.ImGui.treeNode
 import imgui.ImGui.treeNodeToLabelSpacing
 import imgui.ImGui.treePop
 import imgui.ImGui.unindent
-import imgui.WindowFlag
 import imgui.classes.ListClipper
 import imgui.classes.Style
 import imgui.demo.ExampleApp
@@ -100,6 +99,7 @@ import imgui.demo.showExampleApp.StyleEditor
 import imgui.dsl.indent
 import imgui.dsl.listBox
 import imgui.dsl.treeNode
+import imgui.hasnt
 import imgui.internal.DrawIdx
 import imgui.internal.DrawVert
 import imgui.internal.api.debugTools.Companion.metricsHelpMarker
@@ -107,8 +107,6 @@ import imgui.internal.classes.*
 import imgui.internal.formatString
 import imgui.internal.sections.KeyOwner_None
 import imgui.internal.sections.NextWindowDataFlag
-import imgui.hasnt
-import imgui.internal.sections.hasnt
 import imgui.internal.sections.testEngine_FindItemDebugLabel
 import kool.BYTES
 import kotlin.reflect.KMutableProperty0
@@ -602,7 +600,7 @@ interface demoDebugInformations {
         sameLine()
         if (smallButton("Copy"))
             clipboardText = g.debugLogBuf.toString()
-        beginChild("##log", Vec2(), true, WindowFlag.AlwaysVerticalScrollbar or WindowFlag.AlwaysHorizontalScrollbar)
+        beginChild("##log", Vec2(), true, Wf.AlwaysVerticalScrollbar or Wf.AlwaysHorizontalScrollbar)
 
         val clipper = ListClipper()
         clipper.begin(g.debugLogIndex.size)

--- a/core/src/main/kotlin/imgui/api/itemWidgetsUtilities.kt
+++ b/core/src/main/kotlin/imgui/api/itemWidgetsUtilities.kt
@@ -2,14 +2,14 @@ package imgui.api
 
 import glm_.hasnt
 import glm_.vec2.Vec2
-import imgui.*
+import imgui.ID
 import imgui.ImGui.isMouseClicked
-import imgui.internal.sections.ItemFlag
-import imgui.internal.sections.ItemStatusFlag
+import imgui.MouseButton
 import imgui.has
 import imgui.hasnt
-import imgui.internal.sections.has
-import imgui.internal.sections.hasnt
+import imgui.internal.sections.ItemFlag
+import imgui.internal.sections.ItemStatusFlag
+import imgui.or
 import imgui.HoveredFlag as Hf
 
 // Item/Widgets Utilities and Query Functions

--- a/core/src/main/kotlin/imgui/api/main.kt
+++ b/core/src/main/kotlin/imgui/api/main.kt
@@ -27,17 +27,15 @@ import imgui.ImGui.updateHoveredWindowAndCaptureFlags
 import imgui.ImGui.updateInputEvents
 import imgui.ImGui.updateMouseMovingWindowEndFrame
 import imgui.ImGui.updateMouseMovingWindowNewFrame
-import imgui.classes.ContextHookType
 import imgui.classes.Context
+import imgui.classes.ContextHookType
 import imgui.classes.IO
 import imgui.classes.Style
 import imgui.font.FontAtlas
 import imgui.internal.*
 import imgui.internal.classes.Rect
-import imgui.internal.classes.or
 import imgui.internal.sections.IMGUI_DEBUG_LOG_ACTIVEID
 import imgui.internal.sections.ItemFlag
-import imgui.internal.sections.or
 import imgui.static.*
 import org.lwjgl.system.Platform
 import imgui.WindowFlag as Wf

--- a/core/src/main/kotlin/imgui/api/parametersStacks.kt
+++ b/core/src/main/kotlin/imgui/api/parametersStacks.kt
@@ -3,7 +3,6 @@ package imgui.api
 import glm_.f
 import glm_.max
 import glm_.vec2.Vec2
-import glm_.vec2.Vec2i
 import glm_.vec4.Vec4
 import imgui.*
 import imgui.ImGui.contentRegionMaxAbs
@@ -13,15 +12,10 @@ import imgui.ImGui.popItemFlag
 import imgui.ImGui.pushItemFlag
 import imgui.ImGui.style
 import imgui.font.Font
-import imgui.internal.*
 import imgui.internal.classes.ColorMod
 import imgui.internal.classes.StyleMod
+import imgui.internal.floor
 import imgui.internal.sections.NextItemDataFlag
-import imgui.has
-import imgui.internal.sections.has
-import imgui.internal.sections.or
-import imgui.internal.sections.wo
-import imgui.wo
 import imgui.internal.sections.ItemFlag as If
 
 // Parameters stacks (shared)

--- a/core/src/main/kotlin/imgui/api/popupsModals.kt
+++ b/core/src/main/kotlin/imgui/api/popupsModals.kt
@@ -5,7 +5,6 @@ import imgui.*
 import imgui.ImGui.begin
 import imgui.ImGui.beginPopupEx
 import imgui.ImGui.closePopupToLevel
-import imgui.ImGui.currentWindow
 import imgui.ImGui.end
 import imgui.ImGui.isAnyItemHovered
 import imgui.ImGui.isItemHovered
@@ -20,8 +19,6 @@ import imgui.ImGui.topMostPopupModal
 import imgui.internal.sections.IMGUI_DEBUG_LOG_POPUP
 import imgui.internal.sections.NavMoveFlag
 import imgui.internal.sections.NextWindowDataFlag
-import imgui.hasnt
-import imgui.internal.sections.hasnt
 import kotlin.reflect.KMutableProperty0
 import imgui.HoveredFlag as Hf
 import imgui.WindowFlag as Wf

--- a/core/src/main/kotlin/imgui/api/widgetsColorEditorPicker.kt
+++ b/core/src/main/kotlin/imgui/api/widgetsColorEditorPicker.kt
@@ -66,14 +66,13 @@ import imgui.ImGui.style
 import imgui.ImGui.text
 import imgui.ImGui.textEx
 import imgui.classes.DrawList
+import imgui.has
 import imgui.internal.*
 import imgui.internal.classes.Rect
 import imgui.internal.classes.Window
 import imgui.internal.sections.DrawFlag
 import imgui.internal.sections.ItemFlag
 import imgui.internal.sections.ItemStatusFlag
-import imgui.has
-import imgui.internal.sections.has
 import imgui.ColorEditFlag as Cef
 import imgui.InputTextFlag as Itf
 

--- a/core/src/main/kotlin/imgui/api/widgetsSliders.kt
+++ b/core/src/main/kotlin/imgui/api/widgetsSliders.kt
@@ -18,14 +18,8 @@ import imgui.internal.classes.Rect
 import imgui.internal.sections.IMGUI_TEST_ENGINE_ITEM_INFO
 import imgui.internal.sections.ItemFlag
 import imgui.internal.sections.ItemStatusFlag
-import imgui.has
-import imgui.internal.sections.has
 import kool.getValue
 import kool.setValue
-import unsigned.Ubyte
-import unsigned.Uint
-import unsigned.Ulong
-import unsigned.Ushort
 import kotlin.reflect.KMutableProperty0
 
 @Suppress("UNCHECKED_CAST")

--- a/core/src/main/kotlin/imgui/api/widgetsTrees.kt
+++ b/core/src/main/kotlin/imgui/api/widgetsTrees.kt
@@ -17,11 +17,8 @@ import imgui.ImGui.style
 import imgui.ImGui.treeNodeBehavior
 import imgui.ImGui.unindent
 import imgui.internal.classes.Rect
-import imgui.internal.sections.NextItemDataFlag
 import imgui.internal.formatStringToTempBuffer
-import imgui.internal.sections.div
-import imgui.internal.sections.or
-import imgui.or
+import imgui.internal.sections.NextItemDataFlag
 import kotlin.reflect.KMutableProperty0
 import imgui.TreeNodeFlag as Tnf
 

--- a/core/src/main/kotlin/imgui/api/windowsUtilities.kt
+++ b/core/src/main/kotlin/imgui/api/windowsUtilities.kt
@@ -15,7 +15,6 @@ import imgui.classes.DrawList
 import imgui.internal.classes.Window.Companion.getCombinedRootWindow
 import imgui.internal.floor
 import imgui.internal.sections.NextWindowDataFlag
-import imgui.internal.sections.div
 import imgui.FocusedFlag as Ff
 import imgui.HoveredFlag as Hf
 

--- a/core/src/main/kotlin/imgui/classes/ListClipper.kt
+++ b/core/src/main/kotlin/imgui/classes/ListClipper.kt
@@ -6,10 +6,12 @@ import imgui.ImGui.endRow
 import imgui.ImGui.rectRelToAbs
 import imgui.api.g
 import imgui.clamp
-import imgui.internal.floor
+import imgui.has
 import imgui.internal.isAboveGuaranteedIntegerPrecision
-import imgui.internal.sections.*
-import kotlin.math.ceil
+import imgui.internal.sections.IMGUI_DEBUG_LOG_CLIPPER
+import imgui.internal.sections.ListClipperData
+import imgui.internal.sections.ListClipperRange
+import imgui.internal.sections.NavMoveFlag
 
 /** Helper: Manually clip large list of items.
  *  If you have lots evenly spaced items and you have random access to the list, you can perform coarse

--- a/core/src/main/kotlin/imgui/flags & enumerations.kt
+++ b/core/src/main/kotlin/imgui/flags & enumerations.kt
@@ -9,22 +9,47 @@ import imgui.ImGui.getColorU32
 //-----------------------------------------------------------------------------
 
 
+interface Flag<Self : Flag<Self>> {
+  val i: Int
+
+  infix fun and(b: Self): Int = i and b.i
+  infix fun and(b: Int): Int = i and b
+  infix fun or(b: Self): Int = i or b.i
+  infix fun or(b: Int): Int = i or b
+  infix fun xor(b: Self): Int = i xor b.i
+  infix fun xor(b: Int): Int = i xor b
+  infix fun wo(b: Self): Int = and(b.i.inv())
+  infix fun wo(b: Int): Int = and(b.inv())
+  infix fun has(b: Self): Boolean = and(b.i) != 0
+  infix fun hasnt(b: Self): Boolean = and(b.i) == 0
+}
+
+infix fun Int.and(b: Flag<*>): Int = and(b.i)
+infix fun Int.or(b: Flag<*>): Int = or(b.i)
+infix fun Int.xor(b: Flag<*>): Int = xor(b.i)
+infix fun Int.has(b: Flag<*>): Boolean = and(b.i) != 0
+infix fun Int.hasnt(b: Flag<*>): Boolean = and(b.i) == 0
+infix fun Int.wo(b: Flag<*>): Int = and(b.i.inv())
+operator fun Int.minus(flag: Flag<*>): Int = wo(flag)
+operator fun Int.div(flag: Flag<*>): Int = or(flag)
+
+
 /** Flags for ImGui::Begin()
  *  (Those are per-window flags. There are shared flags in ImGuiIO: io.ConfigWindowsResizeFromEdges and io.ConfigWindowsMoveFromTitleBarOnly) */
 typealias WindowFlags = Int
 
 /** Flags: for Begin(), BeginChild()    */
-enum class WindowFlag(@JvmField val i: WindowFlags) {
+enum class WindowFlag(override val i: WindowFlags) : Flag<WindowFlag> {
 
-    None(0),
+  None(0),
 
-    /** Disable title-bar   */
-    NoTitleBar(1 shl 0),
+  /** Disable title-bar   */
+  NoTitleBar(1 shl 0),
 
-    /** Disable user resizing with the lower-right grip */
-    NoResize(1 shl 1),
+  /** Disable user resizing with the lower-right grip */
+  NoResize(1 shl 1),
 
-    /** Disable user moving the window  */
+  /** Disable user moving the window  */
     NoMove(1 shl 2),
 
     /** Disable scrollbars (window can still scroll with mouse or programmatically)  */
@@ -104,43 +129,25 @@ enum class WindowFlag(@JvmField val i: WindowFlags) {
     /** Don't use! For internal use by BeginPopupModal()    */
     _Modal(1 shl 27),
 
-    /** Don't use! For internal use by BeginMenu()  */
-    _ChildMenu(1 shl 28);
-
-    infix fun and(b: WindowFlag): WindowFlags = i and b.i
-    infix fun and(b: WindowFlags): WindowFlags = i and b
-    infix fun or(b: WindowFlag): WindowFlags = i or b.i
-    infix fun or(b: WindowFlags): WindowFlags = i or b
-    infix fun xor(b: WindowFlag): WindowFlags = i xor b.i
-    infix fun xor(b: WindowFlags): WindowFlags = i xor b
-    infix fun wo(b: WindowFlag): WindowFlags = and(b.i.inv())
-    infix fun wo(b: WindowFlags): WindowFlags = and(b.inv())
+  /** Don't use! For internal use by BeginMenu()  */
+  _ChildMenu(1 shl 28)
 }
-
-infix fun WindowFlags.and(b: WindowFlag): WindowFlags = and(b.i)
-infix fun WindowFlags.or(b: WindowFlag): WindowFlags = or(b.i)
-infix fun WindowFlags.xor(b: WindowFlag): WindowFlags = xor(b.i)
-infix fun WindowFlags.has(b: WindowFlag): Boolean = and(b.i) != 0
-infix fun WindowFlags.hasnt(b: WindowFlag): Boolean = and(b.i) == 0
-infix fun WindowFlags.wo(b: WindowFlag): WindowFlags = and(b.i.inv())
-operator fun WindowFlags.minus(flag: WindowFlag): WindowFlags = wo(flag)
-operator fun WindowFlags.div(flag: WindowFlag): WindowFlags = or(flag)
 
 /** Flags for ImGui::InputText(), InputTextMultiline()
  *  (Those are per-item flags. There are shared flags in ImGuiIO: io.ConfigInputTextCursorBlink and io.ConfigInputTextEnterKeepActive) */
 typealias InputTextFlags = Int
 
-enum class InputTextFlag(@JvmField val i: InputTextFlags) { // TODO Int -> *flags the others enum
+enum class InputTextFlag(override val i: InputTextFlags) : Flag<InputTextFlag> {
 
-    None(0),
+  None(0),
 
-    /** Allow 0123456789 . + - * /      */
-    CharsDecimal(1 shl 0),
+  /** Allow 0123456789 . + - * /      */
+  CharsDecimal(1 shl 0),
 
-    /** Allow 0123456789ABCDEFabcdef    */
-    CharsHexadecimal(1 shl 1),
+  /** Allow 0123456789ABCDEFabcdef    */
+  CharsHexadecimal(1 shl 1),
 
-    /** Turn a..z into A..Z */
+  /** Turn a..z into A..Z */
     CharsUppercase(1 shl 2),
 
     /** Filter out spaces), tabs    */
@@ -211,43 +218,25 @@ enum class InputTextFlag(@JvmField val i: InputTextFlags) { // TODO Int -> *flag
     /** For internal use by functions using InputText() before reformatting data */
     _NoMarkEdited(1 shl 27),
 
-    /** For internal use by TempInputText(), will skip calling ItemAdd(). Require bounding-box to strictly match. */
-    _MergedItem(1 shl 28);
-
-    infix fun and(b: InputTextFlag): InputTextFlags = i and b.i
-    infix fun and(b: InputTextFlags): InputTextFlags = i and b
-    infix fun or(b: InputTextFlag): InputTextFlags = i or b.i
-    infix fun or(b: InputTextFlags): InputTextFlags = i or b
-    infix fun xor(b: InputTextFlag): InputTextFlags = i xor b.i
-    infix fun xor(b: InputTextFlags): InputTextFlags = i xor b
-    infix fun wo(b: InputTextFlag): InputTextFlags = and(b.i.inv())
-    infix fun wo(b: InputTextFlags): InputTextFlags = and(b.inv())
+  /** For internal use by TempInputText(), will skip calling ItemAdd(). Require bounding-box to strictly match. */
+  _MergedItem(1 shl 28)
 }
-
-infix fun InputTextFlags.and(b: InputTextFlag): InputTextFlags = and(b.i)
-infix fun InputTextFlags.or(b: InputTextFlag): InputTextFlags = or(b.i)
-infix fun InputTextFlags.xor(b: InputTextFlag): InputTextFlags = xor(b.i)
-infix fun InputTextFlags.has(b: InputTextFlag): Boolean = and(b.i) != 0
-infix fun InputTextFlags.hasnt(b: InputTextFlag): Boolean = and(b.i) == 0
-infix fun InputTextFlags.wo(b: InputTextFlag): InputTextFlags = and(b.i.inv())
-operator fun InputTextFlags.minus(flag: InputTextFlag): InputTextFlags = wo(flag)
-operator fun InputTextFlags.div(flag: InputTextFlag): InputTextFlags = or(flag)
 
 
 typealias TreeNodeFlags = Int
 
 /** Flags: for TreeNode(), TreeNodeEx(), CollapsingHeader()   */
-enum class TreeNodeFlag(@JvmField val i: TreeNodeFlags) {
+enum class TreeNodeFlag(override val i: TreeNodeFlags) : Flag<TreeNodeFlag> {
 
-    None(0),
+  None(0),
 
-    /** Draw as selected    */
-    Selected(1 shl 0),
+  /** Draw as selected    */
+  Selected(1 shl 0),
 
-    /** Draw frame with background (e.g. for CollapsingHeader)  */
-    Framed(1 shl 1),
+  /** Draw frame with background (e.g. for CollapsingHeader)  */
+  Framed(1 shl 1),
 
-    /** Hit testing to allow subsequent widgets to overlap this one */
+  /** Hit testing to allow subsequent widgets to overlap this one */
     AllowItemOverlap(1 shl 2),
 
     /** Don't do a TreePush() when open (e.g. for CollapsingHeader) ( no extra indent nor pushing on ID stack   */
@@ -289,24 +278,8 @@ enum class TreeNodeFlag(@JvmField val i: TreeNodeFlags) {
 
     // [Internal]
 
-    _ClipLabelForTrailingButton(1 shl 20);
-
-    infix fun and(b: TreeNodeFlag): TreeNodeFlags = i and b.i
-    infix fun and(b: TreeNodeFlags): TreeNodeFlags = i and b
-    infix fun or(b: TreeNodeFlag): TreeNodeFlags = i or b.i
-    infix fun or(b: TreeNodeFlags): TreeNodeFlags = i or b
-    infix fun xor(b: TreeNodeFlag): TreeNodeFlags = i xor b.i
-    infix fun xor(b: TreeNodeFlags): TreeNodeFlags = i xor b
-    infix fun wo(b: TreeNodeFlags): TreeNodeFlags = and(b.inv())
+  _ClipLabelForTrailingButton(1 shl 20)
 }
-
-infix fun TreeNodeFlags.and(b: TreeNodeFlag): TreeNodeFlags = and(b.i)
-infix fun TreeNodeFlags.or(b: TreeNodeFlag): TreeNodeFlags = or(b.i)
-infix fun TreeNodeFlags.xor(b: TreeNodeFlag): TreeNodeFlags = xor(b.i)
-infix fun TreeNodeFlags.has(b: TreeNodeFlag): Boolean = and(b.i) != 0
-infix fun TreeNodeFlags.hasnt(b: TreeNodeFlag): Boolean = and(b.i) == 0
-infix fun TreeNodeFlags.wo(b: TreeNodeFlag): TreeNodeFlags = and(b.i.inv())
-
 
 typealias PopupFlags = Int
 
@@ -318,17 +291,17 @@ typealias PopupFlags = Int
  *    IMPORTANT: because the default parameter is 1 (==ImGuiPopupFlags_MouseButtonRight), if you rely on the default parameter
  *    and want to use another flag, you need to pass in the ImGuiPopupFlags_MouseButtonRight flag explicitly.
  *  - Multiple buttons currently cannot be combined/or-ed in those functions (we could allow it later). */
-enum class PopupFlag(@JvmField val i: PopupFlags) {
+enum class PopupFlag(override val i: PopupFlags) : Flag<PopupFlag> {
 
-    None(0),
+  None(0),
 
-    /** For BeginPopupContext*(): open on Left Mouse release. Guaranteed to always be == 0 (same as ImGuiMouseButton_Left) */
-    MouseButtonLeft(0),
+  /** For BeginPopupContext*(): open on Left Mouse release. Guaranteed to always be == 0 (same as ImGuiMouseButton_Left) */
+  MouseButtonLeft(0),
 
-    /** For BeginPopupContext*(): open on Right Mouse release. Guaranteed to always be == 1 (same as ImGuiMouseButton_Right) */
-    MouseButtonRight(1),
+  /** For BeginPopupContext*(): open on Right Mouse release. Guaranteed to always be == 1 (same as ImGuiMouseButton_Right) */
+  MouseButtonRight(1),
 
-    /** For BeginPopupContext*(): open on Middle Mouse release. Guaranteed to always be == 2 (same as ImGuiMouseButton_Middle) */
+  /** For BeginPopupContext*(): open on Middle Mouse release. Guaranteed to always be == 2 (same as ImGuiMouseButton_Middle) */
     MouseButtonMiddle(2),
     MouseButtonMask_(0x1F),
     MouseButtonDefault_(1),
@@ -345,38 +318,23 @@ enum class PopupFlag(@JvmField val i: PopupFlags) {
     /** For IsPopupOpen(): search/test at any level of the popup stack (default test in the current level) */
     AnyPopupLevel(1 shl 8),
     AnyPopup(AnyPopupId or AnyPopupLevel);
-
-    infix fun and(b: PopupFlag): PopupFlags = i and b.i
-    infix fun and(b: PopupFlags): PopupFlags = i and b
-    infix fun or(b: PopupFlag): PopupFlags = i or b.i
-    infix fun or(b: PopupFlags): PopupFlags = i or b
-    infix fun xor(b: PopupFlag): PopupFlags = i xor b.i
-    infix fun xor(b: PopupFlags): PopupFlags = i xor b
-    infix fun wo(b: PopupFlags): PopupFlags = and(b.inv())
 }
-
-infix fun PopupFlags.and(b: PopupFlag): PopupFlags = and(b.i)
-infix fun PopupFlags.or(b: PopupFlag): PopupFlags = or(b.i)
-infix fun PopupFlags.xor(b: PopupFlag): PopupFlags = xor(b.i)
-infix fun PopupFlags.has(b: PopupFlag): Boolean = and(b.i) != 0
-infix fun PopupFlags.hasnt(b: PopupFlag): Boolean = and(b.i) == 0
-infix fun PopupFlags.wo(b: PopupFlag): PopupFlags = and(b.i.inv())
 
 
 typealias SelectableFlags = Int
 
 /** Flags for ImGui::Selectable()   */
-enum class SelectableFlag(@JvmField val i: SelectableFlags) {
+enum class SelectableFlag(override val i: SelectableFlags) : Flag<SelectableFlag> {
 
-    None(0),
+  None(0),
 
-    /** Clicking this doesn't close parent popup window   */
-    DontClosePopups(1 shl 0),
+  /** Clicking this doesn't close parent popup window   */
+  DontClosePopups(1 shl 0),
 
-    /** Selectable frame can span all columns (text will still fit in current column)   */
-    SpanAllColumns(1 shl 1),
+  /** Selectable frame can span all columns (text will still fit in current column)   */
+  SpanAllColumns(1 shl 1),
 
-    /** Generate press events on double clicks too  */
+  /** Generate press events on double clicks too  */
     AllowDoubleClick(1 shl 2),
 
     /** Cannot be selected, display grayed out text */
@@ -410,38 +368,22 @@ enum class SelectableFlag(@JvmField val i: SelectableFlags) {
 
     /** Don't set key/input owner on the initial click (note: mouse buttons are keys! often, the key in question will be ImGuiKey_MouseLeft!) */
     _NoSetKeyOwner(1 shl 27);
-
-    infix fun and(b: SelectableFlag): SelectableFlags = i and b.i
-    infix fun and(b: SelectableFlags): SelectableFlags = i and b
-    infix fun or(b: SelectableFlag): SelectableFlags = i or b.i
-    infix fun or(b: SelectableFlags): SelectableFlags = i or b
-    infix fun xor(b: SelectableFlag): SelectableFlags = i xor b.i
-    infix fun xor(b: SelectableFlags): SelectableFlags = i xor b
-    infix fun wo(b: SelectableFlags): SelectableFlags = and(b.inv())
 }
-
-infix fun SelectableFlags.and(b: SelectableFlag): SelectableFlags = and(b.i)
-infix fun SelectableFlags.or(b: SelectableFlag): SelectableFlags = or(b.i)
-infix fun SelectableFlags.xor(b: SelectableFlag): SelectableFlags = xor(b.i)
-infix fun SelectableFlags.has(b: SelectableFlag): Boolean = and(b.i) != 0
-infix fun SelectableFlags.hasnt(b: SelectableFlag): Boolean = and(b.i) == 0
-infix fun SelectableFlags.wo(b: SelectableFlag): SelectableFlags = and(b.i.inv())
-
 
 typealias ComboFlags = Int
 
 /** Flags: for BeginCombo() */
-enum class ComboFlag(@JvmField val i: ComboFlags) {
-    None(0),
+enum class ComboFlag(override val i: ComboFlags) : Flag<ComboFlag> {
+  None(0),
 
-    /** Align the popup toward the left by default */
-    PopupAlignLeft(1 shl 0),
+  /** Align the popup toward the left by default */
+  PopupAlignLeft(1 shl 0),
 
-    /** Max ~4 items visible */
-    HeightSmall(1 shl 1),
+  /** Max ~4 items visible */
+  HeightSmall(1 shl 1),
 
-    /** Max ~8 items visible (default) */
-    HeightRegular(1 shl 2),
+  /** Max ~8 items visible (default) */
+  HeightRegular(1 shl 2),
 
     /** Max ~20 items visible */
     HeightLarge(1 shl 3),
@@ -458,40 +400,25 @@ enum class ComboFlag(@JvmField val i: ComboFlags) {
 
     // private
 
-    /** enable BeginComboPreview() */
-    _CustomPreview(1 shl 20);
-
-    infix fun and(b: ComboFlag): ComboFlags = i and b.i
-    infix fun and(b: ComboFlags): ComboFlags = i and b
-    infix fun or(b: ComboFlag): ComboFlags = i or b.i
-    infix fun or(b: ComboFlags): ComboFlags = i or b
-    infix fun xor(b: ComboFlag): ComboFlags = i xor b.i
-    infix fun xor(b: ComboFlags): ComboFlags = i xor b
-    infix fun wo(b: ComboFlags): ComboFlags = and(b.inv())
+  /** enable BeginComboPreview() */
+  _CustomPreview(1 shl 20)
 }
-
-infix fun ComboFlags.and(b: ComboFlag): ComboFlags = and(b.i)
-infix fun ComboFlags.or(b: ComboFlag): ComboFlags = or(b.i)
-infix fun ComboFlags.xor(b: ComboFlag): ComboFlags = xor(b.i)
-infix fun ComboFlags.has(b: ComboFlag): Boolean = and(b.i) != 0
-infix fun ComboFlags.hasnt(b: ComboFlag): Boolean = and(b.i) == 0
-infix fun ComboFlags.wo(b: ComboFlag): ComboFlags = and(b.i.inv())
 
 
 typealias TabBarFlags = Int
 
 /** Flags for ImGui::BeginTabBar() */
-enum class TabBarFlag(@JvmField val i: TabBarFlags) {
-    None(0),
+enum class TabBarFlag(override val i: TabBarFlags) : Flag<TabBarFlag> {
+  None(0),
 
-    /** Allow manually dragging tabs to re-order them + New tabs are appended at the end of list */
-    Reorderable(1 shl 0),
+  /** Allow manually dragging tabs to re-order them + New tabs are appended at the end of list */
+  Reorderable(1 shl 0),
 
-    /** Automatically select new tabs when they appear */
-    AutoSelectNewTabs(1 shl 1),
+  /** Automatically select new tabs when they appear */
+  AutoSelectNewTabs(1 shl 1),
 
-    /** Disable buttons to open the tab list popup */
-    TabListPopupButton(1 shl 2),
+  /** Disable buttons to open the tab list popup */
+  TabListPopupButton(1 shl 2),
 
     /** Disable behavior of closing tabs (that are submitted with p_open != NULL) with middle mouse button.
      *  You can still repro this behavior on user's side with if (IsItemHovered() && IsMouseClicked(2)) *p_open = false. */
@@ -519,40 +446,22 @@ enum class TabBarFlag(@JvmField val i: TabBarFlags) {
 
     /** FIXME: Settings are handled by the docking system, this only request the tab bar to mark settings dirty when reordering tabs, */
     _SaveSettings(1 shl 22);
-
-    infix fun and(b: TabBarFlag): TabBarFlags = i and b.i
-    infix fun and(b: TabBarFlags): TabBarFlags = i and b
-    infix fun or(b: TabBarFlag): TabBarFlags = i or b.i
-    infix fun or(b: TabBarFlags): TabBarFlags = i or b
-    infix fun xor(b: TabBarFlag): TabBarFlags = i xor b.i
-    infix fun xor(b: TabBarFlags): TabBarFlags = i xor b
-    infix fun wo(b: TabBarFlags): TabBarFlags = and(b.inv())
 }
-
-infix fun TabBarFlags.and(b: TabBarFlag): TabBarFlags = and(b.i)
-infix fun TabBarFlags.or(b: TabBarFlag): TabBarFlags = or(b.i)
-infix fun TabBarFlags.xor(b: TabBarFlag): TabBarFlags = xor(b.i)
-infix fun TabBarFlags.has(b: TabBarFlag): Boolean = and(b.i) != 0
-infix fun TabBarFlags.hasnt(b: TabBarFlag): Boolean = and(b.i) == 0
-infix fun TabBarFlags.wo(b: TabBarFlag): TabBarFlags = and(b.i.inv())
-operator fun TabBarFlags.minus(flag: TabBarFlag): TabBarFlags = wo(flag)
-operator fun TabBarFlags.div(flag: TabBarFlag): TabBarFlags = or(flag)
-
 
 typealias TabItemFlags = Int
 
 /** Flags for ImGui::BeginTabItem() */
-enum class TabItemFlag(@JvmField val i: TabItemFlags) {
-    None(0),
+enum class TabItemFlag(override val i: TabItemFlags) : Flag<TabItemFlag> {
+  None(0),
 
-    /** Display a dot next to the title + tab is selected when clicking the X + closure is not assumed (will wait for user to stop submitting the tab). Otherwise closure is assumed when pressing the X, so if you keep submitting the tab may reappear at end of tab bar. */
-    UnsavedDocument(1 shl 0),
+  /** Display a dot next to the title + tab is selected when clicking the X + closure is not assumed (will wait for user to stop submitting the tab). Otherwise closure is assumed when pressing the X, so if you keep submitting the tab may reappear at end of tab bar. */
+  UnsavedDocument(1 shl 0),
 
-    /** Trigger flag to programmatically make the tab selected when calling BeginTabItem() */
-    SetSelected(1 shl 1),
+  /** Trigger flag to programmatically make the tab selected when calling BeginTabItem() */
+  SetSelected(1 shl 1),
 
-    /** Disable behavior of closing tabs (that are submitted with p_open != NULL) with middle mouse button. You can still repro this behavior on user's side with if (IsItemHovered() && IsMouseClicked(2)) *p_open = false. */
-    NoCloseWithMiddleMouseButton(1 shl 2),
+  /** Disable behavior of closing tabs (that are submitted with p_open != NULL) with middle mouse button. You can still repro this behavior on user's side with if (IsItemHovered() && IsMouseClicked(2)) *p_open = false. */
+  NoCloseWithMiddleMouseButton(1 shl 2),
 
     /** Don't call PushID(tab->ID)/PopID() on BeginTabItem()/EndTabItem() */
     NoPushId(1 shl 3),
@@ -576,26 +485,9 @@ enum class TabItemFlag(@JvmField val i: TabItemFlags) {
     /** Track whether p_open was set or not (we'll need this info on the next frame to recompute ContentWidth during layout) */
     _NoCloseButton(1 shl 20),
 
-    /** Used by TabItemButton, change the tab item behavior to mimic a button */
-    _Button(1 shl 21);
-
-    infix fun and(b: TabItemFlag): TabItemFlags = i and b.i
-    infix fun and(b: TabItemFlags): TabItemFlags = i and b
-    infix fun or(b: TabItemFlag): TabItemFlags = i or b.i
-    infix fun or(b: TabItemFlags): TabItemFlags = i or b
-    infix fun xor(b: TabItemFlag): TabItemFlags = i xor b.i
-    infix fun xor(b: TabItemFlags): TabItemFlags = i xor b
-    infix fun wo(b: TabItemFlags): TabItemFlags = and(b.inv())
+  /** Used by TabItemButton, change the tab item behavior to mimic a button */
+  _Button(1 shl 21)
 }
-
-infix fun TabItemFlags.and(b: TabItemFlag): TabItemFlags = and(b.i)
-infix fun TabItemFlags.or(b: TabItemFlag): TabItemFlags = or(b.i)
-infix fun TabItemFlags.xor(b: TabItemFlag): TabItemFlags = xor(b.i)
-infix fun TabItemFlags.has(b: TabItemFlag): Boolean = and(b.i) != 0
-infix fun TabItemFlags.hasnt(b: TabItemFlag): Boolean = and(b.i) == 0
-infix fun TabItemFlags.wo(b: TabItemFlag): TabItemFlags = and(b.i.inv())
-operator fun TabItemFlags.minus(flag: TabItemFlag): TabItemFlags = wo(flag)
-operator fun TabItemFlags.div(flag: TabItemFlag): TabItemFlags = or(flag)
 
 
 typealias TableFlags = Int
@@ -622,17 +514,17 @@ typealias TableFlags = Int
 //    - Using Stretch columns OFTEN DOES NOT MAKE SENSE if ScrollX is on, UNLESS you have specified a value for 'inner_width' in BeginTable().
 //      If you specify a value for 'inner_width' then effectively the scrolling space is known and Stretch or mixed Fixed/Stretch columns become meaningful again.
 // - Read on documentation at the top of imgui_tables.cpp for details.
-enum class TableFlag(@JvmField val i: TableFlags) {
+enum class TableFlag(override val i: TableFlags) : Flag<TableFlag> {
 
-    // Features
+  // Features
 
-    None(0),
+  None(0),
 
-    /** Enable resizing columns. */
-    Resizable(1 shl 0),
+  /** Enable resizing columns. */
+  Resizable(1 shl 0),
 
-    /** Enable reordering columns in header row (need calling TableSetupColumn() + TableHeadersRow() to display headers) */
-    Reorderable(1 shl 1),
+  /** Enable reordering columns in header row (need calling TableSetupColumn() + TableHeadersRow() to display headers) */
+  Reorderable(1 shl 1),
 
     /** Enable hiding/disabling columns in context menu. */
     Hideable(1 shl 2),
@@ -742,40 +634,24 @@ enum class TableFlag(@JvmField val i: TableFlags) {
     /** Allow no sorting, disable default sorting. TableGetSortSpecs() may return specs where (SpecsCount == 0). */
     SortTristate(1 shl 27),
 
-    /** [Internal] Combinations and masks */
-    _SizingMask(SizingFixedFit or SizingFixedSame or SizingStretchProp or SizingStretchSame);
-
-    infix fun and(b: TableFlag): TableFlags = i and b.i
-    infix fun and(b: TableFlags): TableFlags = i and b
-    infix fun or(b: TableFlag): TableFlags = i or b.i
-    infix fun or(b: TableFlags): TableFlags = i or b
-    infix fun xor(b: TableFlag): TableFlags = i xor b.i
-    infix fun xor(b: TableFlags): TableFlags = i xor b
-    infix fun wo(b: TableFlags): TableFlags = and(b.inv())
+  /** [Internal] Combinations and masks */
+  _SizingMask(SizingFixedFit or SizingFixedSame or SizingStretchProp or SizingStretchSame)
 }
-
-infix fun TableFlags.and(b: TableFlag): TableFlags = and(b.i)
-infix fun TableFlags.or(b: TableFlag): TableFlags = or(b.i)
-infix fun TableFlags.xor(b: TableFlag): TableFlags = xor(b.i)
-infix fun TableFlags.has(b: TableFlag): Boolean = and(b.i) != 0
-infix fun TableFlags.hasnt(b: TableFlag): Boolean = and(b.i) == 0
-infix fun TableFlags.wo(b: TableFlag): TableFlags = and(b.i.inv())
-
 
 typealias TableColumnFlags = Int
 
 // Flags for ImGui::TableSetupColumn()
-enum class TableColumnFlag(@JvmField val i: TableColumnFlags) {
+enum class TableColumnFlag(override val i: TableColumnFlags) : Flag<TableColumnFlag> {
 
-    // Input configuration flags
+  // Input configuration flags
 
-    None(0),
+  None(0),
 
-    /** Overriding/master disable flag: hide column, won't show in context menu (unlike calling TableSetColumnEnabled() which manipulates the user accessible state) */
-    Disabled(1 shl 0),
+  /** Overriding/master disable flag: hide column, won't show in context menu (unlike calling TableSetColumnEnabled() which manipulates the user accessible state) */
+  Disabled(1 shl 0),
 
-    /** Default as a hidden/disabled column. */
-    DefaultHide(1 shl 1),
+  /** Default as a hidden/disabled column. */
+  DefaultHide(1 shl 1),
 
     /** Default as a sorting column. */
     DefaultSort(1 shl 2),
@@ -845,54 +721,19 @@ enum class TableColumnFlag(@JvmField val i: TableColumnFlags) {
     IndentMask_(IndentEnable or IndentDisable),
     StatusMask_(IsEnabled or IsVisible or IsSorted or IsHovered),
 
-    /** [Internal] Disable user resizing this column directly (it may however we resized indirectly from its left edge) */
-    NoDirectResize_(1 shl 30);
-
-    infix fun and(b: TableColumnFlag): TableColumnFlags = i and b.i
-    infix fun and(b: TableColumnFlags): TableColumnFlags = i and b
-    infix fun or(b: TableColumnFlag): TableColumnFlags = i or b.i
-    infix fun or(b: TableColumnFlags): TableColumnFlags = i or b
-    infix fun xor(b: TableColumnFlag): TableColumnFlags = i xor b.i
-    infix fun xor(b: TableColumnFlags): TableColumnFlags = i xor b
-    infix fun wo(b: TableColumnFlags): TableColumnFlags = and(b.inv())
+  /** [Internal] Disable user resizing this column directly (it may however we resized indirectly from its left edge) */
+  NoDirectResize_(1 shl 30)
 }
-
-infix fun TableColumnFlags.and(b: TableColumnFlag): TableColumnFlags = and(b.i)
-infix fun TableColumnFlags.or(b: TableColumnFlag): TableColumnFlags = or(b.i)
-infix fun TableColumnFlags.xor(b: TableColumnFlag): TableColumnFlags = xor(b.i)
-infix fun TableColumnFlags.has(b: TableColumnFlag): Boolean = and(b.i) != 0
-infix fun TableColumnFlags.hasnt(b: TableColumnFlag): Boolean = and(b.i) == 0
-infix fun TableColumnFlags.wo(b: TableColumnFlag): TableColumnFlags = and(b.i.inv())
-operator fun TableColumnFlags.minus(flag: TableColumnFlag): TableColumnFlags = wo(flag)
-operator fun TableColumnFlags.div(flag: TableColumnFlag): TableColumnFlags = or(flag)
-
-
 
 typealias TableRowFlags = Int
 
 // Flags for ImGui::TableNextRow()
-enum class TableRowFlag(@JvmField val i: Int) {
-    None(0),
+enum class TableRowFlag(override val i: Int) : Flag<TableRowFlag> {
+  None(0),
 
-    /** Identify header row (set default background color + width of its contents accounted differently for auto column width) */
-    Headers(1 shl 0);
-
-    infix fun and(b: TableRowFlag): TableRowFlags = i and b.i
-    infix fun and(b: TableRowFlags): TableRowFlags = i and b
-    infix fun or(b: TableRowFlag): TableRowFlags = i or b.i
-    infix fun or(b: TableRowFlags): TableRowFlags = i or b
-    infix fun xor(b: TableRowFlag): TableRowFlags = i xor b.i
-    infix fun xor(b: TableRowFlags): TableRowFlags = i xor b
-    infix fun wo(b: TableRowFlags): TableRowFlags = and(b.inv())
+  /** Identify header row (set default background color + width of its contents accounted differently for auto column width) */
+  Headers(1 shl 0)
 }
-
-infix fun TableRowFlags.and(b: TableRowFlag): TableRowFlags = and(b.i)
-infix fun TableRowFlags.or(b: TableRowFlag): TableRowFlags = or(b.i)
-infix fun TableRowFlags.xor(b: TableRowFlag): TableRowFlags = xor(b.i)
-infix fun TableRowFlags.has(b: TableRowFlag): Boolean = and(b.i) != 0
-infix fun TableRowFlags.hasnt(b: TableRowFlag): Boolean = and(b.i) == 0
-infix fun TableRowFlags.wo(b: TableRowFlag): TableRowFlags = and(b.i.inv())
-
 
 typealias TableBgTargets = Int
 
@@ -905,95 +746,63 @@ typealias TableBgTargets = Int
 // When using ImGuiTableFlags_RowBg on the table, each row has the RowBg0 color automatically set for odd/even rows.
 // If you set the color of RowBg0 target, your color will override the existing RowBg0 color.
 // If you set the color of RowBg1 or ColumnBg1 target, your color will blend over the RowBg0 color.
-enum class TableBgTarget(@JvmField val i: TableBgTargets) {
-    None(0),
+enum class TableBgTarget(override val i: TableBgTargets) : Flag<TableBgTarget> {
+  None(0),
 
-    /** Set row background color 0 (generally used for background, automatically set when ImGuiTableFlags_RowBg is used) */
-    RowBg0(1),
+  /** Set row background color 0 (generally used for background, automatically set when ImGuiTableFlags_RowBg is used) */
+  RowBg0(1),
 
-    /** Set row background color 1 (generally used for selection marking) */
-    RowBg1(2),
+  /** Set row background color 1 (generally used for selection marking) */
+  RowBg1(2),
 
-    /** Set cell background color (top-most color) */
-    CellBg(3);
-
-    infix fun and(b: TableBgTarget): TableBgTargets = i and b.i
-    infix fun and(b: TableBgTargets): TableBgTargets = i and b
-    infix fun or(b: TableBgTarget): TableBgTargets = i or b.i
-    infix fun or(b: TableBgTargets): TableBgTargets = i or b
-    infix fun xor(b: TableBgTarget): TableBgTargets = i xor b.i
-    infix fun xor(b: TableBgTargets): TableBgTargets = i xor b
-    infix fun wo(b: TableBgTargets): TableBgTargets = and(b.inv())
+  /** Set cell background color (top-most color) */
+  CellBg(3);
 
     companion object {
         infix fun of(i: Int) = values().first { it.i == i }
     }
 }
 
-infix fun TableBgTargets.and(b: TableBgTarget): TableBgTargets = and(b.i)
-infix fun TableBgTargets.or(b: TableBgTarget): TableBgTargets = or(b.i)
-infix fun TableBgTargets.xor(b: TableBgTarget): TableBgTargets = xor(b.i)
-infix fun TableBgTargets.has(b: TableBgTarget): Boolean = and(b.i) != 0
-infix fun TableBgTargets.hasnt(b: TableBgTarget): Boolean = and(b.i) == 0
-infix fun TableBgTargets.wo(b: TableBgTarget): TableBgTargets = and(b.i.inv())
-
-
 typealias FocusedFlags = Int
 
 /** Flags for ImGui::IsWindowFocused() */
-enum class FocusedFlag(@JvmField val i: FocusedFlags) {
-    None(0),
+enum class FocusedFlag(override val i: FocusedFlags) : Flag<FocusedFlag> {
+  None(0),
 
-    /** Return true if any children of the window is focused */
-    ChildWindows(1 shl 0),
+  /** Return true if any children of the window is focused */
+  ChildWindows(1 shl 0),
 
-    /** Test from root window (top most parent of the current hierarchy) */
-    RootWindow(1 shl 1),
+  /** Test from root window (top most parent of the current hierarchy) */
+  RootWindow(1 shl 1),
 
-    /** Return true if any window is focused.
-     *  Important: If you are trying to tell how to dispatch your low-level inputs, do NOT use this. Use 'io.WantCaptureMouse' instead! Please read the FAQ! */
+  /** Return true if any window is focused.
+   *  Important: If you are trying to tell how to dispatch your low-level inputs, do NOT use this. Use 'io.WantCaptureMouse' instead! Please read the FAQ! */
     AnyWindow(1 shl 2),
 
     /** Do not consider popup hierarchy (do not treat popup emitter as parent of popup) (when used with _ChildWindows or _RootWindow) */
     NoPopupHierarchy(1 shl 3),
 
-    //ImGuiFocusedFlags_DockHierarchy               = 1 << 4,   // Consider docking hierarchy (treat dockspace host as parent of docked window) (when used with _ChildWindows or _RootWindow)
-    RootAndChildWindows(RootWindow or ChildWindows);
-
-    infix fun and(b: FocusedFlag): FocusedFlags = i and b.i
-    infix fun and(b: FocusedFlags): FocusedFlags = i and b
-    infix fun or(b: FocusedFlag): FocusedFlags = i or b.i
-    infix fun or(b: FocusedFlags): FocusedFlags = i or b
-    infix fun xor(b: FocusedFlag): FocusedFlags = i xor b.i
-    infix fun xor(b: FocusedFlags): FocusedFlags = i xor b
-    infix fun wo(b: FocusedFlags): FocusedFlags = and(b.inv())
+  //ImGuiFocusedFlags_DockHierarchy               = 1 << 4,   // Consider docking hierarchy (treat dockspace host as parent of docked window) (when used with _ChildWindows or _RootWindow)
+  RootAndChildWindows(RootWindow or ChildWindows)
 }
-
-infix fun FocusedFlags.and(b: FocusedFlag): FocusedFlags = and(b.i)
-infix fun FocusedFlags.or(b: FocusedFlag): FocusedFlags = or(b.i)
-infix fun FocusedFlags.xor(b: FocusedFlag): FocusedFlags = xor(b.i)
-infix fun FocusedFlags.has(b: FocusedFlag): Boolean = and(b.i) != 0
-infix fun FocusedFlags.hasnt(b: FocusedFlag): Boolean = and(b.i) == 0
-infix fun FocusedFlags.wo(b: FocusedFlag): FocusedFlags = and(b.i.inv())
-
 
 typealias HoveredFlags = Int
 
 /** Flags: for IsItemHovered(), IsWindowHovered() etc.
  *  Note: if you are trying to check whether your mouse should be dispatched to Dear ImGui or to your app, you should use 'io.WantCaptureMouse' instead! Please read the FAQ!
  *  Note: windows with the ImGuiWindowFlags_NoInputs flag are ignored by IsWindowHovered() calls.*/
-enum class HoveredFlag(@JvmField val i: HoveredFlags) {
-    /** Return true if directly over the item/window, not obstructed by another window, not obstructed by an active
-     *  popup or modal blocking inputs under them.  */
-    None(0),
+enum class HoveredFlag(override val i: HoveredFlags) : Flag<HoveredFlag> {
+  /** Return true if directly over the item/window, not obstructed by another window, not obstructed by an active
+   *  popup or modal blocking inputs under them.  */
+  None(0),
 
-    /** isWindowHovered() only: Return true if any children of the window is hovered */
-    ChildWindows(1 shl 0),
+  /** isWindowHovered() only: Return true if any children of the window is hovered */
+  ChildWindows(1 shl 0),
 
-    /** isWindowHovered() only: Test from root window (top most parent of the current hierarchy) */
-    RootWindow(1 shl 1),
+  /** isWindowHovered() only: Test from root window (top most parent of the current hierarchy) */
+  RootWindow(1 shl 1),
 
-    /** IsWindowHovered() only: Return true if any window is hovered    */
+  /** IsWindowHovered() only: Return true if any window is hovered    */
     AnyWindow(1 shl 2),
 
     /** IsWindowHovered() only: Do not consider popup hierarchy (do not treat popup emitter as parent of popup) (when used with _ChildWindows or _RootWindow) */
@@ -1025,40 +834,24 @@ enum class HoveredFlag(@JvmField val i: HoveredFlags) {
     /** Return true after io.HoverDelayShort elapsed (~0.10 sec) */
     DelayShort(1 shl 12),
 
-    /** Disable shared delay system where moving from one item to the next keeps the previous timer for a short time (standard for tooltips with long delays) */
-    NoSharedDelay(1 shl 13);
-
-    infix fun and(b: HoveredFlag): HoveredFlags = i and b.i
-    infix fun and(b: HoveredFlags): HoveredFlags = i and b
-    infix fun or(b: HoveredFlag): HoveredFlags = i or b.i
-    infix fun or(b: HoveredFlags): HoveredFlags = i or b
-    infix fun xor(b: HoveredFlag): HoveredFlags = i xor b.i
-    infix fun xor(b: HoveredFlags): HoveredFlags = i xor b
-    infix fun wo(b: HoveredFlags): HoveredFlags = and(b.inv())
+  /** Disable shared delay system where moving from one item to the next keeps the previous timer for a short time (standard for tooltips with long delays) */
+  NoSharedDelay(1 shl 13)
 }
-
-infix fun HoveredFlags.and(b: HoveredFlag): HoveredFlags = and(b.i)
-infix fun HoveredFlags.or(b: HoveredFlag): HoveredFlags = or(b.i)
-infix fun HoveredFlags.xor(b: HoveredFlag): HoveredFlags = xor(b.i)
-infix fun HoveredFlags.has(b: HoveredFlag): Boolean = and(b.i) != 0
-infix fun HoveredFlags.hasnt(b: HoveredFlag): Boolean = and(b.i) == 0
-infix fun HoveredFlags.wo(b: HoveredFlag): HoveredFlags = and(b.i.inv())
-
 
 typealias DragDropFlags = Int
 
 /** Flags for beginDragDropSource(), acceptDragDropPayload() */
-enum class DragDropFlag(@JvmField val i: DragDropFlags) {
-    // BeginDragDropSource() flags
-    None(0),
+enum class DragDropFlag(override val i: DragDropFlags) : Flag<DragDropFlag> {
+  // BeginDragDropSource() flags
+  None(0),
 
-    /** Disable preview tooltip. By default, a successful call to BeginDragDropSource opens a tooltip so you can display a preview or description of the source contents. This flag disables this behavior. */
-    SourceNoPreviewTooltip(1 shl 0),
+  /** Disable preview tooltip. By default, a successful call to BeginDragDropSource opens a tooltip so you can display a preview or description of the source contents. This flag disables this behavior. */
+  SourceNoPreviewTooltip(1 shl 0),
 
-    /** By default, when dragging we clear data so that IsItemHovered() will return false,
-     *  to avoid subsequent user code submitting tooltips.
-     *  This flag disables this behavior so you can still call IsItemHovered() on the source item. */
-    SourceNoDisableHover(1 shl 1),
+  /** By default, when dragging we clear data so that IsItemHovered() will return false,
+   *  to avoid subsequent user code submitting tooltips.
+   *  This flag disables this behavior so you can still call IsItemHovered() on the source item. */
+  SourceNoDisableHover(1 shl 1),
 
     /** Disable the behavior that allows to open tree nodes and collapsing header by holding over them while dragging
      *  a source item. */
@@ -1086,24 +879,9 @@ enum class DragDropFlag(@JvmField val i: DragDropFlags) {
     /** Request hiding the BeginDragDropSource tooltip from the BeginDragDropTarget site. */
     AcceptNoPreviewTooltip(1 shl 12),
 
-    /** For peeking ahead and inspecting the payload before delivery. */
-    AcceptPeekOnly(AcceptBeforeDelivery or AcceptNoDrawDefaultRect);
-
-    infix fun and(b: DragDropFlag): DragDropFlags = i and b.i
-    infix fun and(b: DragDropFlags): DragDropFlags = i and b
-    infix fun or(b: DragDropFlag): DragDropFlags = i or b.i
-    infix fun or(b: DragDropFlags): DragDropFlags = i or b
-    infix fun xor(b: DragDropFlag): DragDropFlags = i xor b.i
-    infix fun xor(b: DragDropFlags): DragDropFlags = i xor b
-    infix fun wo(b: DragDropFlags): DragDropFlags = and(b.inv())
+  /** For peeking ahead and inspecting the payload before delivery. */
+  AcceptPeekOnly(AcceptBeforeDelivery or AcceptNoDrawDefaultRect)
 }
-
-infix fun DragDropFlags.and(b: DragDropFlag): DragDropFlags = and(b.i)
-infix fun DragDropFlags.or(b: DragDropFlag): DragDropFlags = or(b.i)
-infix fun DragDropFlags.xor(b: DragDropFlag): DragDropFlags = xor(b.i)
-infix fun DragDropFlags.has(b: DragDropFlag): Boolean = and(b.i) != 0
-infix fun DragDropFlags.hasnt(b: DragDropFlag): Boolean = and(b.i) == 0
-infix fun DragDropFlags.wo(b: DragDropFlag): DragDropFlags = and(b.i.inv())
 
 // Standard Drag and Drop payload types. Types starting with '_' are defined by Dear ImGui.
 /** float[3]: Standard type for colors, without alpha. User code may use this type. */
@@ -1175,17 +953,17 @@ typealias KeyChord = Int
 // Read details about the 1.87 and 1.89 transition : https://github.com/ocornut/imgui/issues/4921
 
 /** A key identifier (ImGui-side enum) */
-enum class Key(i: KeyChord? = null) {
-    // Keyboard
-    None, Tab, LeftArrow, RightArrow, UpArrow, DownArrow, PageUp, PageDown, Home, End, Insert, Delete, Backspace, Space, Enter, Escape,
-    LeftCtrl, LeftShift, LeftAlt, LeftSuper,
-    RightCtrl, RightShift, RightAlt, RightSuper,
-    Menu,
-    `0`, `1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`, `9`,
-    A, B, C, D, E, F, G, H, I, J,
-    K, L, M, N, O, P, Q, R, S, T,
-    U, V, W, X, Y, Z,
-    F1, F2, F3, F4, F5, F6,
+enum class Key(i: KeyChord? = null) : Flag<Key> {
+  // Keyboard
+  None, Tab, LeftArrow, RightArrow, UpArrow, DownArrow, PageUp, PageDown, Home, End, Insert, Delete, Backspace, Space, Enter, Escape,
+  LeftCtrl, LeftShift, LeftAlt, LeftSuper,
+  RightCtrl, RightShift, RightAlt, RightSuper,
+  Menu,
+  `0`, `1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`, `9`,
+  A, B, C, D, E, F, G, H, I, J,
+  K, L, M, N, O, P, Q, R, S, T,
+  U, V, W, X, Y, Z,
+  F1, F2, F3, F4, F5, F6,
     F7, F8, F9, F10, F11, F12,
 
     /** ' */
@@ -1285,8 +1063,7 @@ enum class Key(i: KeyChord? = null) {
     Mod_Shortcut(1 shl 11),
     Mod_Mask_(0xF800); // 5-bits
 
-    @JvmField
-    val i: KeyChord = i ?: if (ordinal == 0) 0 else 511 + ordinal
+  override val i: KeyChord = i ?: if (ordinal == 0) 0 else 511 + ordinal
 
     val index: Int
         get() = ordinal - 1
@@ -1313,26 +1090,7 @@ enum class Key(i: KeyChord? = null) {
         internal val _NavGamepadMenu = GamepadFaceLeft
         internal val _NavGamepadInput = GamepadFaceUp
     }
-
-    infix fun and(b: Key): KeyChord = i and b.i
-    infix fun and(b: KeyChord): KeyChord = i and b
-    infix fun or(b: Key): KeyChord = i or b.i
-    infix fun or(b: KeyChord): KeyChord = i or b
-    infix fun xor(b: Key): KeyChord = i xor b.i
-    infix fun xor(b: KeyChord): KeyChord = i xor b
-    infix fun has(b: Key): Boolean = and(b.i) != 0
-    infix fun hasnt(b: Key): Boolean = and(b.i) == 0
-    infix fun wo(b: KeyChord): KeyChord = and(b.inv())
 }
-
-infix fun KeyChord.and(b: Key): KeyChord = and(b.i)
-infix fun KeyChord.or(b: Key): KeyChord = or(b.i)
-infix fun KeyChord.xor(b: Key): KeyChord = xor(b.i)
-infix fun KeyChord.has(b: Key): Boolean = and(b.i) != 0
-infix fun KeyChord.hasnt(b: Key): Boolean = and(b.i) == 0
-infix fun KeyChord.wo(b: Key): KeyChord = and(b.i.inv())
-operator fun KeyChord.minus(flag: Key): KeyChord = wo(flag)
-operator fun KeyChord.div(flag: Key): KeyChord = or(flag)
 
 infix fun Long.shl(key: Key) = shl(key.i)
 
@@ -1437,17 +1195,17 @@ typealias ConfigFlags = Int
 /** Configuration flags stored in io.configFlags
  *
  *  Flags: for io.ConfigFlags   */
-enum class ConfigFlag(@JvmField val i: ConfigFlags) {
-    None(0),
+enum class ConfigFlag(override val i: ConfigFlags) : Flag<ConfigFlag> {
+  None(0),
 
-    /** Master keyboard navigation enable flag. NewFrame() will automatically fill io.NavInputs[] based on io.AddKeyEvent() calls. */
-    NavEnableKeyboard(1 shl 0),
+  /** Master keyboard navigation enable flag. NewFrame() will automatically fill io.NavInputs[] based on io.AddKeyEvent() calls. */
+  NavEnableKeyboard(1 shl 0),
 
-    /** Master gamepad navigation enable flag. This is mostly to instruct your imgui backend to fill io.NavInputs[].
-     *  Backend also needs to set ImGuiBackendFlags_HasGamepad. */
-    NavEnableGamepad(1 shl 1),
+  /** Master gamepad navigation enable flag. This is mostly to instruct your imgui backend to fill io.NavInputs[].
+   *  Backend also needs to set ImGuiBackendFlags_HasGamepad. */
+  NavEnableGamepad(1 shl 1),
 
-    /** Instruct navigation to move the mouse cursor. May be useful on TV/console systems where moving a virtual mouse is awkward.
+  /** Instruct navigation to move the mouse cursor. May be useful on TV/console systems where moving a virtual mouse is awkward.
      *  Will update io.MousePos and set io.wantSetMousePos=true. If enabled you MUST honor io.wantSetMousePos requests in your backend,
      *  otherwise ImGui will react as if the mouse is jumping around back and forth. */
     NavEnableSetMousePos(1 shl 2),
@@ -1474,26 +1232,9 @@ enum class ConfigFlag(@JvmField val i: ConfigFlags) {
     /** Application is SRGB-aware. */
     IsSRGB(1 shl 20),
 
-    /** Application is using a touch screen instead of a mouse. */
-    IsTouchScreen(1 shl 21);
-
-    infix fun and(b: ConfigFlag): ConfigFlags = i and b.i
-    infix fun and(b: ConfigFlags): ConfigFlags = i and b
-    infix fun or(b: ConfigFlag): ConfigFlags = i or b.i
-    infix fun or(b: ConfigFlags): ConfigFlags = i or b
-    infix fun xor(b: ConfigFlag): ConfigFlags = i xor b.i
-    infix fun xor(b: ConfigFlags): ConfigFlags = i xor b
-    infix fun wo(b: ConfigFlags): ConfigFlags = and(b.inv())
+  /** Application is using a touch screen instead of a mouse. */
+  IsTouchScreen(1 shl 21)
 }
-
-infix fun ConfigFlags.and(b: ConfigFlag): ConfigFlags = and(b.i)
-infix fun ConfigFlags.or(b: ConfigFlag): ConfigFlags = or(b.i)
-infix fun ConfigFlags.xor(b: ConfigFlag): ConfigFlags = xor(b.i)
-infix fun ConfigFlags.has(b: ConfigFlag): Boolean = and(b.i) != 0
-infix fun ConfigFlags.hasnt(b: ConfigFlag): Boolean = and(b.i) == 0
-infix fun ConfigFlags.wo(b: ConfigFlag): ConfigFlags = and(b.i.inv())
-operator fun ConfigFlags.minus(flag: ConfigFlag): ConfigFlags = wo(flag)
-operator fun ConfigFlags.div(flag: ConfigFlag): ConfigFlags = or(flag)
 
 
 typealias BackendFlags = Int
@@ -1501,38 +1242,21 @@ typealias BackendFlags = Int
 /** Backend capabilities flags stored in io.BackendFlag. Set by imgui_impl_xxx or custom backend.
  *
  *  Flags: for io.BackendFlags  */
-enum class BackendFlag(@JvmField val i: BackendFlags) {
-    None(0),
+enum class BackendFlag(override val i: BackendFlags) : Flag<BackendFlag> {
+  None(0),
 
-    /** Backend Platform supports gamepad and currently has one connected. */
-    HasGamepad(1 shl 0),
+  /** Backend Platform supports gamepad and currently has one connected. */
+  HasGamepad(1 shl 0),
 
-    /** Backend Platform supports honoring GetMouseCursor() value to change the OS cursor shape. */
-    HasMouseCursors(1 shl 1),
+  /** Backend Platform supports honoring GetMouseCursor() value to change the OS cursor shape. */
+  HasMouseCursors(1 shl 1),
 
-    /** Backend Platform supports io.WantSetMousePos requests to reposition the OS mouse position (only used if ImGuiConfigFlags_NavEnableSetMousePos is set). */
-    HasSetMousePos(1 shl 2),
+  /** Backend Platform supports io.WantSetMousePos requests to reposition the OS mouse position (only used if ImGuiConfigFlags_NavEnableSetMousePos is set). */
+  HasSetMousePos(1 shl 2),
 
     /** Backend Platform supports ImDrawCmd::VtxOffset. This enables output of large meshes (64K+ vertices) while still using 16-bit indices. */
     RendererHasVtxOffset(1 shl 3);
-
-    infix fun and(b: BackendFlag): BackendFlags = i and b.i
-    infix fun and(b: BackendFlags): BackendFlags = i and b
-    infix fun or(b: BackendFlag): BackendFlags = i or b.i
-    infix fun or(b: BackendFlags): BackendFlags = i or b
-    infix fun xor(b: BackendFlag): BackendFlags = i xor b.i
-    infix fun xor(b: BackendFlags): BackendFlags = i xor b
-    infix fun wo(b: BackendFlags): BackendFlags = and(b.inv())
 }
-
-infix fun BackendFlags.and(b: BackendFlag): BackendFlags = and(b.i)
-infix fun BackendFlags.or(b: BackendFlag): BackendFlags = or(b.i)
-infix fun BackendFlags.xor(b: BackendFlag): BackendFlags = xor(b.i)
-infix fun BackendFlags.has(b: BackendFlag): Boolean = and(b.i) != 0
-infix fun BackendFlags.hasnt(b: BackendFlag): Boolean = and(b.i) == 0
-infix fun BackendFlags.wo(b: BackendFlag): BackendFlags = and(b.i.inv())
-operator fun BackendFlags.minus(flag: BackendFlag): BackendFlags = wo(flag)
-operator fun BackendFlags.div(flag: BackendFlag): BackendFlags = or(flag)
 
 /** Enumeration for PushStyleColor() / PopStyleColor()  */
 /** A color identifier for styling */
@@ -1738,17 +1462,17 @@ typealias ColorEditFlags = Int
 /** Flags for ColorEdit3() / ColorEdit4() / ColorPicker3() / ColorPicker4() / ColorButton()
  *
  *  Flags: for ColorEdit4(), ColorPicker4() etc.    */
-enum class ColorEditFlag(@JvmField val i: ColorEditFlags) {
+enum class ColorEditFlag(override val i: ColorEditFlags) : Flag<ColorEditFlag> {
 
-    None(0),
+  None(0),
 
-    /** ColorEdit, ColorPicker, ColorButton: ignore Alpha component (will only read 3 components from the input pointer). */
-    NoAlpha(1 shl 1),
+  /** ColorEdit, ColorPicker, ColorButton: ignore Alpha component (will only read 3 components from the input pointer). */
+  NoAlpha(1 shl 1),
 
-    /** ColorEdit: disable picker when clicking on color square.  */
-    NoPicker(1 shl 2),
+  /** ColorEdit: disable picker when clicking on color square.  */
+  NoPicker(1 shl 2),
 
-    /** ColorEdit: disable toggling options menu when right-clicking on inputs/small preview.   */
+  /** ColorEdit: disable toggling options menu when right-clicking on inputs/small preview.   */
     NoOptions(1 shl 3),
 
     /** ColorEdit, ColorPicker: disable color square preview next to the inputs. (e.g. to show only the inputs)   */
@@ -1822,24 +1546,9 @@ enum class ColorEditFlag(@JvmField val i: ColorEditFlags) {
     // [Internal] Masks
     _DisplayMask(DisplayRGB or DisplayHSV or DisplayHEX),
     _DataTypeMask(Uint8 or Float),
-    _PickerMask(PickerHueWheel or PickerHueBar),
-    _InputMask(InputRGB or InputHSV);
-
-    infix fun and(b: ColorEditFlag): ColorEditFlags = i and b.i
-    infix fun and(b: ColorEditFlags): ColorEditFlags = i and b
-    infix fun or(b: ColorEditFlag): ColorEditFlags = i or b.i
-    infix fun or(b: ColorEditFlags): ColorEditFlags = i or b
-    infix fun xor(b: ColorEditFlag): ColorEditFlags = i xor b.i
-    infix fun xor(b: ColorEditFlags): ColorEditFlags = i xor b
-    infix fun wo(b: ColorEditFlags): ColorEditFlags = and(b.inv())
+  _PickerMask(PickerHueWheel or PickerHueBar),
+  _InputMask(InputRGB or InputHSV)
 }
-
-infix fun ColorEditFlags.and(b: ColorEditFlag): ColorEditFlags = and(b.i)
-infix fun ColorEditFlags.or(b: ColorEditFlag): ColorEditFlags = or(b.i)
-infix fun ColorEditFlags.xor(b: ColorEditFlag): ColorEditFlags = xor(b.i)
-infix fun ColorEditFlags.has(b: ColorEditFlag): Boolean = and(b.i) != 0
-infix fun ColorEditFlags.hasnt(b: ColorEditFlag): Boolean = and(b.i) == 0
-infix fun ColorEditFlags.wo(b: ColorEditFlag): ColorEditFlags = and(b.i.inv())
 
 
 /** Flags for DragFloat(), DragInt(), SliderFloat(), SliderInt() etc.
@@ -1847,17 +1556,17 @@ infix fun ColorEditFlags.wo(b: ColorEditFlag): ColorEditFlags = and(b.i.inv())
  *  (Those are per-item flags. There are shared flags in ImGuiIO: io.ConfigDragClickToInputText) */
 typealias SliderFlags = Int
 
-enum class SliderFlag(val i: SliderFlags) {
-    None(0),
+enum class SliderFlag(override val i: SliderFlags) : Flag<SliderFlag> {
+  None(0),
 
-    /** Clamp value to min/max bounds when input manually with CTRL+Click. By default CTRL+Click allows going out of bounds. */
-    AlwaysClamp(1 shl 4),
+  /** Clamp value to min/max bounds when input manually with CTRL+Click. By default CTRL+Click allows going out of bounds. */
+  AlwaysClamp(1 shl 4),
 
-    /** Make the widget logarithmic (linear otherwise). Consider using ImGuiDragFlags_NoRoundToFormat with this if using a format-string with small amount of digits. */
-    Logarithmic(1 shl 5),
+  /** Make the widget logarithmic (linear otherwise). Consider using ImGuiDragFlags_NoRoundToFormat with this if using a format-string with small amount of digits. */
+  Logarithmic(1 shl 5),
 
-    /** Disable rounding underlying value to match precision of the display format string (e.g. %.3f values are rounded to those 3 digits) */
-    NoRoundToFormat(1 shl 6),
+  /** Disable rounding underlying value to match precision of the display format string (e.g. %.3f values are rounded to those 3 digits) */
+  NoRoundToFormat(1 shl 6),
 
     /** Disable CTRL+Click or Enter key allowing to input text directly into the widget */
     NoInput(1 shl 7),
@@ -1869,24 +1578,8 @@ enum class SliderFlag(val i: SliderFlags) {
     /** [Private] Should this widget be orientated vertically? */
     _Vertical(1 shl 20),
 
-    _ReadOnly(1 shl 21);
-
-    infix fun and(b: SliderFlag): SliderFlags = i and b.i
-    infix fun and(b: SliderFlags): SliderFlags = i and b
-    infix fun or(b: SliderFlag): SliderFlags = i or b.i
-    infix fun or(b: SliderFlags): SliderFlags = i or b
-    infix fun xor(b: SliderFlag): SliderFlags = i xor b.i
-    infix fun xor(b: SliderFlags): SliderFlags = i xor b
-    infix fun wo(b: SliderFlags): SliderFlags = and(b.inv())
+  _ReadOnly(1 shl 21)
 }
-
-infix fun SliderFlags.and(b: SliderFlag): SliderFlags = and(b.i)
-infix fun SliderFlags.or(b: SliderFlag): SliderFlags = or(b.i)
-infix fun SliderFlags.xor(b: SliderFlag): SliderFlags = xor(b.i)
-infix fun SliderFlags.has(b: SliderFlag): Boolean = and(b.i) != 0
-infix fun SliderFlags.hasnt(b: SliderFlag): Boolean = and(b.i) == 0
-infix fun SliderFlags.wo(b: SliderFlag): SliderFlags = and(b.i.inv())
-
 
 /** Identify a mouse button.
  *  Those values are guaranteed to be stable and we frequently use 0/1 directly. Named enums provided for convenience. */
@@ -1954,37 +1647,22 @@ typealias CondFlags = Int
  *  All the functions above treat 0 as a shortcut to Cond.Always.
  *
  *  Enum: A condition for many Set*() functions */
-enum class Cond(@JvmField val i: CondFlags) {
+enum class Cond(override val i: CondFlags) : Flag<Cond> {
 
-    /** No condition (always set the variable), same as _Always */
-    None(0),
+  /** No condition (always set the variable), same as _Always */
+  None(0),
 
-    /** No condition (always set the variable), same as _None */
-    Always(1 shl 0),
+  /** No condition (always set the variable), same as _None */
+  Always(1 shl 0),
 
-    /** Set the variable once per runtime session (only the first call will succeed)    */
-    Once(1 shl 1),
+  /** Set the variable once per runtime session (only the first call will succeed)    */
+  Once(1 shl 1),
 
-    /** Set the variable if the object/window has no persistently saved data (no entry in .ini file)    */
+  /** Set the variable if the object/window has no persistently saved data (no entry in .ini file)    */
     FirstUseEver(1 shl 2),
 
     /** Set the variable if the object/window is appearing after being hidden/inactive (or the first time) */
     Appearing(1 shl 3);
 
     //    val isPowerOfTwo = i.isPowerOfTwo // JVM, kind of useless since it's used on cpp to avoid Cond masks
-
-    infix fun and(b: Cond): CondFlags = i and b.i
-    infix fun and(b: CondFlags): CondFlags = i and b
-    infix fun or(b: Cond): CondFlags = i or b.i
-    infix fun or(b: CondFlags): CondFlags = i or b
-    infix fun xor(b: Cond): CondFlags = i xor b.i
-    infix fun xor(b: CondFlags): CondFlags = i xor b
-    infix fun wo(b: CondFlags): CondFlags = and(b.inv())
 }
-
-infix fun CondFlags.and(b: Cond): CondFlags = and(b.i)
-infix fun CondFlags.or(b: Cond): CondFlags = or(b.i)
-infix fun CondFlags.xor(b: Cond): CondFlags = xor(b.i)
-infix fun CondFlags.has(b: Cond): Boolean = and(b.i) != 0
-infix fun CondFlags.hasnt(b: Cond): Boolean = and(b.i) == 0
-infix fun CondFlags.wo(b: Cond): CondFlags = and(b.i.inv())

--- a/core/src/main/kotlin/imgui/internal/api/basicAccessors.kt
+++ b/core/src/main/kotlin/imgui/internal/api/basicAccessors.kt
@@ -6,10 +6,10 @@ import imgui.ImGui.debugHookIdInfo
 import imgui.ImGui.rectAbsToRel
 import imgui.ImGui.setNavWindow
 import imgui.api.g
+import imgui.div
 import imgui.internal.classes.Window
 import imgui.internal.hashStr
 import imgui.internal.sections.*
-import imgui.static.navUpdateAnyRequestFlag
 
 // Basic Accessors
 internal interface basicAccessors {

--- a/core/src/main/kotlin/imgui/internal/api/debugLog.kt
+++ b/core/src/main/kotlin/imgui/internal/api/debugLog.kt
@@ -1,8 +1,8 @@
 package imgui.internal.api
 
 import imgui.api.g
+import imgui.has
 import imgui.internal.classes.DebugLogFlag
-import imgui.internal.classes.has
 import imgui.internal.sections.IMGUI_DEBUG_PRINTF
 
 // Debug Log

--- a/core/src/main/kotlin/imgui/internal/api/disabling.kt
+++ b/core/src/main/kotlin/imgui/internal/api/disabling.kt
@@ -1,7 +1,10 @@
 package imgui.internal.api
 
 import imgui.api.g
-import imgui.internal.sections.*
+import imgui.div
+import imgui.has
+import imgui.hasnt
+import imgui.internal.sections.ItemFlag
 
 // Disabling [BETA API]
 // - Disable all user interactions and dim items visuals (applying style.DisabledAlpha over current colors)

--- a/core/src/main/kotlin/imgui/internal/api/newFrame.kt
+++ b/core/src/main/kotlin/imgui/internal/api/newFrame.kt
@@ -21,7 +21,6 @@ import imgui.api.g
 import imgui.internal.BitArray
 import imgui.internal.classes.DebugLogFlag
 import imgui.internal.classes.Window
-import imgui.internal.classes.has
 import imgui.internal.sections.IMGUI_DEBUG_LOG_IO
 import imgui.internal.sections.InputEvent
 import imgui.static.findHoveredWindow

--- a/core/src/main/kotlin/imgui/internal/api/scrolling.kt
+++ b/core/src/main/kotlin/imgui/internal/api/scrolling.kt
@@ -3,15 +3,14 @@ package imgui.internal.api
 import glm_.has
 import glm_.min
 import glm_.vec2.Vec2
-import imgui.ImGui
-import imgui.WindowFlag
+import imgui.*
 import imgui.api.g
-import imgui.has
 import imgui.internal.classes.Rect
 import imgui.internal.classes.Window
 import imgui.internal.floor
 import imgui.internal.isPowerOfTwo
-import imgui.internal.sections.*
+import imgui.internal.sections.ScrollFlag
+import imgui.internal.sections.ScrollFlags
 import imgui.static.calcNextScrollFromScrollTargetAndClamp
 
 // Scrolling

--- a/core/src/main/kotlin/imgui/internal/api/tablesInternal.kt
+++ b/core/src/main/kotlin/imgui/internal/api/tablesInternal.kt
@@ -22,7 +22,6 @@ import imgui.internal.classes.*
 import imgui.internal.sections.ButtonFlag
 import imgui.internal.sections.ItemFlag
 import imgui.internal.sections.NavLayer
-import imgui.internal.sections.or
 import imgui.or
 import imgui.static.*
 import kool.BYTES

--- a/core/src/main/kotlin/imgui/internal/sections/Columns support.kt
+++ b/core/src/main/kotlin/imgui/internal/sections/Columns support.kt
@@ -1,5 +1,6 @@
 package imgui.internal.sections
 
+import imgui.Flag
 import imgui.ID
 import imgui.internal.DrawListSplitter
 import imgui.internal.classes.Rect
@@ -13,7 +14,7 @@ import imgui.internal.classes.Rect
 typealias OldColumnsFlags = Int
 
 /** Flags: for Columns(), BeginColumns() */
-enum class OldColumnsFlag {
+enum class OldColumnsFlag : Flag<OldColumnsFlag> {
 
     None,
 
@@ -33,24 +34,8 @@ enum class OldColumnsFlag {
      *  width at all_. Will eventually remove.  */
     GrowParentContentsSize;
 
-    val i: OldColumnsFlags = if (ordinal == 0) 0 else 1 shl (ordinal - 1)
-
-    infix fun and(b: OldColumnsFlag): OldColumnsFlags = i and b.i
-    infix fun and(b: OldColumnsFlags): OldColumnsFlags = i and b
-    infix fun or(b: OldColumnsFlag): OldColumnsFlags = i or b.i
-    infix fun or(b: OldColumnsFlags): OldColumnsFlags = i or b
-    infix fun xor(b: OldColumnsFlag): OldColumnsFlags = i xor b.i
-    infix fun xor(b: OldColumnsFlags): OldColumnsFlags = i xor b
-    infix fun wo(b: OldColumnsFlags): OldColumnsFlags = and(b.inv())
+    override val i: OldColumnsFlags = if (ordinal == 0) 0 else 1 shl (ordinal - 1)
 }
-
-infix fun OldColumnsFlags.and(b: OldColumnsFlag): OldColumnsFlags = and(b.i)
-infix fun OldColumnsFlags.or(b: OldColumnsFlag): OldColumnsFlags = or(b.i)
-infix fun OldColumnsFlags.xor(b: OldColumnsFlag): OldColumnsFlags = xor(b.i)
-infix fun OldColumnsFlags.has(b: OldColumnsFlag): Boolean = and(b.i) != 0
-infix fun OldColumnsFlags.hasnt(b: OldColumnsFlag): Boolean = and(b.i) == 0
-infix fun OldColumnsFlags.wo(b: OldColumnsFlag): OldColumnsFlags = and(b.i.inv())
-
 
 /** Storage data for a single column for legacy Columns() api */
 class OldColumnData {

--- a/core/src/main/kotlin/imgui/internal/sections/Macros.kt
+++ b/core/src/main/kotlin/imgui/internal/sections/Macros.kt
@@ -2,8 +2,8 @@ package imgui.internal.sections
 
 import imgui.ImGui
 import imgui.api.g
+import imgui.has
 import imgui.internal.classes.DebugLogFlag
-import imgui.internal.classes.has
 
 
 // Debug Printing Into TTY

--- a/core/src/main/kotlin/imgui/internal/sections/Navigation support.kt
+++ b/core/src/main/kotlin/imgui/internal/sections/Navigation support.kt
@@ -1,6 +1,8 @@
 package imgui.internal.sections
 
+import imgui.Flag
 import imgui.internal.classes.Rect
+import imgui.or
 
 //-----------------------------------------------------------------------------
 // [SECTION] Navigation support
@@ -8,50 +10,34 @@ import imgui.internal.classes.Rect
 
 typealias ActivateFlags = Int
 
-enum class ActivateFlag {
-    None,
+enum class ActivateFlag : Flag<ActivateFlag> {
+  None,
 
-    /** Favor activation that requires keyboard text input (e.g. for Slider/Drag). Default if keyboard is available. */
-    PreferInput,
+  /** Favor activation that requires keyboard text input (e.g. for Slider/Drag). Default if keyboard is available. */
+  PreferInput,
 
-    /** Favor activation for tweaking with arrows or gamepad (e.g. for Slider/Drag). Default if keyboard is not available. */
-    PreferTweak,
+  /** Favor activation for tweaking with arrows or gamepad (e.g. for Slider/Drag). Default if keyboard is not available. */
+  PreferTweak,
 
-    /** Request widget to preserve state if it can (e.g. InputText will try to preserve cursor/selection) */
-    TryToPreserveState;
+  /** Request widget to preserve state if it can (e.g. InputText will try to preserve cursor/selection) */
+  TryToPreserveState;
 
-    val i: ActivateFlags = if (ordinal == 0) 0 else 1 shl (ordinal - 1)
-
-    infix fun and(b: ActivateFlag): ActivateFlags = i and b.i
-    infix fun and(b: ActivateFlags): ActivateFlags = i and b
-    infix fun or(b: ActivateFlag): ActivateFlags = i or b.i
-    infix fun or(b: ActivateFlags): ActivateFlags = i or b
-    infix fun xor(b: ActivateFlag): ActivateFlags = i xor b.i
-    infix fun xor(b: ActivateFlags): ActivateFlags = i xor b
-    infix fun wo(b: ActivateFlags): ActivateFlags = and(b.inv())
+  override val i: ActivateFlags = if (ordinal == 0) 0 else 1 shl (ordinal - 1)
 }
-
-infix fun ActivateFlags.and(b: ActivateFlag): ActivateFlags = and(b.i)
-infix fun ActivateFlags.or(b: ActivateFlag): ActivateFlags = or(b.i)
-infix fun ActivateFlags.xor(b: ActivateFlag): ActivateFlags = xor(b.i)
-infix fun ActivateFlags.has(b: ActivateFlag): Boolean = and(b.i) != 0
-infix fun ActivateFlags.hasnt(b: ActivateFlag): Boolean = and(b.i) == 0
-infix fun ActivateFlags.wo(b: ActivateFlag): ActivateFlags = and(b.i.inv())
-
 
 typealias ScrollFlags = Int
 
-enum class ScrollFlag(@JvmField val i: ScrollFlags) {
-    None(0),
+enum class ScrollFlag(override val i: ScrollFlags) : Flag<ScrollFlag> {
+  None(0),
 
-    /** If item is not visible: scroll as little as possible on X axis to bring item back into view [default for X axis] */
-    KeepVisibleEdgeX(1 shl 0),
+  /** If item is not visible: scroll as little as possible on X axis to bring item back into view [default for X axis] */
+  KeepVisibleEdgeX(1 shl 0),
 
-    /** If item is not visible: scroll as little as possible on Y axis to bring item back into view [default for Y axis for windows that are already visible] */
-    KeepVisibleEdgeY(1 shl 1),
+  /** If item is not visible: scroll as little as possible on Y axis to bring item back into view [default for Y axis for windows that are already visible] */
+  KeepVisibleEdgeY(1 shl 1),
 
-    /** If item is not visible: scroll to make the item centered on X axis [rarely used] */
-    KeepVisibleCenterX(1 shl 2),
+  /** If item is not visible: scroll to make the item centered on X axis [rarely used] */
+  KeepVisibleCenterX(1 shl 2),
 
     /** If item is not visible: scroll to make the item centered on Y axis */
     KeepVisibleCenterY(1 shl 3),
@@ -64,69 +50,36 @@ enum class ScrollFlag(@JvmField val i: ScrollFlags) {
 
     /** Disable forwarding scrolling to parent window if required to keep item/rect visible (only scroll window the function was applied to). */
     NoScrollParent(1 shl 6),
-    MaskX_(KeepVisibleEdgeX or KeepVisibleCenterX or AlwaysCenterX),
-    MaskY_(KeepVisibleEdgeY or KeepVisibleCenterY or AlwaysCenterY);
-
-    infix fun and(b: ScrollFlag): ScrollFlags = i and b.i
-    infix fun and(b: ScrollFlags): ScrollFlags = i and b
-    infix fun or(b: ScrollFlag): ScrollFlags = i or b.i
-    infix fun or(b: ScrollFlags): ScrollFlags = i or b
-    infix fun xor(b: ScrollFlag): ScrollFlags = i xor b.i
-    infix fun xor(b: ScrollFlags): ScrollFlags = i xor b
-    infix fun wo(b: ScrollFlags): ScrollFlags = and(b.inv())
+  MaskX_(KeepVisibleEdgeX or KeepVisibleCenterX or AlwaysCenterX),
+  MaskY_(KeepVisibleEdgeY or KeepVisibleCenterY or AlwaysCenterY)
 }
-
-infix fun ScrollFlags.and(b: ScrollFlag): ScrollFlags = and(b.i)
-infix fun ScrollFlags.or(b: ScrollFlag): ScrollFlags = or(b.i)
-infix fun ScrollFlags.xor(b: ScrollFlag): ScrollFlags = xor(b.i)
-infix fun ScrollFlags.has(b: ScrollFlag): Boolean = and(b.i) != 0
-infix fun ScrollFlags.hasnt(b: ScrollFlag): Boolean = and(b.i) == 0
-infix fun ScrollFlags.wo(b: ScrollFlag): ScrollFlags = and(b.i.inv())
-operator fun ScrollFlags.minus(flag: ScrollFlag): ScrollFlags = wo(flag)
-operator fun ScrollFlags.div(flag: ScrollFlag): ScrollFlags = or(flag)
 
 
 typealias NavHighlightFlags = Int
 
-enum class NavHighlightFlag {
-    None, TypeDefault, TypeThin,
+enum class NavHighlightFlag : Flag<NavHighlightFlag> {
+  None, TypeDefault, TypeThin,
 
-    /** Draw rectangular highlight if (g.NavId == id) _even_ when using the mouse. */
-    AlwaysDraw,
-    NoRounding;
+  /** Draw rectangular highlight if (g.NavId == id) _even_ when using the mouse. */
+  AlwaysDraw,
+  NoRounding;
 
-    val i: NavHighlightFlags = if (ordinal == 0) 0 else 1 shl (ordinal - 1)
-
-    infix fun and(b: NavHighlightFlag): NavHighlightFlags = i and b.i
-    infix fun and(b: NavHighlightFlags): NavHighlightFlags = i and b
-    infix fun or(b: NavHighlightFlag): NavHighlightFlags = i or b.i
-    infix fun or(b: NavHighlightFlags): NavHighlightFlags = i or b
-    infix fun xor(b: NavHighlightFlag): NavHighlightFlags = i xor b.i
-    infix fun xor(b: NavHighlightFlags): NavHighlightFlags = i xor b
-    infix fun wo(b: NavHighlightFlags): NavHighlightFlags = and(b.inv())
+  override val i: NavHighlightFlags = if (ordinal == 0) 0 else 1 shl (ordinal - 1)
 }
-
-infix fun NavHighlightFlags.and(b: NavHighlightFlag): NavHighlightFlags = and(b.i)
-infix fun NavHighlightFlags.or(b: NavHighlightFlag): NavHighlightFlags = or(b.i)
-infix fun NavHighlightFlags.xor(b: NavHighlightFlag): NavHighlightFlags = xor(b.i)
-infix fun NavHighlightFlags.has(b: NavHighlightFlag): Boolean = and(b.i) != 0
-infix fun NavHighlightFlags.hasnt(b: NavHighlightFlag): Boolean = and(b.i) == 0
-infix fun NavHighlightFlags.wo(b: NavHighlightFlag): NavHighlightFlags = and(b.i.inv())
-
 
 typealias NavMoveFlags = Int
 
-enum class NavMoveFlag {
-    None,
+enum class NavMoveFlag : Flag<NavMoveFlag> {
+  None,
 
-    /** On failed request, restart from opposite side */
-    LoopX,
-    LoopY,
+  /** On failed request, restart from opposite side */
+  LoopX,
+  LoopY,
 
-    /** On failed request, request from opposite side one line down (when NavDir==right) or one line up (when NavDir==left) */
-    WrapX,
+  /** On failed request, request from opposite side one line down (when NavDir==right) or one line up (when NavDir==left) */
+  WrapX,
 
-    /** This is not super useful for provided but completeness */
+  /** This is not super useful for provided but completeness */
     WrapY,
 
     /** Allow scoring and considering the current NavId as a move target candidate.
@@ -150,26 +103,8 @@ enum class NavMoveFlag {
     /** Do not alter the visible state of keyboard vs mouse nav highlight */
     DontSetNavHighlight;
 
-    val i: NavMoveFlags = if (ordinal == 0) 0 else 1 shl (ordinal - 1)
-
-    infix fun and(b: NavMoveFlag): NavMoveFlags = i and b.i
-    infix fun and(b: NavMoveFlags): NavMoveFlags = i and b
-    infix fun or(b: NavMoveFlag): NavMoveFlags = i or b.i
-    infix fun or(b: NavMoveFlags): NavMoveFlags = i or b
-    infix fun xor(b: NavMoveFlag): NavMoveFlags = i xor b.i
-    infix fun xor(b: NavMoveFlags): NavMoveFlags = i xor b
-    infix fun wo(b: NavMoveFlags): NavMoveFlags = and(b.inv())
+  override val i: NavMoveFlags = if (ordinal == 0) 0 else 1 shl (ordinal - 1)
 }
-
-infix fun NavMoveFlags.and(b: NavMoveFlag): NavMoveFlags = and(b.i)
-infix fun NavMoveFlags.or(b: NavMoveFlag): NavMoveFlags = or(b.i)
-infix fun NavMoveFlags.xor(b: NavMoveFlag): NavMoveFlags = xor(b.i)
-infix fun NavMoveFlags.has(b: NavMoveFlag): Boolean = and(b.i) != 0
-infix fun NavMoveFlags.hasnt(b: NavMoveFlag): Boolean = and(b.i) == 0
-infix fun NavMoveFlags.wo(b: NavMoveFlag): NavMoveFlags = and(b.i.inv())
-operator fun NavMoveFlags.minus(flag: NavMoveFlag): NavMoveFlags = wo(flag)
-operator fun NavMoveFlags.div(flag: NavMoveFlag): NavMoveFlags = or(flag)
-
 
 enum class NavForward(val i: Int) {
     ScrollToEdge(1 shl 6),

--- a/core/src/main/kotlin/imgui/internal/sections/Widgets support flags, enums, data structures.kt
+++ b/core/src/main/kotlin/imgui/internal/sections/Widgets support flags, enums, data structures.kt
@@ -1,9 +1,11 @@
 package imgui.internal.sections
 
 import glm_.vec2.Vec2
+import imgui.Flag
 import imgui.ID
 import imgui.internal.classes.Rect
 import imgui.internal.classes.Window
+import imgui.or
 
 
 //-----------------------------------------------------------------------------
@@ -19,17 +21,17 @@ typealias ItemFlags = Int
 
 /** Transient per-window flags, reset at the beginning of the frame. For child window, inherited from parent on first Begin().
  *  This is going to be exposed in imgui.h when stabilized enough. */
-enum class ItemFlag(@JvmField val i: ItemFlags) {
+enum class ItemFlag(override val i: ItemFlags) : Flag<ItemFlag> {
 
 
-    // Controlled by user
+  // Controlled by user
 
-    None(0),
+  None(0),
 
-    /** Disable keyboard tabbing (FIXME: should merge with _NoNav) */
-    NoTabStop(1 shl 0),  // false
+  /** Disable keyboard tabbing (FIXME: should merge with _NoNav) */
+  NoTabStop(1 shl 0),  // false
 
-    /** Button() will return true multiple times based on io.KeyRepeatDelay and io.KeyRepeatRate settings. */
+  /** Button() will return true multiple times based on io.KeyRepeatDelay and io.KeyRepeatRate settings. */
     ButtonRepeat(1 shl 1),  // false
 
     /** Disable interactions but doesn't affect visuals. See BeginDisabled()/EndDisabled(). See github.com/ocornut/imgui/issues/211 */
@@ -58,24 +60,7 @@ enum class ItemFlag(@JvmField val i: ItemFlags) {
 
     /** [WIP] Auto-activate input mode when tab focused. Currently only used and supported by a few items before it becomes a generic feature. */
     Inputable(1 shl 10);   // false
-
-    infix fun and(b: ItemFlag): ItemFlags = i and b.i
-    infix fun and(b: ItemFlags): ItemFlags = i and b
-    infix fun or(b: ItemFlag): ItemFlags = i or b.i
-    infix fun or(b: ItemFlags): ItemFlags = i or b
-    infix fun xor(b: ItemFlag): ItemFlags = i xor b.i
-    infix fun xor(b: ItemFlags): ItemFlags = i xor b
-    infix fun wo(b: ItemFlags): ItemFlags = and(b.inv())
 }
-
-infix fun ItemFlags.and(b: ItemFlag): ItemFlags = and(b.i)
-infix fun ItemFlags.or(b: ItemFlag): ItemFlags = or(b.i)
-infix fun ItemFlags.xor(b: ItemFlag): ItemFlags = xor(b.i)
-infix fun ItemFlags.has(b: ItemFlag): Boolean = and(b.i) != 0
-infix fun ItemFlags.hasnt(b: ItemFlag): Boolean = and(b.i) == 0
-infix fun ItemFlags.wo(b: ItemFlag): ItemFlags = and(b.i.inv())
-operator fun ItemFlags.minus(flag: ItemFlag): ItemFlags = wo(flag)
-operator fun ItemFlags.div(flag: ItemFlag): ItemFlags = or(flag)
 
 
 /** Flags: for g.LastItemData.StatusFlags */
@@ -83,17 +68,17 @@ typealias ItemStatusFlags = Int
 
 /** Status flags for an already submitted item
  *  - output: stored in g.LastItemData.StatusFlags   */
-enum class ItemStatusFlag(@JvmField val i: ItemStatusFlags) {
-    None(0),
+enum class ItemStatusFlag(override val i: ItemStatusFlags) : Flag<ItemStatusFlag> {
+  None(0),
 
-    /** Mouse position is within item rectangle (does NOT mean that the window is in correct z-order and can be hovered!, this is only one part of the most-common IsItemHovered test) */
-    HoveredRect(1 shl 0),
+  /** Mouse position is within item rectangle (does NOT mean that the window is in correct z-order and can be hovered!, this is only one part of the most-common IsItemHovered test) */
+  HoveredRect(1 shl 0),
 
-    /** g.LastItemData.DisplayRect is valid */
-    HasDisplayRect(1 shl 1),
+  /** g.LastItemData.DisplayRect is valid */
+  HasDisplayRect(1 shl 1),
 
-    /** Value exposed by item was edited in the current frame (should match the bool return value of most widgets) */
-    Edited(1 shl 2),
+  /** Value exposed by item was edited in the current frame (should match the bool return value of most widgets) */
+  Edited(1 shl 2),
 
     /** Set when Selectable(), TreeNode() reports toggling a selection. We can't report "Selected", only state changes, in order to easily handle clipping with less issues. */
     ToggledSelection(1 shl 3),
@@ -123,42 +108,24 @@ enum class ItemStatusFlag(@JvmField val i: ItemStatusFlags) {
     Openable(1 shl 20),
     Opened(1 shl 21),
 
-    /** Item is a checkable (e.g. CheckBox, MenuItem) */
-    Checkable(1 shl 22),
-    Checked(1 shl 23);
-
-    infix fun and(b: ItemStatusFlag): ItemStatusFlags = i and b.i
-    infix fun and(b: ItemStatusFlags): ItemStatusFlags = i and b
-    infix fun or(b: ItemStatusFlag): ItemStatusFlags = i or b.i
-    infix fun or(b: ItemStatusFlags): ItemStatusFlags = i or b
-    infix fun xor(b: ItemStatusFlag): ItemStatusFlags = i xor b.i
-    infix fun xor(b: ItemStatusFlags): ItemStatusFlags = i xor b
-    infix fun wo(b: ItemStatusFlags): ItemStatusFlags = and(b.inv())
+  /** Item is a checkable (e.g. CheckBox, MenuItem) */
+  Checkable(1 shl 22),
+  Checked(1 shl 23)
 }
-
-infix fun ItemStatusFlags.and(b: ItemStatusFlag): ItemStatusFlags = and(b.i)
-infix fun ItemStatusFlags.or(b: ItemStatusFlag): ItemStatusFlags = or(b.i)
-infix fun ItemStatusFlags.xor(b: ItemStatusFlag): ItemStatusFlags = xor(b.i)
-infix fun ItemStatusFlags.has(b: ItemStatusFlag): Boolean = and(b.i) != 0
-infix fun ItemStatusFlags.hasnt(b: ItemStatusFlag): Boolean = and(b.i) == 0
-infix fun ItemStatusFlags.wo(b: ItemStatusFlag): ItemStatusFlags = and(b.i.inv())
-operator fun ItemStatusFlags.minus(flag: ItemStatusFlag): ItemStatusFlags = wo(flag)
-operator fun ItemStatusFlags.div(flag: ItemStatusFlag): ItemStatusFlags = or(flag)
-
 
 typealias ButtonFlags = Int
 
-enum class ButtonFlag(val i: ButtonFlags) {
+enum class ButtonFlag(override val i: ButtonFlags) : Flag<ButtonFlag> {
 
-    None(0),
+  None(0),
 
-    /** React on left mouse button (default) */
-    MouseButtonLeft(1 shl 0),
+  /** React on left mouse button (default) */
+  MouseButtonLeft(1 shl 0),
 
-    /** React on right mouse button */
-    MouseButtonRight(1 shl 1),
+  /** React on right mouse button */
+  MouseButtonRight(1 shl 1),
 
-    /** React on center mouse button */
+  /** React on center mouse button */
     MouseButtonMiddle(1 shl 2),
 
     /** return true on click (mouse down event) */
@@ -218,107 +185,39 @@ enum class ButtonFlag(val i: ButtonFlags) {
     MouseButtonMask_(MouseButtonLeft or MouseButtonRight or MouseButtonMiddle),
     MouseButtonShift_(16),
     MouseButtonDefault_(MouseButtonLeft.i),
-    PressedOnMask_(PressedOnClick or PressedOnClickRelease or PressedOnClickReleaseAnywhere or PressedOnRelease or PressedOnDoubleClick or PressedOnDragDropHold),
-    PressedOnDefault_(PressedOnClickRelease.i);
-
-    infix fun and(b: ButtonFlag): ButtonFlags = i and b.i
-    infix fun and(b: ButtonFlags): ButtonFlags = i and b
-    infix fun or(b: ButtonFlag): ButtonFlags = i or b.i
-    infix fun or(b: ButtonFlags): ButtonFlags = i or b
-    infix fun xor(b: ButtonFlag): ButtonFlags = i xor b.i
-    infix fun xor(b: ButtonFlags): ButtonFlags = i xor b
-    infix fun wo(b: ButtonFlags): ButtonFlags = and(b.inv())
+  PressedOnMask_(PressedOnClick or PressedOnClickRelease or PressedOnClickReleaseAnywhere or PressedOnRelease or PressedOnDoubleClick or PressedOnDragDropHold),
+  PressedOnDefault_(PressedOnClickRelease.i)
 }
-
-infix fun ButtonFlags.and(b: ButtonFlag): ButtonFlags = and(b.i)
-infix fun ButtonFlags.or(b: ButtonFlag): ButtonFlags = or(b.i)
-infix fun ButtonFlags.xor(b: ButtonFlag): ButtonFlags = xor(b.i)
-infix fun ButtonFlags.has(b: ButtonFlag): Boolean = and(b.i) != 0
-infix fun ButtonFlags.hasnt(b: ButtonFlag): Boolean = and(b.i) == 0
-infix fun ButtonFlags.wo(b: ButtonFlag): ButtonFlags = and(b.i.inv())
-operator fun ButtonFlags.minus(flag: ButtonFlag): ButtonFlags = wo(flag)
-operator fun ButtonFlags.div(flag: ButtonFlag): ButtonFlags = or(flag)
-
 
 typealias SeparatorFlags = Int
 
-enum class SeparatorFlag {
-    None,
+enum class SeparatorFlag : Flag<SeparatorFlag> {
+  None,
 
-    /** Axis default to current layout type, so generally Horizontal unless e.g. in a menu bar  */
-    Horizontal,
-    Vertical,
-    SpanAllColumns;
+  /** Axis default to current layout type, so generally Horizontal unless e.g. in a menu bar  */
+  Horizontal,
+  Vertical,
+  SpanAllColumns;
 
-    val i: SeparatorFlags = if (ordinal == 0) 0 else 1 shl (ordinal - 1)
-
-    infix fun and(b: SeparatorFlag): SeparatorFlags = i and b.i
-    infix fun and(b: SeparatorFlags): SeparatorFlags = i and b
-    infix fun or(b: SeparatorFlag): SeparatorFlags = i or b.i
-    infix fun or(b: SeparatorFlags): SeparatorFlags = i or b
-    infix fun xor(b: SeparatorFlag): SeparatorFlags = i xor b.i
-    infix fun xor(b: SeparatorFlags): SeparatorFlags = i xor b
-    infix fun wo(b: SeparatorFlags): SeparatorFlags = and(b.inv())
+  override val i: SeparatorFlags = if (ordinal == 0) 0 else 1 shl (ordinal - 1)
 }
-
-infix fun SeparatorFlags.and(b: SeparatorFlag): SeparatorFlags = and(b.i)
-infix fun SeparatorFlags.or(b: SeparatorFlag): SeparatorFlags = or(b.i)
-infix fun SeparatorFlags.xor(b: SeparatorFlag): SeparatorFlags = xor(b.i)
-infix fun SeparatorFlags.has(b: SeparatorFlag): Boolean = and(b.i) != 0
-infix fun SeparatorFlags.hasnt(b: SeparatorFlag): Boolean = and(b.i) == 0
-infix fun SeparatorFlags.wo(b: SeparatorFlag): SeparatorFlags = and(b.i.inv())
-operator fun SeparatorFlags.minus(flag: SeparatorFlag): SeparatorFlags = wo(flag)
-operator fun SeparatorFlags.div(flag: SeparatorFlag): SeparatorFlags = or(flag)
-
 
 typealias TextFlags = Int
 
-enum class TextFlag {
-    None, NoWidthForLargeClippedText;
+enum class TextFlag : Flag<TextFlag> {
+  None, NoWidthForLargeClippedText;
 
-    val i: TextFlags = ordinal
-
-    infix fun and(b: TextFlag): TextFlags = i and b.i
-    infix fun and(b: TextFlags): TextFlags = i and b
-    infix fun or(b: TextFlag): TextFlags = i or b.i
-    infix fun or(b: TextFlags): TextFlags = i or b
-    infix fun xor(b: TextFlag): TextFlags = i xor b.i
-    infix fun xor(b: TextFlags): TextFlags = i xor b
-    infix fun wo(b: TextFlags): TextFlags = and(b.inv())
+  override val i: TextFlags = ordinal
 }
-
-infix fun TextFlags.and(b: TextFlag): TextFlags = and(b.i)
-infix fun TextFlags.or(b: TextFlag): TextFlags = or(b.i)
-infix fun TextFlags.xor(b: TextFlag): TextFlags = xor(b.i)
-infix fun TextFlags.has(b: TextFlag): Boolean = and(b.i) != 0
-infix fun TextFlags.hasnt(b: TextFlag): Boolean = and(b.i) == 0
-infix fun TextFlags.wo(b: TextFlag): TextFlags = and(b.i.inv())
-
 
 typealias TooltipFlags = Int
 
-enum class TooltipFlag(val i: TooltipFlags) {
-    None(0),
+enum class TooltipFlag(override val i: TooltipFlags) : Flag<TooltipFlag> {
+  None(0),
 
-    /** Override will clear/ignore previously submitted tooltip (defaults to append) */
-    OverridePreviousTooltip(1 shl 0);
-
-    infix fun and(b: TooltipFlag): TooltipFlags = i and b.i
-    infix fun and(b: TooltipFlags): TooltipFlags = i and b
-    infix fun or(b: TooltipFlag): TooltipFlags = i or b.i
-    infix fun or(b: TooltipFlags): TooltipFlags = i or b
-    infix fun xor(b: TooltipFlag): TooltipFlags = i xor b.i
-    infix fun xor(b: TooltipFlags): TooltipFlags = i xor b
-    infix fun wo(b: TooltipFlags): TooltipFlags = and(b.inv())
+  /** Override will clear/ignore previously submitted tooltip (defaults to append) */
+  OverridePreviousTooltip(1 shl 0)
 }
-
-infix fun TooltipFlags.and(b: TooltipFlag): TooltipFlags = and(b.i)
-infix fun TooltipFlags.or(b: TooltipFlag): TooltipFlags = or(b.i)
-infix fun TooltipFlags.xor(b: TooltipFlag): TooltipFlags = xor(b.i)
-infix fun TooltipFlags.has(b: TooltipFlag): Boolean = and(b.i) != 0
-infix fun TooltipFlags.hasnt(b: TooltipFlag): Boolean = and(b.i) == 0
-infix fun TooltipFlags.wo(b: TooltipFlag): TooltipFlags = and(b.i.inv())
-
 
 /** FIXME: this is in development, not exposed/functional as a generic feature yet.
  *  Horizontal/Vertical enums are fixed to 0/1 so they may be used to index ImVec2 */
@@ -367,18 +266,18 @@ typealias DrawFlags = Int
 
 /** Flags for ImDrawList functions
  *  (Legacy: bit 0 must always correspond to ImDrawFlags_Closed to be backward compatible with old API using a bool. Bits 1..3 must be unused) */
-enum class DrawFlag(val i: DrawFlags) {
-    None(0),
+enum class DrawFlag(override val i: DrawFlags) : Flag<DrawFlag> {
+  None(0),
 
-    /** PathStroke(), AddPolyline(): specify that shape should be closed (Important: this is always == 1 for legacy reason) */
-    Closed(1 shl 0),
+  /** PathStroke(), AddPolyline(): specify that shape should be closed (Important: this is always == 1 for legacy reason) */
+  Closed(1 shl 0),
 
-    // (bits 1..3 unused to facilitate handling of legacy behavior and detection of Flags = 0x0F)
+  // (bits 1..3 unused to facilitate handling of legacy behavior and detection of Flags = 0x0F)
 
-    /** AddRect(), AddRectFilled(), PathRect(): enable rounding top-left corner only (when rounding > 0.0f, we default to all corners). Was 0x01. */
-    RoundCornersTopLeft(1 shl 4),
+  /** AddRect(), AddRectFilled(), PathRect(): enable rounding top-left corner only (when rounding > 0.0f, we default to all corners). Was 0x01. */
+  RoundCornersTopLeft(1 shl 4),
 
-    /** AddRect(), AddRectFilled(), PathRect(): enable rounding top-right corner only (when rounding > 0.0f, we default to all corners). Was 0x02. */
+  /** AddRect(), AddRectFilled(), PathRect(): enable rounding top-right corner only (when rounding > 0.0f, we default to all corners). Was 0x02. */
     RoundCornersTopRight(1 shl 5),
 
     /** AddRect(), AddRectFilled(), PathRect(): enable rounding bottom-left corner only (when rounding > 0.0f, we default to all corners). Was 0x04. */
@@ -395,115 +294,47 @@ enum class DrawFlag(val i: DrawFlags) {
     RoundCornersRight(RoundCornersBottomRight or RoundCornersTopRight),
     RoundCornersAll(RoundCornersTopLeft or RoundCornersTopRight or RoundCornersBottomLeft or RoundCornersBottomRight),
 
-    /** Default to ALL corners if none of the _RoundCornersXX flags are specified. */
-    RoundCornersDefault_(RoundCornersAll.i),
-    RoundCornersMask_(RoundCornersAll or RoundCornersNone);
-
-    infix fun and(b: DrawFlag): DrawFlags = i and b.i
-    infix fun and(b: DrawFlags): DrawFlags = i and b
-    infix fun or(b: DrawFlag): DrawFlags = i or b.i
-    infix fun or(b: DrawFlags): DrawFlags = i or b
-    infix fun xor(b: DrawFlag): DrawFlags = i xor b.i
-    infix fun xor(b: DrawFlags): DrawFlags = i xor b
-    infix fun wo(b: DrawFlags): DrawFlags = and(b.inv())
+  /** Default to ALL corners if none of the _RoundCornersXX flags are specified. */
+  RoundCornersDefault_(RoundCornersAll.i),
+  RoundCornersMask_(RoundCornersAll or RoundCornersNone)
 }
-
-infix fun DrawFlags.and(b: DrawFlag): DrawFlags = and(b.i)
-infix fun DrawFlags.or(b: DrawFlag): DrawFlags = or(b.i)
-infix fun DrawFlags.xor(b: DrawFlag): DrawFlags = xor(b.i)
-infix fun DrawFlags.has(b: DrawFlag): Boolean = and(b.i) != 0
-infix fun DrawFlags.hasnt(b: DrawFlag): Boolean = and(b.i) == 0
-infix fun DrawFlags.wo(b: DrawFlag): DrawFlags = and(b.i.inv())
-
 
 typealias DrawListFlags = Int
 
 /** Flags: for ImDrawList instance. Those are set automatically by ImGui:: functions from ImGuiIO settings, and generally not
  *  manipulated directly. It is however possible to temporarily alter flags between calls to ImDrawList:: functions. */
-enum class DrawListFlag(val i: DrawListFlags) {
-    None(0),
+enum class DrawListFlag(override val i: DrawListFlags) : Flag<DrawListFlag> {
+  None(0),
 
-    /** Enable anti-aliased lines/borders (*2 the number of triangles for 1.0f wide line or lines thin enough to be
-     *  drawn using textures, otherwise *3 the number of triangles) */
-    AntiAliasedLines(1 shl 0),
+  /** Enable anti-aliased lines/borders (*2 the number of triangles for 1.0f wide line or lines thin enough to be
+   *  drawn using textures, otherwise *3 the number of triangles) */
+  AntiAliasedLines(1 shl 0),
 
-    /** Enable anti-aliased lines/borders using textures when possible. Require backend to render with bilinear filtering (NOT point/nearest filtering). */
-    AntiAliasedLinesUseTex(1 shl 1),
+  /** Enable anti-aliased lines/borders using textures when possible. Require backend to render with bilinear filtering (NOT point/nearest filtering). */
+  AntiAliasedLinesUseTex(1 shl 1),
 
-    /** Enable anti-aliased edge around filled shapes (rounded rectangles, circles). */
+  /** Enable anti-aliased edge around filled shapes (rounded rectangles, circles). */
     AntiAliasedFill(1 shl 2),
 
-    /** Can emit 'VtxOffset > 0' to allow large meshes. Set when 'ImGuiBackendFlags_RendererHasVtxOffset' is enabled. */
-    AllowVtxOffset(1 shl 3);
-
-    infix fun and(b: DrawListFlag): DrawListFlags = i and b.i
-    infix fun and(b: DrawListFlags): DrawListFlags = i and b
-    infix fun or(b: DrawListFlag): DrawListFlags = i or b.i
-    infix fun or(b: DrawListFlags): DrawListFlags = i or b
-    infix fun xor(b: DrawListFlag): DrawListFlags = i xor b.i
-    infix fun xor(b: DrawListFlags): DrawListFlags = i xor b
-    infix fun wo(b: DrawListFlags): DrawListFlags = and(b.inv())
+  /** Can emit 'VtxOffset > 0' to allow large meshes. Set when 'ImGuiBackendFlags_RendererHasVtxOffset' is enabled. */
+  AllowVtxOffset(1 shl 3)
 }
-
-infix fun DrawListFlags.and(b: DrawListFlag): DrawListFlags = and(b.i)
-infix fun DrawListFlags.or(b: DrawListFlag): DrawListFlags = or(b.i)
-infix fun DrawListFlags.xor(b: DrawListFlag): DrawListFlags = xor(b.i)
-infix fun DrawListFlags.has(b: DrawListFlag): Boolean = and(b.i) != 0
-infix fun DrawListFlags.hasnt(b: DrawListFlag): Boolean = and(b.i) == 0
-infix fun DrawListFlags.wo(b: DrawListFlag): DrawListFlags = and(b.i.inv())
-
 
 typealias NextWindowDataFlags = Int
 
-enum class NextWindowDataFlag {
-    None, HasPos, HasSize, HasContentSize, HasCollapsed, HasSizeConstraint, HasFocus, HasBgAlpha, HasScroll;
+enum class NextWindowDataFlag : Flag<NextWindowDataFlag> {
+  None, HasPos, HasSize, HasContentSize, HasCollapsed, HasSizeConstraint, HasFocus, HasBgAlpha, HasScroll;
 
-    val i: NextWindowDataFlags = if (ordinal == 0) 0 else 1 shl (ordinal - 1)
-
-    infix fun and(b: NextWindowDataFlag): NextWindowDataFlags = i and b.i
-    infix fun and(b: NextWindowDataFlags): NextWindowDataFlags = i and b
-    infix fun or(b: NextWindowDataFlag): NextWindowDataFlags = i or b.i
-    infix fun or(b: NextWindowDataFlags): NextWindowDataFlags = i or b
-    infix fun xor(b: NextWindowDataFlag): NextWindowDataFlags = i xor b.i
-    infix fun xor(b: NextWindowDataFlags): NextWindowDataFlags = i xor b
-    infix fun wo(b: NextWindowDataFlags): NextWindowDataFlags = and(b.inv())
+  override val i: NextWindowDataFlags = if (ordinal == 0) 0 else 1 shl (ordinal - 1)
 }
-
-infix fun NextWindowDataFlags.and(b: NextWindowDataFlag): NextWindowDataFlags = and(b.i)
-infix fun NextWindowDataFlags.or(b: NextWindowDataFlag): NextWindowDataFlags = or(b.i)
-infix fun NextWindowDataFlags.xor(b: NextWindowDataFlag): NextWindowDataFlags = xor(b.i)
-infix fun NextWindowDataFlags.has(b: NextWindowDataFlag): Boolean = and(b.i) != 0
-infix fun NextWindowDataFlags.hasnt(b: NextWindowDataFlag): Boolean = and(b.i) == 0
-infix fun NextWindowDataFlags.wo(b: NextWindowDataFlag): NextWindowDataFlags = and(b.i.inv())
-operator fun NextWindowDataFlags.minus(flag: NextWindowDataFlag): NextWindowDataFlags = wo(flag)
-operator fun NextWindowDataFlags.div(flag: NextWindowDataFlag): NextWindowDataFlags = or(flag)
-
 
 typealias NextItemDataFlags = Int
 
-enum class NextItemDataFlag(val i: NextItemDataFlags) {
-    None(0),
-    HasWidth(1 shl 0),
-    HasOpen(1 shl 1);
-
-    infix fun and(b: NextItemDataFlag): NextItemDataFlags = i and b.i
-    infix fun and(b: NextItemDataFlags): NextItemDataFlags = i and b
-    infix fun or(b: NextItemDataFlag): NextItemDataFlags = i or b.i
-    infix fun or(b: NextItemDataFlags): NextItemDataFlags = i or b
-    infix fun xor(b: NextItemDataFlag): NextItemDataFlags = i xor b.i
-    infix fun xor(b: NextItemDataFlags): NextItemDataFlags = i xor b
-    infix fun wo(b: NextItemDataFlags): NextItemDataFlags = and(b.inv())
+enum class NextItemDataFlag(override val i: NextItemDataFlags) : Flag<NextItemDataFlag> {
+  None(0),
+  HasWidth(1 shl 0),
+  HasOpen(1 shl 1)
 }
-
-infix fun NextItemDataFlags.and(b: NextItemDataFlag): NextItemDataFlags = and(b.i)
-infix fun NextItemDataFlags.or(b: NextItemDataFlag): NextItemDataFlags = or(b.i)
-infix fun NextItemDataFlags.xor(b: NextItemDataFlag): NextItemDataFlags = xor(b.i)
-infix fun NextItemDataFlags.has(b: NextItemDataFlag): Boolean = and(b.i) != 0
-infix fun NextItemDataFlags.hasnt(b: NextItemDataFlag): Boolean = and(b.i) == 0
-infix fun NextItemDataFlags.wo(b: NextItemDataFlag): NextItemDataFlags = and(b.i.inv())
-operator fun NextItemDataFlags.minus(flag: NextItemDataFlag): NextItemDataFlags = wo(flag)
-operator fun NextItemDataFlags.div(flag: NextItemDataFlag): NextItemDataFlags = or(flag)
-
 
 /** Result of a gamepad/keyboard directional navigation move query result */
 class NavItemData {

--- a/core/src/main/kotlin/imgui/static/forwardDeclarations.kt
+++ b/core/src/main/kotlin/imgui/static/forwardDeclarations.kt
@@ -1,7 +1,6 @@
 package imgui.static
 
 import gli_.has
-import glm_.L
 import glm_.i
 import glm_.max
 import glm_.min
@@ -22,16 +21,10 @@ import imgui.internal.floor
 import imgui.internal.sections.DrawListFlag
 import imgui.internal.sections.SettingsHandler
 import imgui.internal.sections.WindowSettings
-import imgui.hasnt
-import imgui.internal.sections.hasnt
-import imgui.windowsIme.*
 import kool.rem
-import org.lwjgl.system.MemoryUtil
-import uno.glfw.HWND
 import java.awt.Toolkit
 import java.awt.datatransfer.DataFlavor
 import java.awt.datatransfer.StringSelection
-import java.util.ArrayList
 import imgui.WindowFlag as Wf
 
 

--- a/core/src/main/kotlin/imgui/viewport.kt
+++ b/core/src/main/kotlin/imgui/viewport.kt
@@ -11,34 +11,18 @@ import imgui.internal.sections.ViewportP
 typealias ViewportFlags = Int
 
 /** Flags stored in ImGuiViewport::Flags, giving indications to the platform backends. */
-enum class ViewportFlag(val i: ViewportFlags) {
-    None(0),
+enum class ViewportFlag(override val i: ViewportFlags) : Flag<ViewportFlag> {
+  None(0),
 
-    /** Represent a Platform Window */
-    IsPlatformWindow(1 shl 0),
+  /** Represent a Platform Window */
+  IsPlatformWindow(1 shl 0),
 
-    /** Represent a Platform Monitor (unused yet) */
-    IsPlatformMonitor(1 shl 1),
+  /** Represent a Platform Monitor (unused yet) */
+  IsPlatformMonitor(1 shl 1),
 
-    /** Platform Window: is created/managed by the application (rather than a dear imgui backend) */
-    OwnedByApp(1 shl 2);
-
-    infix fun and(b: ViewportFlag): ViewportFlags = i and b.i
-    infix fun and(b: ViewportFlags): ViewportFlags = i and b
-    infix fun or(b: ViewportFlag): ViewportFlags = i or b.i
-    infix fun or(b: ViewportFlags): ViewportFlags = i or b
-    infix fun xor(b: ViewportFlag): ViewportFlags = i xor b.i
-    infix fun xor(b: ViewportFlags): ViewportFlags = i xor b
-    infix fun wo(b: ViewportFlag): ViewportFlags = and(b.i.inv())
-    infix fun wo(b: ViewportFlags): ViewportFlags = and(b.inv())
+  /** Platform Window: is created/managed by the application (rather than a dear imgui backend) */
+  OwnedByApp(1 shl 2)
 }
-
-infix fun ViewportFlags.and(b: ViewportFlag): ViewportFlags = and(b.i)
-infix fun ViewportFlags.or(b: ViewportFlag): ViewportFlags = or(b.i)
-infix fun ViewportFlags.xor(b: ViewportFlag): ViewportFlags = xor(b.i)
-infix fun ViewportFlags.has(b: ViewportFlag): Boolean = and(b.i) != 0
-infix fun ViewportFlags.hasnt(b: ViewportFlag): Boolean = and(b.i) == 0
-infix fun ViewportFlags.wo(b: ViewportFlag): ViewportFlags = and(b.i.inv())
 
 // - Currently represents the Platform Window created by the application which is hosting our Dear ImGui windows.
 // - In 'docking' branch with multi-viewport enabled, we extend this concept to have multiple active viewports.

--- a/gl/src/main/kotlin/imgui/impl/gl/ImplGL3.kt
+++ b/gl/src/main/kotlin/imgui/impl/gl/ImplGL3.kt
@@ -18,7 +18,6 @@ import gln.vertexArray.glVertexAttribPointer
 import imgui.BackendFlag
 import imgui.DEBUG
 import imgui.ImGui.io
-import imgui.impl.glfw.ImplGlfw
 import imgui.internal.DrawData
 import imgui.internal.DrawIdx
 import imgui.internal.DrawVert
@@ -84,9 +83,6 @@ class ImplGL3 : GLInterface {
     }
 
     override fun newFrame() {
-
-        assert(ImplGlfw.Companion.data != null) { "Did you call ImGui_ImplGlfw_InitForXXX()?" }
-
         if (data.shaderHandle.isInvalid)
             createDeviceObjects()
     }


### PR DESCRIPTION
Introduce `interface Flag` which defines byte-manipulation functions (like `and`, `or`, `wo`, etc) which work on its `i` property. This results in removing a lot of duplicate code that was redefining those functions for every Flag-like enum