### PR TITLE
Introduce type-safe Flags and FlagArray to no longer use raw ints

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.7.10" />
+    <option name="version" value="1.8.20" />
   </component>
 </project>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,11 +1,10 @@
-import magik.github
-
 plugins {
-    kotlin("jvm") version embeddedKotlinVersion
+    kotlin("jvm") version "1.8.20"
     id("org.lwjgl.plugin") version "0.0.30"
     id("elect86.magik") version "0.3.1"
     `maven-publish`
     id("com.github.johnrengelman.shadow") version "7.1.2"
+    id("com.google.devtools.ksp") version "1.8.20-1.0.10" apply false
 }
 
 //projects.core.dependencyProject.apply {

--- a/core/core.gradle.kts
+++ b/core/core.gradle.kts
@@ -1,10 +1,11 @@
+
 import magik.createGithubPublication
 import magik.github
-import org.lwjgl.lwjgl
-import org.lwjgl.Lwjgl.Module.jemalloc
-import org.lwjgl.Lwjgl.Module.stb
 import org.gradle.nativeplatform.platform.internal.Architectures
 import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
+import org.lwjgl.Lwjgl.Module.jemalloc
+import org.lwjgl.Lwjgl.Module.stb
+import org.lwjgl.lwjgl
 
 plugins {
     id("org.lwjgl.plugin")
@@ -12,6 +13,7 @@ plugins {
     `maven-publish`
     kotlin("jvm")
     id("com.github.johnrengelman.shadow")
+    id("com.google.devtools.ksp")
 }
 
 group = rootProject.group
@@ -30,6 +32,10 @@ dependencies {
     implementation("kotlin.graphics:kool:0.9.68")
     //    implementation(unsigned, kool, glm, gli/*, uno.core*/)
     lwjgl { implementation(jemalloc, stb) }
+
+    // Temporarily use a commit-hash for the version until the "is checks for equality" change is released
+    implementation("com.github.livefront.sealed-enum:runtime:f690fca874")
+    ksp("com.github.livefront.sealed-enum:ksp:f690fca874")
 
     val brotliVersion = "1.11.0"
     val operatingSystem: OperatingSystem = DefaultNativePlatform.getCurrentOperatingSystem()
@@ -72,7 +78,7 @@ kotlin.jvmToolchain {
 tasks {
     withType<org.jetbrains.kotlin.gradle.dsl.KotlinCompile<*>>().all {
         kotlinOptions {
-            freeCompilerArgs += listOf("-opt-in=kotlin.RequiresOptIn")
+            freeCompilerArgs += listOf("-opt-in=kotlin.RequiresOptIn", "-Xallow-kotlin-package")
         }
     }
     withType<Test>().configureEach { useJUnitPlatform() }

--- a/core/src/main/java/imgui/Jdsl.java
+++ b/core/src/main/java/imgui/Jdsl.java
@@ -536,7 +536,7 @@ public class Jdsl {
         tabItem(label, pOpen, Flag.empty(), block);
     }
 
-    public static void tabItem(String label, MutableProperty0<Boolean> pOpen, Flag<TabItemFlag> tabItemFlags, Runnable block) {
+    public static void tabItem(String label, MutableProperty0<Boolean> pOpen, Flag<TabItemFlag.ItemOnly> tabItemFlags, Runnable block) {
         if (imgui.beginTabItem(label, pOpen, tabItemFlags))
             block.run();
         imgui.endTabItem();

--- a/core/src/main/java/imgui/Jdsl.java
+++ b/core/src/main/java/imgui/Jdsl.java
@@ -265,6 +265,11 @@ public class Jdsl {
             block.run();
     }
 
+    public static <F extends Flag<F>> void checkboxFlags(String label, int[] flags, Flag<F> flagsValue, Runnable block) {
+        if (imgui.checkboxFlags(label, flags, flagsValue))
+            block.run();
+    }
+
     public static void radioButton(String label, boolean active, Runnable block) {
         if (imgui.radioButton(label, active))
             block.run();

--- a/core/src/main/java/imgui/Jdsl.java
+++ b/core/src/main/java/imgui/Jdsl.java
@@ -3,6 +3,8 @@ package imgui;
 import glm_.vec2.Vec2;
 import glm_.vec4.Vec4;
 import imgui.font.Font;
+import imgui.internal.sections.ButtonFlag;
+import imgui.internal.sections.OldColumnsFlag;
 
 /**
  * twin brother of dsl, manual overloads
@@ -15,17 +17,18 @@ public class Jdsl {
     // Tables
 
     public static void table(String strId, int columnsCount, Runnable block) {
-        tables(strId, columnsCount, 0, new Vec2(), 0f, block);
+        tables(strId, columnsCount, Flag.empty(), new Vec2(), 0f, block);
     }
 
-    public static void tables(String strId, int columnsCount, int flags, Runnable block) {
+    public static void tables(String strId, int columnsCount, Flag<TableFlag> flags, Runnable block) {
         tables(strId, columnsCount, flags, new Vec2(), 0f, block);
     }
 
-    public static void tables(String strId, int columnsCount, int flags, Vec2 outerSize, Runnable block) {
+    public static void tables(String strId, int columnsCount, Flag<TableFlag> flags, Vec2 outerSize, Runnable block) {
         tables(strId, columnsCount, flags, outerSize, 0f, block);
     }
-    public static void tables(String strId, int columnsCount, int flags, Vec2 outerSize,
+
+    public static void tables(String strId, int columnsCount, Flag<TableFlag> flags, Vec2 outerSize,
                               float innerWidth, Runnable block) {
         if (imgui.beginTable(strId, columnsCount, flags, outerSize, innerWidth)) { // ~open
             block.run();
@@ -36,14 +39,14 @@ public class Jdsl {
     // Windows
 
     public static void window(String name, Runnable block) {
-        window(name, null, 0, block);
+        window(name, null, Flag.empty(), block);
     }
 
     public static void window(String name, MutableProperty0<Boolean> open, Runnable block) {
-        window(name, open, 0, block);
+        window(name, open, Flag.empty(), block);
     }
 
-    public static void window(String name, MutableProperty0<Boolean> open, int windowFlags, Runnable block) {
+    public static void window(String name, MutableProperty0<Boolean> open, Flag<WindowFlag> windowFlags, Runnable block) {
         if (imgui.begin(name, open, windowFlags)) // ~open
             block.run();
         imgui.end();
@@ -52,18 +55,18 @@ public class Jdsl {
     // Child Windows
 
     public static void child(String strId, Runnable block) {
-        child(strId, new Vec2(), false, 0, block);
+        child(strId, new Vec2(), false, Flag.empty(), block);
     }
 
     public static void child(String strId, Vec2 size, Runnable block) {
-        child(strId, size, false, 0, block);
+        child(strId, size, false, Flag.empty(), block);
     }
 
     public static void child(String strId, Vec2 size, boolean border, Runnable block) {
-        child(strId, size, border, 0, block);
+        child(strId, size, border, Flag.empty(), block);
     }
 
-    public static void child(String strId, Vec2 size, boolean border, int windowFlags, Runnable block) {
+    public static void child(String strId, Vec2 size, boolean border, Flag<WindowFlag> windowFlags, Runnable block) {
         if (imgui.beginChild(strId, size, border, windowFlags)) // ~open
             block.run();
         imgui.endChild();
@@ -229,7 +232,7 @@ public class Jdsl {
             block.run();
     }
 
-    public static void invisibleButton(String strId, Vec2 sizeArg, int flags, Runnable block) {
+    public static void invisibleButton(String strId, Vec2 sizeArg, Flag<ButtonFlag> flags, Runnable block) {
         if (imgui.invisibleButton(strId, sizeArg, flags))
             block.run();
     }
@@ -257,7 +260,7 @@ public class Jdsl {
             block.run();
     }
 
-    public static void checkboxFlags(String label, MutableProperty0<Integer> vPtr, int flagsValue, Runnable block) {
+    public static <F extends Flag<F>> void checkboxFlags(String label, MutableProperty0<Flag<F>> vPtr, Flag<F> flagsValue, Runnable block) {
         if (imgui.checkboxFlags(label, vPtr, flagsValue))
             block.run();
     }
@@ -277,10 +280,10 @@ public class Jdsl {
 
 
     public static void useCombo(String label, String previewValue, Runnable block) {
-        useCombo(label, previewValue, 0, block);
+        useCombo(label, previewValue, Flag.empty(), block);
     }
 
-    public static void useCombo(String label, String previewValue, int comboFlags, Runnable block) {
+    public static void useCombo(String label, String previewValue, Flag<ComboFlag> comboFlags, Runnable block) {
         if (imgui.beginCombo(label, previewValue, comboFlags)) {
             block.run();
             imgui.endCombo();
@@ -354,19 +357,19 @@ public class Jdsl {
 //    }
 
     public static void collapsingHeader(String label, Runnable block) {
-        collapsingHeader(label, 0, block);
+        collapsingHeader(label, Flag.empty(), block);
     }
 
-    public static void collapsingHeader(String label, int treeNodeFlags, Runnable block) {
+    public static void collapsingHeader(String label, Flag<TreeNodeFlag> treeNodeFlags, Runnable block) {
         if (imgui.collapsingHeader(label, treeNodeFlags))
             block.run();
     }
 
     public static void collapsingHeader(String label, MutableProperty0<Boolean> open, Runnable block) {
-        collapsingHeader(label, open, 0, block);
+        collapsingHeader(label, open, Flag.empty(), block);
     }
 
-    public static void collapsingHeader(String label, MutableProperty0<Boolean> open, int treeNodeFlags, Runnable block) {
+    public static void collapsingHeader(String label, MutableProperty0<Boolean> open, Flag<TreeNodeFlag> treeNodeFlags, Runnable block) {
         if (imgui.collapsingHeader(label, open, treeNodeFlags))
             block.run();
     }
@@ -375,18 +378,18 @@ public class Jdsl {
     // Widgets: Selectables
 
     public static void selectable(String label, Runnable block) {
-        selectable(label, false, 0, new Vec2(), block);
+        selectable(label, false, Flag.empty(), new Vec2(), block);
     }
 
     public static void selectable(String label, boolean selected, Runnable block) {
-        selectable(label, selected, 0, new Vec2(), block);
+        selectable(label, selected, Flag.empty(), new Vec2(), block);
     }
 
-    public static void selectable(String label, boolean selected, int flags, Runnable block) {
+    public static void selectable(String label, boolean selected, Flag<SelectableFlag> flags, Runnable block) {
         selectable(label, selected, flags, new Vec2(), block);
     }
 
-    public static void selectable(String label, boolean selected, int flags, Vec2 sizeArg, Runnable block) {
+    public static void selectable(String label, boolean selected, Flag<SelectableFlag> flags, Vec2 sizeArg, Runnable block) {
         if (imgui.selectable(label, selected, flags, sizeArg))
             block.run();
     }
@@ -449,10 +452,10 @@ public class Jdsl {
     // Popups, Modals
 
     public static void popup(String strId, Runnable block) {
-        popup(strId, 0, block);
+        popup(strId, Flag.empty(), block);
     }
 
-    public static void popup(String strId, int windowFlags, Runnable block) {
+    public static void popup(String strId, Flag<WindowFlag> windowFlags, Runnable block) {
         if (imgui.beginPopup(strId, windowFlags)) {
             block.run();
             imgui.endPopup();
@@ -460,10 +463,10 @@ public class Jdsl {
     }
 
     public static void popupContextItem(String strId, Runnable block) {
-        popupContextItem(strId, 0, block);
+        popupContextItem(strId, Flag.empty(), block);
     }
 
-    public static void popupContextItem(String strId, int popupFlags, Runnable block) {
+    public static void popupContextItem(String strId, Flag<PopupFlag> popupFlags, Runnable block) {
         if (imgui.beginPopupContextItem(strId, popupFlags)) {
             block.run();
             imgui.endPopup();
@@ -471,10 +474,10 @@ public class Jdsl {
     }
 
     public static void popupContextWindow(String strId, Runnable block) {
-        popupContextWindow(strId, 0, block);
+        popupContextWindow(strId, Flag.empty(), block);
     }
 
-    public static void popupContextWindow(String strId, int popupFlags, Runnable block) {
+    public static void popupContextWindow(String strId, Flag<PopupFlag> popupFlags, Runnable block) {
         if (imgui.beginPopupContextWindow(strId, popupFlags)) {
             block.run();
             imgui.endPopup();
@@ -482,10 +485,10 @@ public class Jdsl {
     }
 
     public static void popupContextVoid(String strId, Runnable block) {
-        popupContextVoid(strId, 0, block);
+        popupContextVoid(strId, Flag.empty(), block);
     }
 
-    public static void popupContextVoid(String strId, int popupFlags, Runnable block) {
+    public static void popupContextVoid(String strId, Flag<PopupFlag> popupFlags, Runnable block) {
         if (imgui.beginPopupContextVoid(strId, popupFlags)) {
             block.run();
             imgui.endPopup();
@@ -493,14 +496,14 @@ public class Jdsl {
     }
 
     public static void popupModal(String name, Runnable block) {
-        popupModal(name, null, 0, block);
+        popupModal(name, null, Flag.empty(), block);
     }
 
     public static void popupModal(String name, MutableProperty0<Boolean> pOpen, Runnable block) {
-        popupModal(name, pOpen, 0, block);
+        popupModal(name, pOpen, Flag.empty(), block);
     }
 
-    public static void popupModal(String name, MutableProperty0<Boolean> pOpen, int windowFlags, Runnable block) {
+    public static void popupModal(String name, MutableProperty0<Boolean> pOpen, Flag<WindowFlag> windowFlags, Runnable block) {
         if (imgui.beginPopupModal(name, pOpen, windowFlags)) {
             block.run();
             imgui.endPopup();
@@ -511,24 +514,24 @@ public class Jdsl {
     // Tab Bars, Tabs
 
     public static void tabBar(String strId, Runnable block) {
-        tabBar(strId, 0, block);
+        tabBar(strId, Flag.empty(), block);
     }
 
-    public static void tabBar(String strId, int tabBarFlags, Runnable block) {
+    public static void tabBar(String strId, Flag<TabBarFlag> tabBarFlags, Runnable block) {
         if (imgui.beginTabBar(strId, tabBarFlags))
             block.run();
         imgui.endTabBar();
     }
 
     public static void tabItem(String label, Runnable block) {
-        tabItem(label, null, 0, block);
+        tabItem(label, null, Flag.empty(), block);
     }
 
     public static void tabItem(String label, MutableProperty0<Boolean> pOpen, Runnable block) {
-        tabItem(label, pOpen, 0, block);
+        tabItem(label, pOpen, Flag.empty(), block);
     }
 
-    public static void tabItem(String label, MutableProperty0<Boolean> pOpen, int tabItemFlags, Runnable block) {
+    public static void tabItem(String label, MutableProperty0<Boolean> pOpen, Flag<TabItemFlag> tabItemFlags, Runnable block) {
         if (imgui.beginTabItem(label, pOpen, tabItemFlags))
             block.run();
         imgui.endTabItem();
@@ -538,10 +541,10 @@ public class Jdsl {
     // Drag and Drop
 
     public static void dragDropSource(Runnable block) {
-        dragDropSource(0, block);
+        dragDropSource(Flag.empty(), block);
     }
 
-    public static void dragDropSource(int dragDropFlags, Runnable block) {
+    public static void dragDropSource(Flag<DragDropFlag> dragDropFlags, Runnable block) {
         if (imgui.beginDragDropSource(dragDropFlags)) {
             block.run();
             imgui.endDragDropSource();
@@ -568,10 +571,10 @@ public class Jdsl {
     // Miscellaneous Utilities
 
     public static void childFrame(int id, Vec2 size, Runnable block) {
-        childFrame(id, size, 0, block);
+        childFrame(id, size, Flag.empty(), block);
     }
 
-    public static void childFrame(int id, Vec2 size, int windowFlags, Runnable block) {
+    public static void childFrame(int id, Vec2 size, Flag<WindowFlag> windowFlags, Runnable block) {
         imgui.beginChildFrame(id, size, windowFlags);
         block.run();
         imgui.endChildFrame();
@@ -579,7 +582,7 @@ public class Jdsl {
 
     // Columns
 
-    public static void columns(String strId, int columnsCount, int flags, Runnable block) {
+    public static void columns(String strId, int columnsCount, Flag<OldColumnsFlag> flags, Runnable block) {
         imgui.beginColumns(strId, columnsCount, flags);
         try {
             block.run();

--- a/core/src/main/kotlin/imgui/api/childWindows.kt
+++ b/core/src/main/kotlin/imgui/api/childWindows.kt
@@ -3,15 +3,20 @@ package imgui.api
 import gli_.has
 import glm_.glm
 import glm_.vec2.Vec2
-import imgui.*
+import imgui.ID
 import imgui.ImGui.beginChildEx
 import imgui.ImGui.currentWindow
 import imgui.ImGui.end
 import imgui.ImGui.itemAdd
 import imgui.ImGui.itemSize
 import imgui.ImGui.renderNavHighlight
+import imgui.WindowFlags
+import imgui.emptyFlags
 import imgui.internal.classes.Rect
-import imgui.internal.sections.*
+import imgui.internal.sections.Axis
+import imgui.internal.sections.ItemStatusFlag
+import imgui.internal.sections.NavHighlightFlag
+import imgui.internal.sections.shl
 import imgui.WindowFlag as Wf
 
 
@@ -27,14 +32,14 @@ interface childWindows {
      *    [Important: due to legacy reason, this is inconsistent with most other functions such as BeginMenu/EndMenu,
      *     BeginPopup/EndPopup, etc. where the EndXXX call should only be called if the corresponding BeginXXX function
      *     returned true. Begin and BeginChild are the only odd ones out. Will be fixed in a future update.] */
-    fun beginChild(strId: String, size: Vec2 = Vec2(), border: Boolean = false, flags: WindowFlags = 0): Boolean =
-            beginChildEx(strId, currentWindow.getID(strId), size, border, flags)
+    fun beginChild(strId: String, size: Vec2 = Vec2(), border: Boolean = false, flags: WindowFlags = emptyFlags()): Boolean =
+        beginChildEx(strId, currentWindow.getID(strId), size, border, flags)
 
     /** begin a scrolling region.
      *  size == 0f: use remaining window size
      *  size < 0f: use remaining window size minus abs(size)
      *  size > 0f: fixed size. each axis can use a different mode, e.g. Vec2(0, 400).   */
-    fun beginChild(id: ID, sizeArg: Vec2 = Vec2(), border: Boolean = false, flags: WindowFlags = Wf.None.i): Boolean {
+    fun beginChild(id: ID, sizeArg: Vec2 = Vec2(), border: Boolean = false, flags: WindowFlags = emptyFlags()): Boolean {
         assert(id != 0)
         return beginChildEx("", id, sizeArg, border, flags)
     }
@@ -67,7 +72,7 @@ interface childWindows {
 
                 // When browsing a window that has no activable items (scroll only) we keep a highlight on the child (pass g.NavId to trick into always displaying)
                 if (window.dc.navLayersActiveMask == 0 && window === g.navWindow)
-                    renderNavHighlight(Rect(bb.min - 2, bb.max + 2), g.navId, NavHighlightFlag.TypeThin.i)
+                    renderNavHighlight(Rect(bb.min - 2, bb.max + 2), g.navId, NavHighlightFlag.TypeThin)
             } else // Not navigable into
                 itemAdd(bb, 0)
             if (g.hoveredWindow === window)

--- a/core/src/main/kotlin/imgui/api/childWindows.kt
+++ b/core/src/main/kotlin/imgui/api/childWindows.kt
@@ -3,15 +3,13 @@ package imgui.api
 import gli_.has
 import glm_.glm
 import glm_.vec2.Vec2
-import imgui.ID
+import imgui.*
 import imgui.ImGui.beginChildEx
 import imgui.ImGui.currentWindow
 import imgui.ImGui.end
 import imgui.ImGui.itemAdd
 import imgui.ImGui.itemSize
 import imgui.ImGui.renderNavHighlight
-import imgui.WindowFlags
-import imgui.emptyFlags
 import imgui.internal.classes.Rect
 import imgui.internal.sections.Axis
 import imgui.internal.sections.ItemStatusFlag
@@ -32,14 +30,14 @@ interface childWindows {
      *    [Important: due to legacy reason, this is inconsistent with most other functions such as BeginMenu/EndMenu,
      *     BeginPopup/EndPopup, etc. where the EndXXX call should only be called if the corresponding BeginXXX function
      *     returned true. Begin and BeginChild are the only odd ones out. Will be fixed in a future update.] */
-    fun beginChild(strId: String, size: Vec2 = Vec2(), border: Boolean = false, flags: WindowFlags = emptyFlags()): Boolean =
+    fun beginChild(strId: String, size: Vec2 = Vec2(), border: Boolean = false, flags: WindowFlags = emptyFlags): Boolean =
         beginChildEx(strId, currentWindow.getID(strId), size, border, flags)
 
     /** begin a scrolling region.
      *  size == 0f: use remaining window size
      *  size < 0f: use remaining window size minus abs(size)
      *  size > 0f: fixed size. each axis can use a different mode, e.g. Vec2(0, 400).   */
-    fun beginChild(id: ID, sizeArg: Vec2 = Vec2(), border: Boolean = false, flags: WindowFlags = emptyFlags()): Boolean {
+    fun beginChild(id: ID, sizeArg: Vec2 = Vec2(), border: Boolean = false, flags: WindowFlags = emptyFlags): Boolean {
         assert(id != 0)
         return beginChildEx("", id, sizeArg, border, flags)
     }

--- a/core/src/main/kotlin/imgui/api/columns.kt
+++ b/core/src/main/kotlin/imgui/api/columns.kt
@@ -16,6 +16,8 @@ import imgui.ImGui.pushItemWidth
 import imgui.ImGui.setWindowClipRectBeforeSetChannel
 import imgui.ImGui.style
 import imgui.emptyFlags
+import imgui.has
+import imgui.hasnt
 import imgui.internal.floor
 import imgui.internal.lerp
 import imgui.internal.sections.OldColumns
@@ -33,10 +35,10 @@ interface columns {
         val window = currentWindow
         assert(columnsCount >= 1)
 
-        val flags: OldColumnsFlags = if (border) emptyFlags() else Cf.NoBorder
+        val flags: OldColumnsFlags = if (border) emptyFlags else Cf.NoBorder
         //flags |= ImGuiOldColumnFlags_NoPreserveWidths; // NB: Legacy behavior
         window.dc.currentColumns?.let {
-            if (it.count == columnsCount && it.flags eq flags)
+            if (it.count == columnsCount && it.flags == flags)
                 return
 
             endColumns()

--- a/core/src/main/kotlin/imgui/api/columns.kt
+++ b/core/src/main/kotlin/imgui/api/columns.kt
@@ -15,8 +15,7 @@ import imgui.ImGui.popItemWidth
 import imgui.ImGui.pushItemWidth
 import imgui.ImGui.setWindowClipRectBeforeSetChannel
 import imgui.ImGui.style
-import imgui.has
-import imgui.hasnt
+import imgui.emptyFlags
 import imgui.internal.floor
 import imgui.internal.lerp
 import imgui.internal.sections.OldColumns
@@ -34,10 +33,10 @@ interface columns {
         val window = currentWindow
         assert(columnsCount >= 1)
 
-        val flags: OldColumnsFlags = if (border) Cf.None.i else Cf.NoBorder.i
+        val flags: OldColumnsFlags = if (border) emptyFlags() else Cf.NoBorder
         //flags |= ImGuiOldColumnFlags_NoPreserveWidths; // NB: Legacy behavior
         window.dc.currentColumns?.let {
-            if (it.count == columnsCount && it.flags == flags)
+            if (it.count == columnsCount && it.flags eq flags)
                 return
 
             endColumns()

--- a/core/src/main/kotlin/imgui/api/cursorLayout.kt
+++ b/core/src/main/kotlin/imgui/api/cursorLayout.kt
@@ -11,12 +11,12 @@ import imgui.ImGui.itemAdd
 import imgui.ImGui.itemSize
 import imgui.ImGui.separatorEx
 import imgui.ImGui.style
-import imgui.div
 import imgui.internal.classes.GroupData
 import imgui.internal.classes.Rect
 import imgui.internal.sections.ItemFlag
 import imgui.internal.sections.ItemStatusFlag
 import imgui.internal.sections.SeparatorFlag
+import imgui.internal.sections.SeparatorFlags
 import imgui.internal.sections.LayoutType as Lt
 
 
@@ -37,7 +37,8 @@ interface cursorLayout {
             return
 
         // Those flags should eventually be overridable by the user
-        var flags = if (window.dc.layoutType == Lt.Horizontal) SeparatorFlag.Vertical.i else SeparatorFlag.Horizontal.i
+        var flags: SeparatorFlags =
+            if (window.dc.layoutType == Lt.Horizontal) SeparatorFlag.Vertical else SeparatorFlag.Horizontal
         flags /= SeparatorFlag.SpanAllColumns // NB: this only applies to legacy Columns() api as they relied on Separator() a lot.
         separatorEx(flags)
     }
@@ -178,7 +179,7 @@ interface cursorLayout {
 
         window.dc.currLineTextBaseOffset = window.dc.prevLineTextBaseOffset max groupData.backupCurrLineTextBaseOffset      // FIXME: Incorrect, we should grab the base offset from the *first line* of the group but it is hard to obtain now.
         itemSize(groupBb.size)
-        itemAdd(groupBb, 0, null, ItemFlag.NoTabStop.i)
+        itemAdd(groupBb, 0, null, ItemFlag.NoTabStop)
 
         // If the current ActiveId was declared within the boundary of our group, we copy it to LastItemId so IsItemActive(), IsItemDeactivated() etc. will be functional on the entire group.
         // It would be neater if we replaced window.DC.LastItemId by e.g. 'bool LastItemIsActive', but would put a little more burden on individual widgets.

--- a/core/src/main/kotlin/imgui/api/cursorLayout.kt
+++ b/core/src/main/kotlin/imgui/api/cursorLayout.kt
@@ -11,6 +11,7 @@ import imgui.ImGui.itemAdd
 import imgui.ImGui.itemSize
 import imgui.ImGui.separatorEx
 import imgui.ImGui.style
+import imgui.div
 import imgui.internal.classes.GroupData
 import imgui.internal.classes.Rect
 import imgui.internal.sections.ItemFlag

--- a/core/src/main/kotlin/imgui/api/debugUtilities.kt
+++ b/core/src/main/kotlin/imgui/api/debugUtilities.kt
@@ -10,7 +10,6 @@ import imgui.ImGui.textUnformatted
 import imgui.TableFlag
 import imgui.dsl.table
 import imgui.internal.textCharFromUtf8
-import imgui.or
 import uno.kotlin.NUL
 
 // Debug Utilities

--- a/core/src/main/kotlin/imgui/api/debugUtilities.kt
+++ b/core/src/main/kotlin/imgui/api/debugUtilities.kt
@@ -10,6 +10,7 @@ import imgui.ImGui.textUnformatted
 import imgui.TableFlag
 import imgui.dsl.table
 import imgui.internal.textCharFromUtf8
+import imgui.or
 import uno.kotlin.NUL
 
 // Debug Utilities

--- a/core/src/main/kotlin/imgui/api/demoDebugInformations.kt
+++ b/core/src/main/kotlin/imgui/api/demoDebugInformations.kt
@@ -99,7 +99,6 @@ import imgui.demo.showExampleApp.StyleEditor
 import imgui.dsl.indent
 import imgui.dsl.listBox
 import imgui.dsl.treeNode
-import imgui.hasnt
 import imgui.internal.DrawIdx
 import imgui.internal.DrawVert
 import imgui.internal.api.debugTools.Companion.metricsHelpMarker
@@ -255,7 +254,7 @@ interface demoDebugInformations {
 
                     bulletText("Table 0x%08X (${table.columnsCount} columns, in '${table.outerWindow!!.name}')", table.id)
                     if (isItemHovered())
-                        foregroundDrawList.addRect(table.outerRect.min - 1, table.outerRect.max + 1, COL32(255, 255, 0, 255), 0f, 0, 2f)
+                        foregroundDrawList.addRect(table.outerRect.min - 1, table.outerRect.max + 1, COL32(255, 255, 0, 255), thickness = 2f)
                     indent()
                     for (rectN in TRT.values()) {
                         if (rectN >= TRT.ColumnsRect) {
@@ -267,7 +266,7 @@ interface demoDebugInformations {
                                         .format(r.min.x, r.min.y, r.max.x, r.max.y, r.width, r.height)
                                 selectable(buf)
                                 if (isItemHovered())
-                                    foregroundDrawList.addRect(r.min - 1, r.max + 1, COL32(255, 255, 0, 255), 0f, 0, 2f)
+                                    foregroundDrawList.addRect(r.min - 1, r.max + 1, COL32(255, 255, 0, 255), thickness = 2f)
                             }
                         } else {
                             val r = Funcs.getTableRect(table, rectN, -1)
@@ -275,7 +274,7 @@ interface demoDebugInformations {
                                 r.min.x, r.min.y, r.max.x, r.max.y, r.width, r.height)
                             selectable(buf)
                             if (isItemHovered())
-                                foregroundDrawList.addRect(r.min - 1, r.max + 1, COL32(255, 255, 0, 255), 0f, 0, 2f)
+                                foregroundDrawList.addRect(r.min - 1, r.max + 1, COL32(255, 255, 0, 255), thickness = 2f)
                         }
                     }
                     unindent()
@@ -391,7 +390,7 @@ interface demoDebugInformations {
 
             treeNode("SettingsIniData", "Settings unpacked data (.ini): ${g.settingsIniData.toByteArray().size} bytes") {
                 val size = Vec2(-Float.MIN_VALUE, ImGui.textLineHeight * 20)
-                inputTextMultiline("##Ini", g.settingsIniData, size, InputTextFlag.ReadOnly.i)
+                inputTextMultiline("##Ini", g.settingsIniData, size, InputTextFlag.ReadOnly)
             }
         }
 
@@ -470,7 +469,7 @@ interface demoDebugInformations {
                 listBox("##routes", Vec2(-Float.MIN_VALUE, textLineHeightWithSpacing * 8)) {
                     for (key in Key.Named) {
                         val rt = g.keysRoutingTable
-                        var idx = rt.index[key.i]
+                        var idx = rt.index[key]
                         while (idx != -1) {
                             val routingData = rt.entries[idx]
                             val keyChordName = getKeyChordName(key or routingData.mods)
@@ -555,7 +554,7 @@ interface demoDebugInformations {
                         val r = Funcs.getTableRect(table, TRT.values()[cfg.showTablesRectsType], columnN)
                         val col = if (table.hoveredColumnBody == columnN) COL32(255, 255, 128, 255) else COL32(255, 0, 128, 255)
                         val thickness = if (table.hoveredColumnBody == columnN) 3f else 1f
-                        drawList.addRect(r.min, r.max, col, 0f, 0, thickness)
+                        drawList.addRect(r.min, r.max, col, thickness = thickness)
                     }
                 } else {
                     val r = Funcs.getTableRect(table, TRT.values()[cfg.showTablesRectsType], -1)
@@ -585,13 +584,13 @@ interface demoDebugInformations {
 
         alignTextToFramePadding()
         text("Log events:")
-        sameLine(); checkboxFlags("All", g::debugLogFlags, DebugLogFlag.EventMask_.i)
-        sameLine(); checkboxFlags("ActiveId", g::debugLogFlags, DebugLogFlag.EventActiveId.i)
-        sameLine(); checkboxFlags("Focus", g::debugLogFlags, DebugLogFlag.EventFocus.i)
-        sameLine(); checkboxFlags("Popup", g::debugLogFlags, DebugLogFlag.EventPopup.i)
-        sameLine(); checkboxFlags("Nav", g::debugLogFlags, DebugLogFlag.EventNav.i)
-        sameLine(); checkboxFlags("Clipper", g::debugLogFlags, DebugLogFlag.EventClipper.i)
-        sameLine(); checkboxFlags("IO", g::debugLogFlags, DebugLogFlag.EventIO.i)
+        sameLine(); checkboxFlags("All", g::debugLogFlags, DebugLogFlag.EventMask)
+        sameLine(); checkboxFlags("ActiveId", g::debugLogFlags, DebugLogFlag.EventActiveId)
+        sameLine(); checkboxFlags("Focus", g::debugLogFlags, DebugLogFlag.EventFocus)
+        sameLine(); checkboxFlags("Popup", g::debugLogFlags, DebugLogFlag.EventPopup)
+        sameLine(); checkboxFlags("Nav", g::debugLogFlags, DebugLogFlag.EventNav)
+        sameLine(); checkboxFlags("Clipper", g::debugLogFlags, DebugLogFlag.EventClipper)
+        sameLine(); checkboxFlags("IO", g::debugLogFlags, DebugLogFlag.EventIO)
 
         if (smallButton("Clear")) {
             g.debugLogBuf.clear()
@@ -687,12 +686,12 @@ interface demoDebugInformations {
 
         // Display decorated stack
         tool.lastActiveFrame = g.frameCount
-        if (tool.results.isNotEmpty() && beginTable("##table", 3, TableFlag.Borders.i)) {
+        if (tool.results.isNotEmpty() && beginTable("##table", 3, TableFlag.Borders)) {
 
             val idWidth = calcTextSize("0xDDDDDDDD").x
-            tableSetupColumn("Seed", TableColumnFlag.WidthFixed.i, idWidth)
-            tableSetupColumn("PushID", TableColumnFlag.WidthStretch.i)
-            tableSetupColumn("Result", TableColumnFlag.WidthFixed.i, idWidth)
+            tableSetupColumn("Seed", TableColumnFlag.WidthFixed, idWidth)
+            tableSetupColumn("PushID", TableColumnFlag.WidthStretch)
+            tableSetupColumn("Result", TableColumnFlag.WidthFixed, idWidth)
             tableHeadersRow()
             for (n in tool.results.indices) {
                 val info = tool.results[n]
@@ -717,7 +716,7 @@ interface demoDebugInformations {
         var showConfigInfo = false
         operator fun invoke(open: KMutableProperty0<Boolean>) {
 
-            if (!begin("About Dear ImGui", open, Wf.AlwaysAutoResize.i)) {
+            if (!begin("About Dear ImGui", open, Wf.AlwaysAutoResize)) {
                 end()
                 return
             }
@@ -733,7 +732,7 @@ interface demoDebugInformations {
 
                 val copyToClipboard = button("Copy to clipboard")
                 val childSize = Vec2(0f, textLineHeightWithSpacing * 18)
-                beginChildFrame(getID("cfginfos"), childSize, Wf.NoMove.i)
+                beginChildFrame(getID("cfginfos"), childSize, Wf.NoMove)
                 if (copyToClipboard) {
                     logToClipboard()
                     logText("```\n") // Back quotes will make text appears without formatting when pasting on GitHub

--- a/core/src/main/kotlin/imgui/api/dragAndDrop.kt
+++ b/core/src/main/kotlin/imgui/api/dragAndDrop.kt
@@ -1,7 +1,6 @@
 package imgui.api
 
 import imgui.*
-import imgui.DragDropFlag
 import imgui.ImGui.beginTooltip
 import imgui.ImGui.clearDragDrop
 import imgui.ImGui.endTooltip
@@ -16,8 +15,8 @@ import imgui.ImGui.setActiveIdUsingAllKeyboardKeys
 import imgui.classes.Payload
 import imgui.internal.classes.Rect
 import imgui.internal.classes.Window
-import imgui.internal.*
-import imgui.internal.sections.*
+import imgui.internal.hashStr
+import imgui.internal.sections.ItemStatusFlag
 import imgui.DragDropFlag as Ddf
 
 // Drag and Drop
@@ -26,7 +25,6 @@ import imgui.DragDropFlag as Ddf
 // - If you stop calling BeginDragDropSource() the payload is preserved however it won't have a preview tooltip (we currently display a fallback "..." tooltip, see #1725)
 // - An item can be both drag source and drop target.
 interface dragAndDrop {
-
     /** call after submitting an item which may be dragged. when this return true, you can call SetDragDropPayload() + EndDragDropSource()
      *
      *  When this returns true you need to: a) call SetDragDropPayload() exactly once, b) you may render the payload visual/description, c) call EndDragDropSource()
@@ -36,18 +34,7 @@ interface dragAndDrop {
      *  - We then pull and use the mouse button that was used to activate the item and use it to carry on the drag.
      *  If the item has no identifier:
      *  - Currently always assume left mouse button. */
-    fun beginDragDropSource(flag: Ddf): Boolean = beginDragDropSource(flag.i)
-
-    /** call after submitting an item which may be dragged. when this return true, you can call SetDragDropPayload() + EndDragDropSource()
-     *
-     *  When this returns true you need to: a) call SetDragDropPayload() exactly once, b) you may render the payload visual/description, c) call EndDragDropSource()
-     *  If the item has an identifier:
-     *  - This assume/require the item to be activated (typically via ButtonBehavior).
-     *  - Therefore if you want to use this with a mouse button other than left mouse button, it is up to the item itself to activate with another button.
-     *  - We then pull and use the mouse button that was used to activate the item and use it to carry on the drag.
-     *  If the item has no identifier:
-     *  - Currently always assume left mouse button. */
-    fun beginDragDropSource(flags: DragDropFlags = 0): Boolean {
+    fun beginDragDropSource(flags: DragDropFlags = emptyFlags()): Boolean {
 
         var window: Window? = g.currentWindow!!
 
@@ -64,8 +51,8 @@ interface dragAndDrop {
                 // Common path: items with ID
                 if (g.activeId != sourceId)
                     return false
-                if (g.activeIdMouseButton != -1)
-                    mouseButton = MouseButton.of(g.activeIdMouseButton)
+                if (g.activeIdMouseButton != MouseButton.None)
+                    mouseButton = g.activeIdMouseButton
                 if (!g.io.mouseDown[mouseButton.i] || window!!.skipItems)
                     return false
                 g.activeIdAllowOverlap = false
@@ -228,7 +215,7 @@ interface dragAndDrop {
 
     /** Accept contents of a given type. If DragDropFlag.AcceptBeforeDelivery is set you can peek into the payload
      *  before the mouse button is released. */
-    fun acceptDragDropPayload(type: String, flags_: DrawListFlags = 0): Payload? {
+    fun acceptDragDropPayload(type: String, flags_: DragDropFlags = emptyFlags()): Payload? {
         var flags = flags_
         val window = g.currentWindow!!
         val payload = g.dragDropPayload
@@ -249,9 +236,9 @@ interface dragAndDrop {
 
         // Render default drop visuals
         payload.preview = wasAcceptedPreviously
-        flags = flags or (g.dragDropSourceFlags and DragDropFlag.AcceptNoDrawDefaultRect) // Source can also inhibit the preview (useful for external sources that live for 1 frame)
+        flags = flags or (g.dragDropSourceFlags and Ddf.AcceptNoDrawDefaultRect) // Source can also inhibit the preview (useful for external sources that live for 1 frame)
         if (flags hasnt Ddf.AcceptNoDrawDefaultRect && payload.preview)
-            window.drawList.addRect(r.min - 3.5f, r.max + 3.5f, Col.DragDropTarget.u32, 0f, 0, 2f)
+            window.drawList.addRect(r.min - 3.5f, r.max + 3.5f, Col.DragDropTarget.u32, thickness = 2f)
 
         g.dragDropAcceptFrameCount = g.frameCount
         // For extern drag sources affecting os window focus, it's easier to just test !isMouseDown() instead of isMouseReleased()

--- a/core/src/main/kotlin/imgui/api/dragAndDrop.kt
+++ b/core/src/main/kotlin/imgui/api/dragAndDrop.kt
@@ -34,7 +34,7 @@ interface dragAndDrop {
      *  - We then pull and use the mouse button that was used to activate the item and use it to carry on the drag.
      *  If the item has no identifier:
      *  - Currently always assume left mouse button. */
-    fun beginDragDropSource(flags: DragDropFlags = emptyFlags()): Boolean {
+    fun beginDragDropSource(flags: DragDropFlags = emptyFlags): Boolean {
 
         var window: Window? = g.currentWindow!!
 
@@ -215,7 +215,7 @@ interface dragAndDrop {
 
     /** Accept contents of a given type. If DragDropFlag.AcceptBeforeDelivery is set you can peek into the payload
      *  before the mouse button is released. */
-    fun acceptDragDropPayload(type: String, flags_: DragDropFlags = emptyFlags()): Payload? {
+    fun acceptDragDropPayload(type: String, flags_: DragDropFlags = emptyFlags): Payload? {
         var flags = flags_
         val window = g.currentWindow!!
         val payload = g.dragDropPayload

--- a/core/src/main/kotlin/imgui/api/focusActivation.kt
+++ b/core/src/main/kotlin/imgui/api/focusActivation.kt
@@ -35,7 +35,7 @@ interface focusActivation {
 
         // Scroll could be done in NavInitRequestApplyResult() via an opt-in flag (we however don't want regular init requests to scroll)
         if (!isItemVisible)
-            scrollToRectEx(window, g.lastItemData.rect, ScrollFlag.None.i)
+            scrollToRectEx(window, g.lastItemData.rect)
     }
 
     /** focus keyboard on the next widget. Use positive 'offset' to access sub components of a multiple component widget.

--- a/core/src/main/kotlin/imgui/api/focusActivation.kt
+++ b/core/src/main/kotlin/imgui/api/focusActivation.kt
@@ -11,6 +11,7 @@ import imgui.ImGui.setNavWindow
 import imgui.internal.sections.IMGUI_DEBUG_LOG_ACTIVEID
 import imgui.internal.sections.NavMoveFlag
 import imgui.internal.sections.ScrollFlag
+import imgui.or
 import imgui.static.navUpdateAnyRequestFlag
 
 

--- a/core/src/main/kotlin/imgui/api/inputUtilitiesMouse.kt
+++ b/core/src/main/kotlin/imgui/api/inputUtilitiesMouse.kt
@@ -25,7 +25,7 @@ interface inputUtilitiesMouse {
     }
 
     /** did mouse button clicked? (went from !Down to Down). Same as GetMouseClickedCount() == 1. */
-    fun isMouseClicked(button: MouseButton, repeat: Boolean = false): Boolean = button.isClicked(KeyOwner_Any, if (repeat) InputFlag.Repeat else emptyFlags())
+    fun isMouseClicked(button: MouseButton, repeat: Boolean = false): Boolean = button.isClicked(KeyOwner_Any, if (repeat) InputFlag.Repeat else emptyFlags)
 
     fun isMouseReleased(button: Int): Boolean = isMouseReleased(MouseButton of button)
 

--- a/core/src/main/kotlin/imgui/api/inputUtilitiesMouse.kt
+++ b/core/src/main/kotlin/imgui/api/inputUtilitiesMouse.kt
@@ -2,15 +2,12 @@ package imgui.api
 
 import glm_.i
 import glm_.vec2.Vec2
+import imgui.*
 import imgui.ImGui.io
 import imgui.ImGui.isClicked
 import imgui.ImGui.isMouseDragPastThreshold
 import imgui.ImGui.style
 import imgui.ImGui.testOwner
-import imgui.ImGui.toKey
-import imgui.MOUSE_INVALID
-import imgui.MouseButton
-import imgui.MouseCursor
 import imgui.internal.classes.InputFlag
 import imgui.internal.classes.Rect
 import imgui.internal.sections.KeyOwner_Any
@@ -24,11 +21,11 @@ interface inputUtilitiesMouse {
     /** is mouse button held?   */
     fun isMouseDown(button: MouseButton): Boolean {
         assert(button.i in io.mouseDown.indices)
-        return io.mouseDown[button.i] && button.toKey() testOwner KeyOwner_Any // should be same as IsKeyDown(MouseButtonToKey(button), ImGuiKeyOwner_Any), but this allows legacy code hijacking the io.Mousedown[] array.
+        return io.mouseDown[button.i] && button.key testOwner KeyOwner_Any // should be same as IsKeyDown(MouseButtonToKey(button), ImGuiKeyOwner_Any), but this allows legacy code hijacking the io.Mousedown[] array.
     }
 
     /** did mouse button clicked? (went from !Down to Down). Same as GetMouseClickedCount() == 1. */
-    fun isMouseClicked(button: MouseButton, repeat: Boolean = false): Boolean = button.isClicked(KeyOwner_Any, if (repeat) InputFlag.Repeat.i else InputFlag.None.i)
+    fun isMouseClicked(button: MouseButton, repeat: Boolean = false): Boolean = button.isClicked(KeyOwner_Any, if (repeat) InputFlag.Repeat else emptyFlags())
 
     fun isMouseReleased(button: Int): Boolean = isMouseReleased(MouseButton of button)
 
@@ -37,7 +34,7 @@ interface inputUtilitiesMouse {
         if (button == MouseButton.None)
             return false // The None button is never clicked.
 
-        return io.mouseReleased[button.i] && button.toKey() testOwner KeyOwner_Any // Should be same as IsKeyReleased(MouseButtonToKey(button), ImGuiKeyOwner_Any)
+        return io.mouseReleased[button.i] && button.key testOwner KeyOwner_Any // Should be same as IsKeyReleased(MouseButtonToKey(button), ImGuiKeyOwner_Any)
     }
 
 
@@ -46,7 +43,7 @@ interface inputUtilitiesMouse {
         if (button == MouseButton.None)
             return false // The None button is never clicked.
 
-        return io.mouseClickedCount[button.i] == 2 && button.toKey() testOwner KeyOwner_Any
+        return io.mouseClickedCount[button.i] == 2 && button.key testOwner KeyOwner_Any
     }
 
     /** return the number of successive mouse-clicks at the time where a click happen (otherwise 0). */

--- a/core/src/main/kotlin/imgui/api/inputsUtilitiesKeyboardMouseGamepad.kt
+++ b/core/src/main/kotlin/imgui/api/inputsUtilitiesKeyboardMouseGamepad.kt
@@ -7,6 +7,7 @@ import imgui.ImGui.isDown
 import imgui.ImGui.isPressed
 import imgui.ImGui.isReleased
 import imgui.Key
+import imgui.emptyFlags
 import imgui.internal.classes.InputFlag
 import imgui.internal.sections.KeyOwner_Any
 
@@ -33,7 +34,7 @@ interface inputsUtilitiesKeyboardMouseGamepad {
      *  uses io.KeyRepeatDelay / KeyRepeatRate
      *
      *  was key pressed (went from !Down to Down)? if repeat=true, uses io.KeyRepeatDelay / KeyRepeatRate */
-    infix fun Key.isPressed(repeat: Boolean): Boolean = isPressed(KeyOwner_Any, if (repeat) InputFlag.Repeat.i else InputFlag.None.i)
+    infix fun Key.isPressed(repeat: Boolean): Boolean = isPressed(KeyOwner_Any, if (repeat) InputFlag.Repeat else emptyFlags())
 
     /** ~IsKeyPressed() */
     val Key.isPressed: Boolean

--- a/core/src/main/kotlin/imgui/api/inputsUtilitiesKeyboardMouseGamepad.kt
+++ b/core/src/main/kotlin/imgui/api/inputsUtilitiesKeyboardMouseGamepad.kt
@@ -34,7 +34,7 @@ interface inputsUtilitiesKeyboardMouseGamepad {
      *  uses io.KeyRepeatDelay / KeyRepeatRate
      *
      *  was key pressed (went from !Down to Down)? if repeat=true, uses io.KeyRepeatDelay / KeyRepeatRate */
-    infix fun Key.isPressed(repeat: Boolean): Boolean = isPressed(KeyOwner_Any, if (repeat) InputFlag.Repeat else emptyFlags())
+    infix fun Key.isPressed(repeat: Boolean): Boolean = isPressed(KeyOwner_Any, if (repeat) InputFlag.Repeat else emptyFlags)
 
     /** ~IsKeyPressed() */
     val Key.isPressed: Boolean

--- a/core/src/main/kotlin/imgui/api/inputsUtilitiesShortcutRouting.kt
+++ b/core/src/main/kotlin/imgui/api/inputsUtilitiesShortcutRouting.kt
@@ -36,7 +36,7 @@ interface inputsUtilitiesShortcutRouting {
     // - Route is granted to a single owner. When multiple requests are made we have policies to select the winning route.
     // - Multiple read sites may use the same owner id and will all get the granted route.
     // - For routing: when owner_id is 0 we use the current Focus Scope ID as a default owner in order to identify our location.
-    fun shortcut(keyChord_: KeyChord, ownerId: ID = 0, flags_: InputFlags = emptyFlags()): Boolean {
+    fun shortcut(keyChord_: KeyChord, ownerId: ID = 0, flags_: InputFlags = emptyFlags): Boolean {
 
         var flags = flags_
         // When using (owner_id == 0/Any): SetShortcutRouting() will use CurrentFocusScopeId and filter with this, so IsKeyPressed() is fine with he 0/Any.

--- a/core/src/main/kotlin/imgui/api/inputsUtilitiesShortcutRouting.kt
+++ b/core/src/main/kotlin/imgui/api/inputsUtilitiesShortcutRouting.kt
@@ -6,8 +6,8 @@ import imgui.ImGui.convertShortcutMod
 import imgui.ImGui.convertSingleModFlagToKey
 import imgui.ImGui.getRoutingIdFromOwnerId
 import imgui.ImGui.isPressed
-import imgui.internal.classes.*
-import imgui.internal.isPowerOfTwo
+import imgui.internal.classes.InputFlag
+import imgui.internal.classes.InputFlags
 import imgui.internal.sections.KeyRoutingData
 
 // Inputs Utilities: Shortcut testing (with Routing Resolution)
@@ -36,29 +36,29 @@ interface inputsUtilitiesShortcutRouting {
     // - Route is granted to a single owner. When multiple requests are made we have policies to select the winning route.
     // - Multiple read sites may use the same owner id and will all get the granted route.
     // - For routing: when owner_id is 0 we use the current Focus Scope ID as a default owner in order to identify our location.
-    fun shortcut(keyChord_: KeyChord, ownerId: ID = 0, flags_: InputFlags = 0): Boolean {
+    fun shortcut(keyChord_: KeyChord, ownerId: ID = 0, flags_: InputFlags = emptyFlags()): Boolean {
 
         var flags = flags_
         // When using (owner_id == 0/Any): SetShortcutRouting() will use CurrentFocusScopeId and filter with this, so IsKeyPressed() is fine with he 0/Any.
-        if (flags hasnt InputFlag.RouteMask_)
+        if (flags hasnt InputFlag.RouteMask)
             flags /= InputFlag.RouteFocused
         if (!setShortcutRouting(keyChord_, ownerId, flags))
             return false
 
         val keyChord = if (keyChord_ has Key.Mod_Shortcut) convertShortcutMod(keyChord_) else keyChord_
         // [JVM] don't attempt finding a `Key` with mods, it might not exist and crash, keep it as an `Int`
-        val mods = keyChord and Key.Mod_Mask_
+        val mods = keyChord and Key.Mod_Mask
         if (g.io.keyMods != mods)
             return false
 
         // Special storage location for mods
-        var key = Key of (keyChord wo Key.Mod_Mask_)
+        var key = Key of (keyChord wo Key.Mod_Mask)
         if (key == Key.None)
             key = (Key of mods).convertSingleModFlagToKey()
 
-        if (!key.isPressed(ownerId, flags and (InputFlag.Repeat or InputFlag.RepeatRateMask_)))
+        if (!key.isPressed(ownerId, flags and (InputFlag.Repeat or InputFlag.RepeatRateMask)))
             return false
-        assert((flags wo InputFlag.SupportedByShortcut) == 0) { "Passing flags not supported by this function !" }
+        assert((flags wo InputFlag.SupportedByShortcut).isEmpty) { "Passing flags not supported by this function !" }
 
         return true
     }
@@ -73,10 +73,10 @@ interface inputsUtilitiesShortcutRouting {
     fun setShortcutRouting(keyChord: KeyChord, ownerId: ID, flags_: InputFlags): Boolean {
 
         var flags = flags_
-        if (flags hasnt InputFlag.RouteMask_)
+        if (flags hasnt InputFlag.RouteMask)
             flags /= InputFlag.RouteGlobalHigh // IMPORTANT: This is the default for SetShortcutRouting() but NOT Shortcut()
         else
-            assert((flags and InputFlag.RouteMask_).isPowerOfTwo) { "Check that only 1 routing flag is used" }
+            assert((flags and InputFlag.RouteMask).isPowerOfTwo) { "Check that only 1 routing flag is used" }
 
         if (flags has InputFlag.RouteUnlessBgFocused)
             if (g.navWindow == null)
@@ -119,9 +119,9 @@ interface inputsUtilitiesShortcutRouting {
         //  - Shortcut(ImGuiMod_Ctrl | ImGuiMod_Shift);                // Not legal
         val rt = g.keysRoutingTable
         val keyChord = if (keyChord_ has Key.Mod_Shortcut) convertShortcutMod(keyChord_) else keyChord_
-        var key = Key of (keyChord wo Key.Mod_Mask_)
+        var key = Key of (keyChord wo Key.Mod_Mask)
         // [JVM] don't attempt finding a `Key` with mods, it might not exist and crash, keep it as an `Int`
-        val mods = keyChord and Key.Mod_Mask_
+        val mods = keyChord and Key.Mod_Mask
         if (key == Key.None)
             key = key.convertSingleModFlagToKey()
         //        IM_ASSERT(IsNamedKey(key))

--- a/core/src/main/kotlin/imgui/api/itemWidgetsUtilities.kt
+++ b/core/src/main/kotlin/imgui/api/itemWidgetsUtilities.kt
@@ -1,11 +1,8 @@
 package imgui.api
 
 import glm_.vec2.Vec2
-import imgui.HoveredFlags
-import imgui.ID
+import imgui.*
 import imgui.ImGui.isMouseClicked
-import imgui.MouseButton
-import imgui.emptyFlags
 import imgui.internal.sections.ItemFlag
 import imgui.internal.sections.ItemStatusFlag
 import imgui.HoveredFlag as Hf
@@ -20,7 +17,7 @@ interface itemWidgetsUtilities {
      *          such as a text() item still returns true with isItemHovered()
      *      - this should work even for non-interactive items that have no ID, so we cannot use LastItemId  */
 
-    fun isItemHovered(flags: HoveredFlags = emptyFlags()): Boolean {
+    fun isItemHovered(flags: ItemHoveredFlags = emptyFlags): Boolean {
 
         val window = g.currentWindow!!
         if (g.navDisableMouseHover && !g.navDisableHighlight && flags hasnt Hf.NoNavOverride) {
@@ -34,7 +31,6 @@ interface itemWidgetsUtilities {
             val statusFlags = g.lastItemData.statusFlags
             if (statusFlags hasnt ItemStatusFlag.HoveredRect)
                 return false
-            assert(flags hasnt (Hf.AnyWindow or Hf.RootWindow or Hf.ChildWindows or Hf.NoPopupHierarchy)) { "Flags not supported by this function" }
 
             // Done with rectangle culling so we can perform heavier checks now
             // Test if we are hovering the right window (our window could be behind another window)

--- a/core/src/main/kotlin/imgui/api/itemWidgetsUtilities.kt
+++ b/core/src/main/kotlin/imgui/api/itemWidgetsUtilities.kt
@@ -1,15 +1,13 @@
 package imgui.api
 
-import glm_.hasnt
 import glm_.vec2.Vec2
+import imgui.HoveredFlags
 import imgui.ID
 import imgui.ImGui.isMouseClicked
 import imgui.MouseButton
-import imgui.has
-import imgui.hasnt
+import imgui.emptyFlags
 import imgui.internal.sections.ItemFlag
 import imgui.internal.sections.ItemStatusFlag
-import imgui.or
 import imgui.HoveredFlag as Hf
 
 // Item/Widgets Utilities and Query Functions
@@ -21,9 +19,8 @@ interface itemWidgetsUtilities {
      *      - we allow hovering to be true when activeId==window.moveID, so that clicking on non-interactive items
      *          such as a text() item still returns true with isItemHovered()
      *      - this should work even for non-interactive items that have no ID, so we cannot use LastItemId  */
-    fun isItemHovered(flags: Hf) = isItemHovered(flags.i)
 
-    fun isItemHovered(flags: Int = Hf.None.i): Boolean {
+    fun isItemHovered(flags: HoveredFlags = emptyFlags()): Boolean {
 
         val window = g.currentWindow!!
         if (g.navDisableMouseHover && !g.navDisableHighlight && flags hasnt Hf.NoNavOverride) {
@@ -87,6 +84,9 @@ interface itemWidgetsUtilities {
         return true
     }
 
+    val isItemHovered : Boolean
+        get() = isItemHovered()
+
     /** Is the last item active? (e.g. button being held, text field being edited.
      *  This will continuously return true while holding mouse button on an item. Items that don't interact will always return false) */
     val isItemActive: Boolean
@@ -103,7 +103,7 @@ interface itemWidgetsUtilities {
      *  Important: this can be useful but it is NOT equivalent to the behavior of e.g.Button()!
      *  Most widgets have specific reactions based on mouse-up/down state, mouse position etc. */
     fun isItemClicked(mouseButton: MouseButton = MouseButton.Left): Boolean =
-        isMouseClicked(mouseButton) && isItemHovered(Hf.None)
+        isMouseClicked(mouseButton) && isItemHovered()
 
     /** Is the last item visible? (items may be out of sight because of clipping/scrolling)    */
     val isItemVisible: Boolean

--- a/core/src/main/kotlin/imgui/api/main.kt
+++ b/core/src/main/kotlin/imgui/api/main.kt
@@ -1,7 +1,6 @@
 package imgui.api
 
 import glm_.f
-import glm_.hasnt
 import glm_.max
 import glm_.min
 import glm_.vec2.Vec2
@@ -32,10 +31,10 @@ import imgui.classes.ContextHookType
 import imgui.classes.IO
 import imgui.classes.Style
 import imgui.font.FontAtlas
-import imgui.internal.*
+import imgui.internal.DrawData
 import imgui.internal.classes.Rect
+import imgui.internal.sections.DrawListFlags
 import imgui.internal.sections.IMGUI_DEBUG_LOG_ACTIVEID
-import imgui.internal.sections.ItemFlag
 import imgui.static.*
 import org.lwjgl.system.Platform
 import imgui.WindowFlag as Wf
@@ -101,10 +100,10 @@ interface main {
         g.drawListSharedData.clipRectFullscreen = virtualSpace.toVec4()
         g.drawListSharedData.curveTessellationTol = style.curveTessellationTol
         g.drawListSharedData.setCircleTessellationMaxError_(style.circleTessellationMaxError)
-        var flags = Dlf.None.i
+        var flags: DrawListFlags = emptyFlags()
         if (style.antiAliasedLines)
             flags = flags or Dlf.AntiAliasedLines
-        if (style.antiAliasedLinesUseTex && g.font.containerAtlas.flags hasnt FontAtlas.Flag.NoBakedLines.i)
+        if (style.antiAliasedLinesUseTex && g.font.containerAtlas.flags hasnt FontAtlas.Flag.NoBakedLines)
             flags = flags or Dlf.AntiAliasedLinesUseTex
         if (style.antiAliasedFill)
             flags = flags or Dlf.AntiAliasedFill
@@ -261,7 +260,7 @@ interface main {
         g.currentWindowStack.clear()
         g.beginPopupStack.clear()
         g.itemFlagsStack.clear()
-        g.itemFlagsStack += ItemFlag.None.i
+        g.itemFlagsStack += emptyFlags()
         g.groupStack.clear()
 
         // // [DEBUG] Update debug features

--- a/core/src/main/kotlin/imgui/api/main.kt
+++ b/core/src/main/kotlin/imgui/api/main.kt
@@ -40,8 +40,6 @@ import org.lwjgl.system.Platform
 import imgui.WindowFlag as Wf
 import imgui.internal.sections.DrawListFlag as Dlf
 
-@Suppress("UNCHECKED_CAST")
-
 /** Main */
 interface main {
 
@@ -100,7 +98,7 @@ interface main {
         g.drawListSharedData.clipRectFullscreen = virtualSpace.toVec4()
         g.drawListSharedData.curveTessellationTol = style.curveTessellationTol
         g.drawListSharedData.setCircleTessellationMaxError_(style.circleTessellationMaxError)
-        var flags: DrawListFlags = emptyFlags()
+        var flags: DrawListFlags = emptyFlags
         if (style.antiAliasedLines)
             flags = flags or Dlf.AntiAliasedLines
         if (style.antiAliasedLinesUseTex && g.font.containerAtlas.flags hasnt FontAtlas.Flag.NoBakedLines)
@@ -260,7 +258,7 @@ interface main {
         g.currentWindowStack.clear()
         g.beginPopupStack.clear()
         g.itemFlagsStack.clear()
-        g.itemFlagsStack += emptyFlags()
+        g.itemFlagsStack += emptyFlags
         g.groupStack.clear()
 
         // // [DEBUG] Update debug features

--- a/core/src/main/kotlin/imgui/api/miscellaneousUtilities.kt
+++ b/core/src/main/kotlin/imgui/api/miscellaneousUtilities.kt
@@ -53,7 +53,7 @@ interface miscellaneousUtilities {
 
 
     /** helper to create a child window / scrolling region that looks like a normal widget frame    */
-    fun beginChildFrame(id: ID, size: Vec2, extraFlags: WindowFlags = emptyFlags()): Boolean {
+    fun beginChildFrame(id: ID, size: Vec2, extraFlags: WindowFlags = emptyFlags): Boolean {
         pushStyleColor(Col.ChildBg, style.colors[Col.FrameBg])
         pushStyleVar(StyleVar.ChildRounding, style.frameRounding)
         pushStyleVar(StyleVar.ChildBorderSize, style.frameBorderSize)

--- a/core/src/main/kotlin/imgui/api/miscellaneousUtilities.kt
+++ b/core/src/main/kotlin/imgui/api/miscellaneousUtilities.kt
@@ -53,7 +53,7 @@ interface miscellaneousUtilities {
 
 
     /** helper to create a child window / scrolling region that looks like a normal widget frame    */
-    fun beginChildFrame(id: ID, size: Vec2, extraFlags: WindowFlags = 0): Boolean {
+    fun beginChildFrame(id: ID, size: Vec2, extraFlags: WindowFlags = emptyFlags()): Boolean {
         pushStyleColor(Col.ChildBg, style.colors[Col.FrameBg])
         pushStyleVar(StyleVar.ChildRounding, style.frameRounding)
         pushStyleVar(StyleVar.ChildBorderSize, style.frameBorderSize)

--- a/core/src/main/kotlin/imgui/api/parametersStacks.kt
+++ b/core/src/main/kotlin/imgui/api/parametersStacks.kt
@@ -215,14 +215,14 @@ interface parametersStacks {
     /** FIXME: Look into renaming this once we have settled the new Focus/Activation/TabStop system.
      *
      *  == tab stop enable. Allow focusing using TAB/Shift-TAB, enabled by default but you can disable it for certain widgets */
-    fun pushAllowKeyboardFocus(allowKeyboardFocus: Boolean) = pushItemFlag(If.NoTabStop.i, !allowKeyboardFocus)
+    fun pushAllowKeyboardFocus(allowKeyboardFocus: Boolean) = pushItemFlag(If.NoTabStop, !allowKeyboardFocus)
 
     fun popAllowKeyboardFocus() = popItemFlag()
 
     /** in 'repeat' mode, Button*() functions return repeated true in a typematic manner
      *  (using io.KeyRepeatDelay/io.KeyRepeatRate setting). Note that you can call IsItemActive() after any Button() to
      *  tell if the button is held in the current frame.    */
-    fun pushButtonRepeat(repeat: Boolean) = pushItemFlag(If.ButtonRepeat.i, repeat)
+    fun pushButtonRepeat(repeat: Boolean) = pushItemFlag(If.ButtonRepeat, repeat)
 
     fun popButtonRepeat() = popItemFlag()
 

--- a/core/src/main/kotlin/imgui/api/popupsModals.kt
+++ b/core/src/main/kotlin/imgui/api/popupsModals.kt
@@ -38,7 +38,7 @@ import imgui.WindowFlag as Wf
 interface popupsModals {
 
     /** return true if the popup is open, and you can start outputting to it. */
-    fun beginPopup(strId: String, flags_: WindowFlags = emptyFlags()): Boolean {
+    fun beginPopup(strId: String, flags_: WindowFlags = emptyFlags): Boolean {
         if (g.openPopupStack.size <= g.beginPopupStack.size) {    // Early out for performance
             g.nextWindowData.clearFlags()    // We behave like Begin() and need to consume those values
             return false
@@ -52,7 +52,7 @@ interface popupsModals {
      *
      *  If 'p_open' is specified for a modal popup window, the popup will have a regular close button which will close the popup.
      *  Note that popup visibility status is owned by Dear ImGui (and manipulated with e.g. OpenPopup) so the actual value of *p_open is meaningless here.   */
-    fun beginPopupModal(name: String, pOpen: KMutableProperty0<Boolean>? = null, flags_: WindowFlags = emptyFlags()): Boolean {
+    fun beginPopupModal(name: String, pOpen: KMutableProperty0<Boolean>? = null, flags_: WindowFlags = emptyFlags): Boolean {
 
         val window = g.currentWindow!!
         val id = window.getID(name)
@@ -110,14 +110,14 @@ interface popupsModals {
     //  - IMPORTANT: Notice that for OpenPopupOnItemClick() we exceptionally default flags to 1 (== ImGuiPopupFlags_MouseButtonRight) for backward compatibility with older API taking 'int mouse_button = 1' parameter
 
     /** call to mark popup as open (don't call every frame!). */
-    fun openPopup(strId: String, popupFlags: PopupFlags = emptyFlags()) {
+    fun openPopup(strId: String, popupFlags: PopupFlags = emptyFlags) {
         val id = g.currentWindow!!.getID(strId)
         IMGUI_DEBUG_LOG_POPUP("[popup] OpenPopup(\"$strId\" -> 0x%08X)", id)
         openPopupEx(id, popupFlags)
     }
 
     /** id overload to facilitate calling from nested stacks */
-    fun openPopup(id: ID, popupFlags: PopupFlags = emptyFlags()) = openPopupEx(id, popupFlags)
+    fun openPopup(id: ID, popupFlags: PopupFlags = emptyFlags) = openPopupEx(id, popupFlags)
 
     /** helper to open popup when clicked on last item. Default to ImGuiPopupFlags_MouseButtonRight == 1.
      *  (note: actually triggers on the mouse _released_ event to be consistent with popup behaviors)
@@ -237,7 +237,7 @@ interface popupsModals {
 
 
     /** return true if the popup is open. */
-    fun isPopupOpen(strId: String, popupFlags: PopupFlags = emptyFlags()): Boolean {
+    fun isPopupOpen(strId: String, popupFlags: PopupFlags = emptyFlags): Boolean {
         val id = if (popupFlags has PopupFlag.AnyPopupId) 0 else g.currentWindow!!.getID(strId)
         if (popupFlags has PopupFlag.AnyPopupLevel && id != 0)
             assert(false) { "Cannot use IsPopupOpen() with a string id and ImGuiPopupFlags_AnyPopupLevel." } // But non-string version is legal and used internally

--- a/core/src/main/kotlin/imgui/api/tabBarsTabs.kt
+++ b/core/src/main/kotlin/imgui/api/tabBarsTabs.kt
@@ -20,7 +20,7 @@ import kotlin.reflect.KMutableProperty0
 interface tabBarsTabs {
 
     /** create and append into a TabBar */
-    fun beginTabBar(strId: String, flags: TabBarFlags = 0): Boolean {
+    fun beginTabBar(strId: String, flags: TabBarFlags = emptyFlags()): Boolean {
 
         val window = g.currentWindow!!
         if (window.skipItems) return false
@@ -62,11 +62,11 @@ interface tabBarsTabs {
     }
 
     /** create a Tab. Returns true if the Tab is selected. */
-    fun beginTabItem(label: String, pOpen: BooleanArray, index: Int, flags: TabItemFlags = 0): Boolean =
-            beginTabItem(label, pOpen mutablePropertyAt index, flags)
+    fun beginTabItem(label: String, pOpen: BooleanArray, index: Int, flags: TabItemFlags = emptyFlags()): Boolean =
+        beginTabItem(label, pOpen mutablePropertyAt index, flags)
 
     /** create a Tab. Returns true if the Tab is selected. */
-    fun beginTabItem(label: String, pOpen: KMutableProperty0<Boolean>? = null, flags: TabItemFlags = 0): Boolean {
+    fun beginTabItem(label: String, pOpen: KMutableProperty0<Boolean>? = null, flags: TabItemFlags = emptyFlags()): Boolean {
 
         val window = g.currentWindow!!
         if (window.skipItems)
@@ -97,7 +97,7 @@ interface tabBarsTabs {
     }
 
     /** create a Tab behaving like a button. return true when clicked. cannot be selected in the tab bar. */
-    fun tabItemButton(label: String, flags: TabItemFlags = TabItemFlag.None.i): Boolean {
+    fun tabItemButton(label: String, flags: TabItemFlags = emptyFlags()): Boolean {
 
         val window = g.currentWindow!!
         if (window.skipItems)

--- a/core/src/main/kotlin/imgui/api/tabBarsTabs.kt
+++ b/core/src/main/kotlin/imgui/api/tabBarsTabs.kt
@@ -20,7 +20,7 @@ import kotlin.reflect.KMutableProperty0
 interface tabBarsTabs {
 
     /** create and append into a TabBar */
-    fun beginTabBar(strId: String, flags: TabBarFlags = emptyFlags()): Boolean {
+    fun beginTabBar(strId: String, flags: TabBarFlags = emptyFlags): Boolean {
 
         val window = g.currentWindow!!
         if (window.skipItems) return false
@@ -62,18 +62,17 @@ interface tabBarsTabs {
     }
 
     /** create a Tab. Returns true if the Tab is selected. */
-    fun beginTabItem(label: String, pOpen: BooleanArray, index: Int, flags: TabItemFlags = emptyFlags()): Boolean =
+    fun beginTabItem(label: String, pOpen: BooleanArray, index: Int, flags: TabItemOnlyFlags = emptyFlags): Boolean =
         beginTabItem(label, pOpen mutablePropertyAt index, flags)
 
     /** create a Tab. Returns true if the Tab is selected. */
-    fun beginTabItem(label: String, pOpen: KMutableProperty0<Boolean>? = null, flags: TabItemFlags = emptyFlags()): Boolean {
+    fun beginTabItem(label: String, pOpen: KMutableProperty0<Boolean>? = null, flags: TabItemOnlyFlags = emptyFlags): Boolean {
 
         val window = g.currentWindow!!
         if (window.skipItems)
             return false
 
         val tabBar = g.currentTabBar ?: error("Needs to be called between BeginTabBar() and EndTabBar()!")
-        assert(flags hasnt TabItemFlag._Button) { "BeginTabItem() Can't be used with button flags, use TabItemButton() instead!" }
 
         val ret = tabBar.tabItemEx(label, pOpen, flags, null)
         if (ret && flags hasnt TabItemFlag.NoPushId) {
@@ -97,7 +96,7 @@ interface tabBarsTabs {
     }
 
     /** create a Tab behaving like a button. return true when clicked. cannot be selected in the tab bar. */
-    fun tabItemButton(label: String, flags: TabItemFlags = emptyFlags()): Boolean {
+    fun tabItemButton(label: String, flags: TabItemOnlyFlags = emptyFlags): Boolean {
 
         val window = g.currentWindow!!
         if (window.skipItems)

--- a/core/src/main/kotlin/imgui/api/tables.kt
+++ b/core/src/main/kotlin/imgui/api/tables.kt
@@ -387,7 +387,7 @@ interface tables {
 
         // Assert when passing a width or weight if policy is entirely left to default, to avoid storing width into weight and vice-versa.
         // Give a grace to users of ImGuiTableFlags_ScrollX.
-        if (table.isDefaultSizingPolicy && flags hasnt Tcf.WidthMask && flags hasnt Tcf.IsEnabled)
+        if (table.isDefaultSizingPolicy && flags hasnt Tcf.WidthMask && table.flags hasnt Tf.ScrollX)
             assert(initWidthOrWeight <= 0f) { "Can only specify width/weight if sizing policy is set explicitly in either Table or Column." }
 
         // When passing a width automatically enforce WidthFixed policy

--- a/core/src/main/kotlin/imgui/api/tooltips.kt
+++ b/core/src/main/kotlin/imgui/api/tooltips.kt
@@ -4,7 +4,6 @@ import imgui.ImGui.beginTooltipEx
 import imgui.ImGui.currentWindowRead
 import imgui.ImGui.end
 import imgui.ImGui.text
-import imgui.has
 import imgui.internal.sections.TooltipFlag
 import imgui.WindowFlag as Wf
 
@@ -13,7 +12,7 @@ import imgui.WindowFlag as Wf
 interface tooltips {
 
     /** begin/append a tooltip window. to create full-featured tooltip (with any kind of items). */
-    fun beginTooltip() = beginTooltipEx(TooltipFlag.None.i, Wf.None.i)
+    fun beginTooltip() = beginTooltipEx()
 
     fun endTooltip() {
         assert(currentWindowRead!!.flags has Wf._Tooltip) { "Mismatched BeginTooltip()/EndTooltip() calls" }
@@ -22,7 +21,7 @@ interface tooltips {
 
     /** set a text-only tooltip, typically use with ImGui::IsItemHovered(). override any previous call to SetTooltip(). */
     fun setTooltip(fmt: String, vararg args: Any) {
-        beginTooltipEx(TooltipFlag.OverridePreviousTooltip.i, Wf.None.i)
+        beginTooltipEx(TooltipFlag.OverridePreviousTooltip)
         text(fmt, *args)
         endTooltip()
     }

--- a/core/src/main/kotlin/imgui/api/tooltips.kt
+++ b/core/src/main/kotlin/imgui/api/tooltips.kt
@@ -4,6 +4,7 @@ import imgui.ImGui.beginTooltipEx
 import imgui.ImGui.currentWindowRead
 import imgui.ImGui.end
 import imgui.ImGui.text
+import imgui.has
 import imgui.internal.sections.TooltipFlag
 import imgui.WindowFlag as Wf
 

--- a/core/src/main/kotlin/imgui/api/widgetsColorEditorPicker.kt
+++ b/core/src/main/kotlin/imgui/api/widgetsColorEditorPicker.kt
@@ -85,21 +85,21 @@ interface widgetsColorEditorPicker {
     /** 3-4 components color edition. Click on colored squared to open a color picker, right-click for options.
      *  Hint: 'float col[3]' function argument is same as 'float* col'.
      *  You can pass address of first element out of a contiguous set, e.g. &myvector.x */
-    fun colorEdit3(label: String, col: Vec4, flags: ColorEditFlags = emptyFlags()): Boolean =
+    fun colorEdit3(label: String, col: Vec4, flags: ColorEditFlags = emptyFlags): Boolean =
         colorEdit4(label, col to _fa, flags or Cef.NoAlpha)
             .also { col put _fa }
 
-    fun colorEdit3(label: String, col: FloatArray, flags: ColorEditFlags = emptyFlags()): Boolean =
+    fun colorEdit3(label: String, col: FloatArray, flags: ColorEditFlags = emptyFlags): Boolean =
         colorEdit4(label, col, flags or Cef.NoAlpha)
 
     /** Edit colors components (each component in 0.0f..1.0f range).
      *  See enum ImGuiColorEditFlags_ for available options. e.g. Only access 3 floats if ColorEditFlags.NoAlpha flag is set.
      *  With typical options: Left-click on color square to open color picker. Right-click to open option menu.
      *  CTRL-Click over input fields to edit them and TAB to go to next item.   */
-    fun colorEdit4(label: String, col: Vec4, flags: ColorEditFlags = emptyFlags()): Boolean =
+    fun colorEdit4(label: String, col: Vec4, flags: ColorEditFlags = emptyFlags): Boolean =
         colorEdit4(label, col to _fa, flags).also { col put _fa }
 
-    fun colorEdit4(label: String, col: FloatArray, flags_: ColorEditFlags = emptyFlags()): Boolean {
+    fun colorEdit4(label: String, col: FloatArray, flags_: ColorEditFlags = emptyFlags): Boolean {
 
         val window = currentWindow
         if (window.skipItems)
@@ -315,7 +315,7 @@ interface widgetsColorEditorPicker {
         }
     }
 
-    fun colorEditVec4(label: String, col: Vec4, flags: ColorEditFlags = emptyFlags()): Boolean {
+    fun colorEditVec4(label: String, col: Vec4, flags: ColorEditFlags = emptyFlags): Boolean {
         val col4 = floatArrayOf(col.x, col.y, col.z, col.w)
         val valueChanged = colorEdit4(label, col4, flags)
         col.x = col4[0]
@@ -325,11 +325,11 @@ interface widgetsColorEditorPicker {
         return valueChanged
     }
 
-    fun colorPicker3(label: String, col: Vec4, flags: ColorEditFlags = emptyFlags()): Boolean =
+    fun colorPicker3(label: String, col: Vec4, flags: ColorEditFlags = emptyFlags): Boolean =
         colorPicker3(label, col to _fa, flags)
             .also { col put _fa }
 
-    fun colorPicker3(label: String, col: FloatArray, flags: ColorEditFlags = emptyFlags()): Boolean {
+    fun colorPicker3(label: String, col: FloatArray, flags: ColorEditFlags = emptyFlags): Boolean {
         val col4 = floatArrayOf(*col, 1f)
         if (!colorPicker4(label, col4, flags or Cef.NoAlpha)) return false
         col[0] = col4[0]; col[1] = col4[1]; col[2] = col4[2]
@@ -342,7 +342,7 @@ interface widgetsColorEditorPicker {
      *  FIXME: we adjust the big color square height based on item width, which may cause a flickering feedback loop
      *  (if automatic height makes a vertical scrollbar appears, affecting automatic width..)
      *  FIXME: this is trying to be aware of style.Alpha but not fully correct. Also, the color wheel will have overlapping glitches with (style.Alpha < 1.0)   */
-    fun colorPicker4(label: String, col: Vec4, flags: ColorEditFlags = emptyFlags(), refCol: Vec4? = null): Boolean =
+    fun colorPicker4(label: String, col: Vec4, flags: ColorEditFlags = emptyFlags, refCol: Vec4? = null): Boolean =
         colorPicker4(label, col to _fa, flags, refCol?.to(_fa2))
             .also { col put _fa; refCol?.put(_fa2) }
 
@@ -352,7 +352,7 @@ interface widgetsColorEditorPicker {
      *  FIXME: we adjust the big color square height based on item width, which may cause a flickering feedback loop
      *  (if automatic height makes a vertical scrollbar appears, affecting automatic width..)
      *  FIXME: this is trying to be aware of style.Alpha but not fully correct. Also, the color wheel will have overlapping glitches with (style.Alpha < 1.0)   */
-    fun colorPicker4(label: String, col: FloatArray, flags_: ColorEditFlags = emptyFlags(), refCol: FloatArray? = null): Boolean {
+    fun colorPicker4(label: String, col: FloatArray, flags_: ColorEditFlags = emptyFlags, refCol: FloatArray? = null): Boolean {
 
         val window = currentWindow
         if (window.skipItems)
@@ -629,7 +629,7 @@ interface widgetsColorEditorPicker {
             val cosHueAngle = glm.cos(H * 2f * glm.PIf)
             val sinHueAngle = glm.sin(H * 2f * glm.PIf)
             val hueCursorPos = Vec2(wheelCenter.x + cosHueAngle * (wheelRInner + wheelROuter) * 0.5f,
-                                    wheelCenter.y + sinHueAngle * (wheelRInner + wheelROuter) * 0.5f)
+                wheelCenter.y + sinHueAngle * (wheelRInner + wheelROuter) * 0.5f)
             val hueCursorRad = wheelThickness * if (valueChangedH) 0.65f else 0.55f
             val hueCursorSegments = glm.clamp((hueCursorRad / 1.4f).i, 9, 32)
             drawList.addCircleFilled(hueCursorPos, hueCursorRad, hueColor32, hueCursorSegments)
@@ -705,7 +705,7 @@ interface widgetsColorEditorPicker {
      *  FIXME: May want to display/ignore the alpha component in the color display? Yet show it in the tooltip.
      *  'desc_id' is not called 'label' because we don't display it next to the button, but only in the tooltip.
      *  Note that 'col' may be encoded in HSV if ImGuiColorEditFlags_InputHSV is set.   */
-    fun colorButton(descId: String, col: Vec4, flags_: ColorEditFlags = emptyFlags(), sizeArg: Vec2 = Vec2()): Boolean {
+    fun colorButton(descId: String, col: Vec4, flags_: ColorEditFlags = emptyFlags, sizeArg: Vec2 = Vec2()): Boolean {
 
         val window = currentWindow
         if (window.skipItems)

--- a/core/src/main/kotlin/imgui/api/widgetsColorEditorPicker.kt
+++ b/core/src/main/kotlin/imgui/api/widgetsColorEditorPicker.kt
@@ -1,6 +1,5 @@
 package imgui.api
 
-import gli_.has
 import glm_.func.cos
 import glm_.func.sin
 import glm_.glm
@@ -66,7 +65,6 @@ import imgui.ImGui.style
 import imgui.ImGui.text
 import imgui.ImGui.textEx
 import imgui.classes.DrawList
-import imgui.has
 import imgui.internal.*
 import imgui.internal.classes.Rect
 import imgui.internal.classes.Window
@@ -87,21 +85,21 @@ interface widgetsColorEditorPicker {
     /** 3-4 components color edition. Click on colored squared to open a color picker, right-click for options.
      *  Hint: 'float col[3]' function argument is same as 'float* col'.
      *  You can pass address of first element out of a contiguous set, e.g. &myvector.x */
-    fun colorEdit3(label: String, col: Vec4, flags: ColorEditFlags = 0): Boolean =
-            colorEdit4(label, col to _fa, flags or Cef.NoAlpha)
-                    .also { col put _fa }
+    fun colorEdit3(label: String, col: Vec4, flags: ColorEditFlags = emptyFlags()): Boolean =
+        colorEdit4(label, col to _fa, flags or Cef.NoAlpha)
+            .also { col put _fa }
 
-    fun colorEdit3(label: String, col: FloatArray, flags: ColorEditFlags = 0): Boolean =
-            colorEdit4(label, col, flags or Cef.NoAlpha)
+    fun colorEdit3(label: String, col: FloatArray, flags: ColorEditFlags = emptyFlags()): Boolean =
+        colorEdit4(label, col, flags or Cef.NoAlpha)
 
     /** Edit colors components (each component in 0.0f..1.0f range).
      *  See enum ImGuiColorEditFlags_ for available options. e.g. Only access 3 floats if ColorEditFlags.NoAlpha flag is set.
      *  With typical options: Left-click on color square to open color picker. Right-click to open option menu.
      *  CTRL-Click over input fields to edit them and TAB to go to next item.   */
-    fun colorEdit4(label: String, col: Vec4, flags: ColorEditFlags = 0): Boolean =
-            colorEdit4(label, col to _fa, flags).also { col put _fa }
+    fun colorEdit4(label: String, col: Vec4, flags: ColorEditFlags = emptyFlags()): Boolean =
+        colorEdit4(label, col to _fa, flags).also { col put _fa }
 
-    fun colorEdit4(label: String, col: FloatArray, flags_: ColorEditFlags = 0): Boolean {
+    fun colorEdit4(label: String, col: FloatArray, flags_: ColorEditFlags = emptyFlags()): Boolean {
 
         val window = currentWindow
         if (window.skipItems)
@@ -184,7 +182,7 @@ interface widgetsColorEditorPicker {
                 } else
                     valueChanged /= dragInt(ids[n], i, n, 1f, 0, if (hdr) 0 else 255, fmtTableInt[fmtIdx][n])
                 if (flags hasnt Cef.NoOptions)
-                    openPopupOnItemClick("context", PopupFlag.MouseButtonRight.i)
+                    openPopupOnItemClick("context", PopupFlag.MouseButtonRight)
             }
 
         } else if (flags has Cef.DisplayHEX && flags hasnt Cef.NoInputs) {
@@ -205,7 +203,7 @@ interface widgetsColorEditorPicker {
                 str.substring(p).scanHex(i, if (alpha) 4 else 3, 2)   // Treat at unsigned (%X is unsigned)
             }
             if (flags hasnt Cef.NoOptions)
-                openPopupOnItemClick("context", PopupFlag.MouseButtonRight.i)
+                openPopupOnItemClick("context", PopupFlag.MouseButtonRight)
         }
 
         var pickerActiveWindow: Window? = null
@@ -225,7 +223,7 @@ interface widgetsColorEditorPicker {
                     setNextWindowPos(g.lastItemData.rect.bl + Vec2(0f, style.itemSpacing.y))
                 }
             if (flags hasnt Cef.NoOptions)
-                openPopupOnItemClick("context", PopupFlag.MouseButtonRight.i)
+                openPopupOnItemClick("context", PopupFlag.MouseButtonRight)
 
             if (beginPopup("picker"))
                 if (g.currentWindow!!.beginCount == 1) {
@@ -317,7 +315,7 @@ interface widgetsColorEditorPicker {
         }
     }
 
-    fun colorEditVec4(label: String, col: Vec4, flags: ColorEditFlags = 0): Boolean {
+    fun colorEditVec4(label: String, col: Vec4, flags: ColorEditFlags = emptyFlags()): Boolean {
         val col4 = floatArrayOf(col.x, col.y, col.z, col.w)
         val valueChanged = colorEdit4(label, col4, flags)
         col.x = col4[0]
@@ -327,11 +325,11 @@ interface widgetsColorEditorPicker {
         return valueChanged
     }
 
-    fun colorPicker3(label: String, col: Vec4, flags: ColorEditFlags = 0): Boolean =
-            colorPicker3(label, col to _fa, flags)
-                    .also { col put _fa }
+    fun colorPicker3(label: String, col: Vec4, flags: ColorEditFlags = emptyFlags()): Boolean =
+        colorPicker3(label, col to _fa, flags)
+            .also { col put _fa }
 
-    fun colorPicker3(label: String, col: FloatArray, flags: ColorEditFlags = 0): Boolean {
+    fun colorPicker3(label: String, col: FloatArray, flags: ColorEditFlags = emptyFlags()): Boolean {
         val col4 = floatArrayOf(*col, 1f)
         if (!colorPicker4(label, col4, flags or Cef.NoAlpha)) return false
         col[0] = col4[0]; col[1] = col4[1]; col[2] = col4[2]
@@ -344,9 +342,9 @@ interface widgetsColorEditorPicker {
      *  FIXME: we adjust the big color square height based on item width, which may cause a flickering feedback loop
      *  (if automatic height makes a vertical scrollbar appears, affecting automatic width..)
      *  FIXME: this is trying to be aware of style.Alpha but not fully correct. Also, the color wheel will have overlapping glitches with (style.Alpha < 1.0)   */
-    fun colorPicker4(label: String, col: Vec4, flags: ColorEditFlags = 0, refCol: Vec4? = null): Boolean =
-            colorPicker4(label, col to _fa, flags, refCol?.to(_fa2))
-                    .also { col put _fa; refCol?.put(_fa2) }
+    fun colorPicker4(label: String, col: Vec4, flags: ColorEditFlags = emptyFlags(), refCol: Vec4? = null): Boolean =
+        colorPicker4(label, col to _fa, flags, refCol?.to(_fa2))
+            .also { col put _fa; refCol?.put(_fa2) }
 
     /** ColorPicker
      *  Note: only access 3 floats if ImGuiColorEditFlags_NoAlpha flag is set.
@@ -354,7 +352,7 @@ interface widgetsColorEditorPicker {
      *  FIXME: we adjust the big color square height based on item width, which may cause a flickering feedback loop
      *  (if automatic height makes a vertical scrollbar appears, affecting automatic width..)
      *  FIXME: this is trying to be aware of style.Alpha but not fully correct. Also, the color wheel will have overlapping glitches with (style.Alpha < 1.0)   */
-    fun colorPicker4(label: String, col: FloatArray, flags_: ColorEditFlags = 0, refCol: FloatArray? = null): Boolean {
+    fun colorPicker4(label: String, col: FloatArray, flags_: ColorEditFlags = emptyFlags(), refCol: FloatArray? = null): Boolean {
 
         val window = currentWindow
         if (window.skipItems)
@@ -378,9 +376,9 @@ interface widgetsColorEditorPicker {
 
         // Read stored options
         if (flags hasnt Cef._PickerMask)
-            flags = flags or ((if (g.colorEditOptions has Cef._PickerMask) g.colorEditOptions else Cef.DefaultOptions.i) and Cef._PickerMask)
+            flags = flags or ((if (g.colorEditOptions has Cef._PickerMask) g.colorEditOptions else Cef.DefaultOptions) and Cef._PickerMask)
         if (flags hasnt Cef._InputMask)
-            flags = flags or ((if (g.colorEditOptions has Cef._InputMask) g.colorEditOptions else Cef.DefaultOptions.i) and Cef._InputMask)
+            flags = flags or ((if (g.colorEditOptions has Cef._InputMask) g.colorEditOptions else Cef.DefaultOptions) and Cef._InputMask)
         assert((flags and Cef._PickerMask).isPowerOfTwo) { "Check that only 1 is selected" }
         assert((flags and Cef._InputMask).isPowerOfTwo)  // Check that only 1 is selected
         if (flags hasnt Cef.NoOptions)
@@ -426,7 +424,7 @@ interface widgetsColorEditorPicker {
         var valueChangedH = false
         var valueChangedSv = false
 
-        pushItemFlag(ItemFlag.NoNav.i, true)
+        pushItemFlag(ItemFlag.NoNav, true)
         if (flags has Cef.PickerHueWheel) {
             // Hue wheel + SV triangle logic
             invisibleButton("hsv", Vec2(svPickerSize + style.itemInnerSpacing.x + barsWidth, svPickerSize))
@@ -457,7 +455,7 @@ interface widgetsColorEditorPicker {
                 }
             }
             if (flags hasnt Cef.NoOptions)
-                openPopupOnItemClick("context", PopupFlag.MouseButtonRight.i)
+                openPopupOnItemClick("context", PopupFlag.MouseButtonRight)
 
         } else if (flags has Cef.PickerHueBar) {
             // SV rectangle logic
@@ -472,7 +470,7 @@ interface widgetsColorEditorPicker {
                 valueChangedSv = true; valueChanged = true
             }
             if (flags hasnt Cef.NoOptions)
-                openPopupOnItemClick("context", PopupFlag.MouseButtonRight.i)
+                openPopupOnItemClick("context", PopupFlag.MouseButtonRight)
             // Hue bar logic
             cursorScreenPos = Vec2(bar0PosX, pickerPos.y)
             invisibleButton("hue", Vec2(barsWidth, svPickerSize))
@@ -508,7 +506,7 @@ interface widgetsColorEditorPicker {
             }
         }
         if (flags hasnt Cef.NoSidePreview) {
-            pushItemFlag(ItemFlag.NoNavDefaultFocus.i, true)
+            pushItemFlag(ItemFlag.NoNavDefaultFocus, true)
             val colV4 = Vec4(col[0], col[1], col[2], if (flags has Cef.NoAlpha) 1f else col[3])
             if (flags has Cef.NoLabel)
                 text("Current")
@@ -618,7 +616,7 @@ interface widgetsColorEditorPicker {
                 val a1 = (n + 1f) / 6f * 2f * glm.PIf + aeps
                 val vertStartIdx = drawList.vtxBuffer.size
                 drawList.pathArcTo(wheelCenter, (wheelRInner + wheelROuter) * 0.5f, a0, a1, segmentPerArc)
-                drawList.pathStroke(colWhite, 0, wheelThickness)
+                drawList.pathStroke(colWhite, thickness = wheelThickness)
                 val vertEndIdx = drawList.vtxBuffer.size
 
                 // Paint colors over existing vertices
@@ -707,7 +705,7 @@ interface widgetsColorEditorPicker {
      *  FIXME: May want to display/ignore the alpha component in the color display? Yet show it in the tooltip.
      *  'desc_id' is not called 'label' because we don't display it next to the button, but only in the tooltip.
      *  Note that 'col' may be encoded in HSV if ImGuiColorEditFlags_InputHSV is set.   */
-    fun colorButton(descId: String, col: Vec4, flags_: ColorEditFlags = 0, sizeArg: Vec2 = Vec2()): Boolean {
+    fun colorButton(descId: String, col: Vec4, flags_: ColorEditFlags = emptyFlags(), sizeArg: Vec2 = Vec2()): Boolean {
 
         val window = currentWindow
         if (window.skipItems)
@@ -725,7 +723,7 @@ interface widgetsColorEditorPicker {
 
         var flags = flags_
         if (flags has Cef.NoAlpha)
-            flags = flags and (Cef.AlphaPreview or Cef.AlphaPreviewHalf).inv()
+            flags = flags wo (Cef.AlphaPreview or Cef.AlphaPreviewHalf)
 
         val colRgb = Vec4(col)
         if (flags has Cef.InputHSV)
@@ -742,9 +740,11 @@ interface widgetsColorEditorPicker {
         }
         if (flags has Cef.AlphaPreviewHalf && colRgb.w < 1f) {
             val midX = round((bbInner.min.x + bbInner.max.x) * 0.5f)
-            renderColorRectWithAlphaCheckerboard(window.drawList, Vec2(bbInner.min.x + gridStep, bbInner.min.y), bbInner.max,
-                                                 getColorU32(colRgb), gridStep, Vec2(-gridStep + off, off), rounding, DrawFlag.RoundCornersRight.i)
-            window.drawList.addRectFilled(bbInner.min, Vec2(midX, bbInner.max.y), getColorU32(colRgbWithoutAlpha), rounding, DrawFlag.RoundCornersLeft.i)
+            renderColorRectWithAlphaCheckerboard(
+                window.drawList, Vec2(bbInner.min.x + gridStep, bbInner.min.y), bbInner.max,
+                getColorU32(colRgb), gridStep, Vec2(-gridStep + off, off), rounding, DrawFlag.RoundCornersRight
+            )
+            window.drawList.addRectFilled(bbInner.min, Vec2(midX, bbInner.max.y), getColorU32(colRgbWithoutAlpha), rounding, DrawFlag.RoundCornersLeft)
         } else {
             /*  Because getColorU32() multiplies by the global style alpha and we don't want to display a checkerboard 
                 if the source code had no alpha */

--- a/core/src/main/kotlin/imgui/api/widgetsComboBox.kt
+++ b/core/src/main/kotlin/imgui/api/widgetsComboBox.kt
@@ -43,7 +43,7 @@ import imgui.ComboFlag as Cf
 // - The old Combo() api are helpers over BeginCombo()/EndCombo() which are kept available for convenience purpose. This is analogous to how ListBox are created.
 interface widgetsComboBox {
 
-    fun beginCombo(label: String, previewValue_: String?, flags: ComboFlags = emptyFlags()): Boolean {
+    fun beginCombo(label: String, previewValue_: String?, flags: ComboFlags = emptyFlags): Boolean {
 
         var previewValue = previewValue_
 

--- a/core/src/main/kotlin/imgui/api/widgetsComboBox.kt
+++ b/core/src/main/kotlin/imgui/api/widgetsComboBox.kt
@@ -28,11 +28,10 @@ import imgui.ImGui.setItemDefaultFocus
 import imgui.ImGui.setNextWindowSizeConstraints
 import imgui.ImGui.style
 import imgui.classes.SizeCallbackData
-import imgui.has
-import imgui.hasnt
 import imgui.internal.classes.Rect
 import imgui.internal.hashStr
-import imgui.internal.sections.*
+import imgui.internal.sections.DrawFlag
+import imgui.internal.sections.NextWindowDataFlag
 import kool.getValue
 import kool.setValue
 import uno.kotlin.NUL
@@ -44,10 +43,9 @@ import imgui.ComboFlag as Cf
 // - The old Combo() api are helpers over BeginCombo()/EndCombo() which are kept available for convenience purpose. This is analogous to how ListBox are created.
 interface widgetsComboBox {
 
-    fun beginCombo(label: String, previewValue_: String?, flags_: ComboFlags = 0): Boolean {
+    fun beginCombo(label: String, previewValue_: String?, flags: ComboFlags = emptyFlags()): Boolean {
 
         var previewValue = previewValue_
-        var flags = flags_
 
         val window = currentWindow
 
@@ -57,7 +55,7 @@ interface widgetsComboBox {
             return false
 
         val id = window.getID(label)
-        assert(flags and (Cf.NoArrowButton or Cf.NoPreview) != Cf.NoArrowButton or Cf.NoPreview) { "Can't use both flags together" }
+        assert(Cf.NoArrowButton or Cf.NoPreview !in flags) { "Can't use both flags together" }
 
         val arrowSize = if (flags has Cf.NoArrowButton) 0f else frameHeight
         val labelSize = calcTextSize(label, hideTextAfterDoubleHash = true)
@@ -71,9 +69,9 @@ interface widgetsComboBox {
         // Open on click
         val (pressed, hovered, _) = buttonBehavior(bb, id)
         val popupId = hashStr("##ComboPopup", 0, id)
-        var popupOpen = isPopupOpen(popupId, PopupFlag.None.i)
+        var popupOpen = isPopupOpen(popupId)
         if (pressed && !popupOpen) {
-            openPopupEx(popupId, PopupFlag.None.i)
+            openPopupEx(popupId)
             popupOpen = true
         }
 
@@ -82,11 +80,22 @@ interface widgetsComboBox {
         val valueX2 = bb.min.x max (bb.max.x - arrowSize)
         renderNavHighlight(bb, id)
         if (flags hasnt Cf.NoPreview)
-            window.drawList.addRectFilled(bb.min, Vec2(valueX2, bb.max.y), frameCol.u32,
-                                          style.frameRounding, if (flags has Cf.NoArrowButton) DrawFlag.RoundCornersAll.i else DrawFlag.RoundCornersLeft.i)
+            window.drawList.addRectFilled(
+                bb.min,
+                Vec2(valueX2, bb.max.y),
+                frameCol.u32,
+                style.frameRounding,
+                if (flags has Cf.NoArrowButton) DrawFlag.RoundCornersAll else DrawFlag.RoundCornersLeft
+            )
         if (flags hasnt Cf.NoArrowButton) {
             val bgCol = if (popupOpen || hovered) Col.ButtonHovered else Col.Button
-            window.drawList.addRectFilled(Vec2(valueX2, bb.min.y), bb.max, bgCol.u32, style.frameRounding, if (w <= arrowSize) DrawFlag.RoundCornersAll.i else DrawFlag.RoundCornersRight.i)
+            window.drawList.addRectFilled(
+                Vec2(valueX2, bb.min.y),
+                bb.max,
+                bgCol.u32,
+                style.frameRounding,
+                if (w <= arrowSize) DrawFlag.RoundCornersAll else DrawFlag.RoundCornersRight
+            )
             if (valueX2 + arrowSize - style.framePadding.x <= bb.max.x)
                 window.drawList.renderArrow(Vec2(valueX2 + style.framePadding.y, bb.min.y + style.framePadding.y), Col.Text.u32, Dir.Down, 1f)
         }
@@ -156,7 +165,7 @@ interface widgetsComboBox {
         if (popupMaxHeightInItem != -1 && g.nextWindowData.flags hasnt NextWindowDataFlag.HasSizeConstraint)
             setNextWindowSizeConstraints(Vec2(), Vec2(Float.MAX_VALUE, calcMaxPopupHeightFromItemCount(popupMaxHeightInItem)))
 
-        if (!beginCombo(label, previewValue, Cf.None.i)) return false
+        if (!beginCombo(label, previewValue)) return false
 
         // Display items
         // FIXME-OPT: Use clipper (but we need to disable it on the appearing frame to make sure our call to setItemDefaultFocus() is processed)
@@ -190,7 +199,7 @@ interface widgetsComboBox {
         if (popupMaxHeightInItems != -1 && g.nextWindowData.flags hasnt NextWindowDataFlag.HasSizeConstraint)
             setNextWindowSizeConstraints(Vec2(), Vec2(Float.MAX_VALUE, calcMaxPopupHeightFromItemCount(popupMaxHeightInItems)))
 
-        if (!beginCombo(label, previewValue, Cf.None.i))
+        if (!beginCombo(label, previewValue))
             return false
 
         // Display items

--- a/core/src/main/kotlin/imgui/api/widgetsDrags.kt
+++ b/core/src/main/kotlin/imgui/api/widgetsDrags.kt
@@ -59,14 +59,14 @@ interface widgetsDrags {
     /** If v_min >= v_max we have no bound */
     fun dragFloat(
         label: String, v: KMutableProperty0<Float>, vSpeed: Float = 1f, vMin: Float = 0f,
-        vMax: Float = 0f, format: String? = "%.3f", flags: SliderFlags = emptyFlags()
+        vMax: Float = 0f, format: String? = "%.3f", flags: SliderFlags = emptyFlags
     ): Boolean =
         dragScalar(label, DataType.Float, v, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
 
     /** If v_min >= v_max we have no bound */
     fun dragFloat(
         label: String, v: FloatArray, ptr: Int, vSpeed: Float = 1f, vMin: Float = 0f,
-        vMax: Float = 0f, format: String = "%.3f", flags: SliderFlags = emptyFlags()
+        vMax: Float = 0f, format: String = "%.3f", flags: SliderFlags = emptyFlags
     ): Boolean =
         withFloat(v, ptr) { pV ->
             dragScalar(label, DataType.Float, pV, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
@@ -74,39 +74,39 @@ interface widgetsDrags {
 
     fun dragFloat2(
         label: String, v: FloatArray, vSpeed: Float = 1f, vMin: Float = 0f, vMax: Float = 0f,
-        format: String = "%.3f", flags: SliderFlags = emptyFlags()
+        format: String = "%.3f", flags: SliderFlags = emptyFlags
     ): Boolean =
         dragScalarN(label, DataType.Float, v, 2, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
 
     fun dragVec2(
         label: String, v: Vec2, vSpeed: Float = 1f, vMin: Float = 0f, vMax: Float = 0f,
-        format: String = "%.3f", flags: SliderFlags = emptyFlags()
+        format: String = "%.3f", flags: SliderFlags = emptyFlags
     ): Boolean =
         dragScalarN(label, DataType.Float, v to _fa, 2, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
             .also { v put _fa }
 
     fun dragFloat3(
         label: String, v: FloatArray, vSpeed: Float = 1f, vMin: Float = 0f, vMax: Float = 0f,
-        format: String = "%.3f", flags: SliderFlags = emptyFlags()
+        format: String = "%.3f", flags: SliderFlags = emptyFlags
     ): Boolean =
         dragScalarN(label, DataType.Float, v, 3, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
 
     fun dragVec3(
         label: String, v: Vec3, vSpeed: Float = 1f, vMin: Float = 0f, vMax: Float = 0f,
-        format: String = "%.3f", flags: SliderFlags = emptyFlags()
+        format: String = "%.3f", flags: SliderFlags = emptyFlags
     ): Boolean =
         dragScalarN(label, DataType.Float, v to _fa, 3, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
             .also { v put _fa }
 
     fun dragFloat4(
         label: String, v: FloatArray, vSpeed: Float = 1f, vMin: Float = 0f, vMax: Float = 0f,
-        format: String = "%.3f", flags: SliderFlags = emptyFlags()
+        format: String = "%.3f", flags: SliderFlags = emptyFlags
     ): Boolean =
         dragScalarN(label, DataType.Float, v, 4, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
 
     fun dragVec4(
         label: String, v: Vec4, vSpeed: Float = 1f, vMin: Float = 0f, vMax: Float = 0f,
-        format: String = "%.3f", flags: SliderFlags = emptyFlags()
+        format: String = "%.3f", flags: SliderFlags = emptyFlags
     ): Boolean =
         dragScalarN(label, DataType.Float, v to _fa, 4, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
             .also { v put _fa }
@@ -115,7 +115,7 @@ interface widgetsDrags {
     fun dragFloatRange2(
         label: String, vCurrentMinPtr: KMutableProperty0<Float>, vCurrentMaxPtr: KMutableProperty0<Float>,
         vSpeed: Float = 1f, vMin: Float = 0f, vMax: Float = 0f, format: String = "%.3f",
-        formatMax: String = format, flags: SliderFlags = emptyFlags()
+        formatMax: String = format, flags: SliderFlags = emptyFlags
     ): Boolean {
 
         val vCurrentMin by vCurrentMinPtr
@@ -129,7 +129,7 @@ interface widgetsDrags {
 
         var minMin = if (vMin >= vMax) -Float.MAX_VALUE else vMin
         var minMax = if (vMin >= vMax) vCurrentMax else vMax min vCurrentMax
-        val minFlags = flags or if (minMin == minMax) SliderFlag._ReadOnly else emptyFlags()
+        val minFlags = flags or if (minMin == minMax) SliderFlag._ReadOnly else emptyFlags
         var valueChanged = dragScalar("##min", DataType.Float, vCurrentMinPtr, vSpeed,
             minMin mutableProperty { minMin = it }, minMax mutableProperty { minMax = it }, format, minFlags
         )
@@ -138,10 +138,10 @@ interface widgetsDrags {
 
         var maxMin = if (vMin >= vMax) vCurrentMin else vMin max vCurrentMin
         var maxMax = if (vMin >= vMax) Float.MAX_VALUE else vMax
-        val maxFlags = flags or if (maxMin == maxMax) SliderFlag._ReadOnly else emptyFlags()
+        val maxFlags = flags or if (maxMin == maxMax) SliderFlag._ReadOnly else emptyFlags
         val fmt = formatMax.ifEmpty { format }
         valueChanged /= dragScalar("##max", DataType.Float, vCurrentMaxPtr, vSpeed,
-                                   maxMin mutableProperty { maxMin = it }, maxMax mutableProperty { maxMax = it }, fmt, maxFlags)
+            maxMin mutableProperty { maxMin = it }, maxMax mutableProperty { maxMax = it }, fmt, maxFlags)
         ImGui.popItemWidth()
         ImGui.sameLine(0f, ImGui.style.itemInnerSpacing.x)
 
@@ -157,51 +157,51 @@ interface widgetsDrags {
      *  NB: vSpeed is float to allow adjusting the drag speed with more precision     */
     fun dragInt(
         label: String, v: IntArray, ptr: Int, vSpeed: Float = 1f, vMin: Int = 0, vMax: Int = 0,
-        format: String? = "%d", flags: SliderFlags = emptyFlags()
+        format: String? = "%d", flags: SliderFlags = emptyFlags
     ): Boolean =
         withInt(v, ptr) { dragInt(label, it, vSpeed, vMin, vMax, format, flags) }
 
     fun dragInt(
         label: String, v: KMutableProperty0<Int>, vSpeed: Float = 1f, vMin: Int = 0, vMax: Int = 0,
-        format: String? = "%d", flags: SliderFlags = emptyFlags()
+        format: String? = "%d", flags: SliderFlags = emptyFlags
     ): Boolean =
         dragScalar(label, DataType.Int, v, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
 
     fun dragInt2(
         label: String, v: IntArray, vSpeed: Float = 1f, vMin: Int = 0, vMax: Int = 0,
-        format: String = "%d", flags: SliderFlags = emptyFlags()
+        format: String = "%d", flags: SliderFlags = emptyFlags
     ): Boolean =
         dragScalarN(label, DataType.Int, v, 2, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
 
     fun dragVec2i(
         label: String, v: Vec2i, vSpeed: Float = 1f, vMin: Int = 0, vMax: Int = 0,
-        format: String = "%d", flags: SliderFlags = emptyFlags()
+        format: String = "%d", flags: SliderFlags = emptyFlags
     ): Boolean =
         dragScalarN(label, DataType.Int, v to _ia, 2, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
             .also { v put _ia }
 
     fun dragInt3(
         label: String, v: IntArray, vSpeed: Float = 1f, vMin: Int = 0, vMax: Int = 0,
-        format: String = "%d", flags: SliderFlags = emptyFlags()
+        format: String = "%d", flags: SliderFlags = emptyFlags
     ): Boolean =
         dragScalarN(label, DataType.Int, v, 3, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
 
     fun dragVec3i(
         label: String, v: Vec3i, vSpeed: Float = 1f, vMin: Int = 0, vMax: Int = 0,
-        format: String = "%d", flags: SliderFlags = emptyFlags()
+        format: String = "%d", flags: SliderFlags = emptyFlags
     ): Boolean =
         dragScalarN(label, DataType.Int, v to _ia, 3, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
             .also { v put _ia }
 
     fun dragInt4(
         label: String, v: IntArray, vSpeed: Float = 1f, vMin: Int = 0, vMax: Int = 0,
-        format: String = "%d", flags: SliderFlags = emptyFlags()
+        format: String = "%d", flags: SliderFlags = emptyFlags
     ): Boolean =
         dragScalarN(label, DataType.Int, v, 4, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
 
     fun dragVec4i(
         label: String, v: Vec4i, vSpeed: Float = 1f, vMin: Int = 0, vMax: Int = 0,
-        format: String = "%d", flags: SliderFlags = emptyFlags()
+        format: String = "%d", flags: SliderFlags = emptyFlags
     ): Boolean =
         dragScalarN(label, DataType.Int, v to _ia, 4, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
             .also { v put _ia }
@@ -210,7 +210,7 @@ interface widgetsDrags {
     fun dragIntRange2(
         label: String, vCurrentMinPtr: KMutableProperty0<Int>, vCurrentMaxPtr: KMutableProperty0<Int>,
         vSpeed: Float = 1f, vMin: Int = 0, vMax: Int = 0, format: String = "%d",
-        formatMax: String = format, flags: SliderFlags = emptyFlags()
+        formatMax: String = format, flags: SliderFlags = emptyFlags
     ): Boolean {
 
         val vCurrentMin by vCurrentMinPtr
@@ -224,14 +224,14 @@ interface widgetsDrags {
 
         val minMin = if (vMin >= vMax) Int.MIN_VALUE else vMin
         val minMax = if (vMin >= vMax) vCurrentMax else vMax min vCurrentMax
-        val minFlags = flags or if (minMin == minMax) SliderFlag._ReadOnly else emptyFlags()
+        val minFlags = flags or if (minMin == minMax) SliderFlag._ReadOnly else emptyFlags
         var valueChanged = dragInt("##min", vCurrentMinPtr, vSpeed, minMin, minMax, format, minFlags)
         popItemWidth()
         sameLine(0f, style.itemInnerSpacing.x)
 
         val maxMin = if (vMin >= vMax) vCurrentMin else vMin max vCurrentMin
         val maxMax = if (vMin >= vMax) Int.MAX_VALUE else vMax
-        val maxFlags = flags or if (maxMin == maxMax) SliderFlag._ReadOnly else emptyFlags()
+        val maxFlags = flags or if (maxMin == maxMax) SliderFlag._ReadOnly else emptyFlags
         val fmt = if (formatMax.isNotEmpty()) formatMax else format
         valueChanged /= dragInt("##max", vCurrentMaxPtr, vSpeed, maxMin, maxMax, fmt, maxFlags)
         popItemWidth()
@@ -253,14 +253,14 @@ interface widgetsDrags {
     fun dragScalar(
         label: String, pData: FloatArray, vSpeed: Float = 1f,
         pMin: KMutableProperty0<Float>? = null, pMax: KMutableProperty0<Float>? = null,
-        format: String? = null, flags: SliderFlags = emptyFlags()
+        format: String? = null, flags: SliderFlags = emptyFlags
     ): Boolean =
         dragScalar(label, pData, 0, vSpeed, pMin?.get(), pMax?.get(), format, flags)
 
     /** If vMin >= vMax we have no bound  */
     fun dragScalar(
         label: String, pData: FloatArray, ptr: Int = 0, vSpeed: Float = 1f, min: Float? = null, max: Float? = null,
-        format: String? = null, flags: SliderFlags = emptyFlags()
+        format: String? = null, flags: SliderFlags = emptyFlags
     ): Boolean =
         withFloat(pData, ptr) {
             dragScalar(label, DataType.Float, it, vSpeed, min?.asMutableProperty, max?.asMutableProperty, format, flags)
@@ -271,7 +271,7 @@ interface widgetsDrags {
     fun <N> dragScalar(
         label: String, dataType: DataType, pData: KMutableProperty0<N>, vSpeed: Float = 1f,
         pMin: KMutableProperty0<N>? = null, pMax: KMutableProperty0<N>? = null,
-        format_: String? = null, flags: SliderFlags = emptyFlags()
+        format_: String? = null, flags: SliderFlags = emptyFlags
     ): Boolean
             where N : Number, N : Comparable<N> {
 
@@ -287,7 +287,7 @@ interface widgetsDrags {
 
         val tempInputAllowed = flags hasnt SliderFlag.NoInput
         ImGui.itemSize(totalBb, ImGui.style.framePadding.y)
-        if (!ImGui.itemAdd(totalBb, id, frameBb, if (tempInputAllowed) ItemFlag.Inputable else emptyFlags()))
+        if (!ImGui.itemAdd(totalBb, id, frameBb, if (tempInputAllowed) ItemFlag.Inputable else emptyFlags))
             return false
 
         // Default format string when passing NULL
@@ -363,7 +363,7 @@ interface widgetsDrags {
     fun <N> dragScalarN(
         label: String, dataType: DataType, v: Any, components: Int, vSpeed: Float = 1f,
         vMin: KMutableProperty0<N>? = null, vMax: KMutableProperty0<N>? = null,
-        format: String? = null, flags: SliderFlags = emptyFlags()
+        format: String? = null, flags: SliderFlags = emptyFlags
     ): Boolean
             where N : Number, N : Comparable<N> {
 

--- a/core/src/main/kotlin/imgui/api/widgetsDrags.kt
+++ b/core/src/main/kotlin/imgui/api/widgetsDrags.kt
@@ -57,48 +57,66 @@ interface widgetsDrags {
     // [JVM] TODO inline? -> class
 
     /** If v_min >= v_max we have no bound */
-    fun dragFloat(label: String, v: KMutableProperty0<Float>, vSpeed: Float = 1f, vMin: Float = 0f,
-                  vMax: Float = 0f, format: String? = "%.3f", flags: SliderFlags = SliderFlag.None.i): Boolean =
-            dragScalar(label, DataType.Float, v, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
+    fun dragFloat(
+        label: String, v: KMutableProperty0<Float>, vSpeed: Float = 1f, vMin: Float = 0f,
+        vMax: Float = 0f, format: String? = "%.3f", flags: SliderFlags = emptyFlags()
+    ): Boolean =
+        dragScalar(label, DataType.Float, v, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
 
     /** If v_min >= v_max we have no bound */
-    fun dragFloat(label: String, v: FloatArray, ptr: Int, vSpeed: Float = 1f, vMin: Float = 0f,
-                  vMax: Float = 0f, format: String = "%.3f", flags: SliderFlags = SliderFlag.None.i): Boolean =
-            withFloat(v, ptr) { pV ->
-                dragScalar(label, DataType.Float, pV, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
-            }
+    fun dragFloat(
+        label: String, v: FloatArray, ptr: Int, vSpeed: Float = 1f, vMin: Float = 0f,
+        vMax: Float = 0f, format: String = "%.3f", flags: SliderFlags = emptyFlags()
+    ): Boolean =
+        withFloat(v, ptr) { pV ->
+            dragScalar(label, DataType.Float, pV, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
+        }
 
-    fun dragFloat2(label: String, v: FloatArray, vSpeed: Float = 1f, vMin: Float = 0f, vMax: Float = 0f,
-                   format: String = "%.3f", flags: SliderFlags = SliderFlag.None.i): Boolean =
-            dragScalarN(label, DataType.Float, v, 2, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
+    fun dragFloat2(
+        label: String, v: FloatArray, vSpeed: Float = 1f, vMin: Float = 0f, vMax: Float = 0f,
+        format: String = "%.3f", flags: SliderFlags = emptyFlags()
+    ): Boolean =
+        dragScalarN(label, DataType.Float, v, 2, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
 
-    fun dragVec2(label: String, v: Vec2, vSpeed: Float = 1f, vMin: Float = 0f, vMax: Float = 0f,
-                 format: String = "%.3f", flags: SliderFlags = SliderFlag.None.i): Boolean =
-            dragScalarN(label, DataType.Float, v to _fa, 2, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
-                    .also { v put _fa }
+    fun dragVec2(
+        label: String, v: Vec2, vSpeed: Float = 1f, vMin: Float = 0f, vMax: Float = 0f,
+        format: String = "%.3f", flags: SliderFlags = emptyFlags()
+    ): Boolean =
+        dragScalarN(label, DataType.Float, v to _fa, 2, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
+            .also { v put _fa }
 
-    fun dragFloat3(label: String, v: FloatArray, vSpeed: Float = 1f, vMin: Float = 0f, vMax: Float = 0f,
-                   format: String = "%.3f", flags: SliderFlags = SliderFlag.None.i): Boolean =
-            dragScalarN(label, DataType.Float, v, 3, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
+    fun dragFloat3(
+        label: String, v: FloatArray, vSpeed: Float = 1f, vMin: Float = 0f, vMax: Float = 0f,
+        format: String = "%.3f", flags: SliderFlags = emptyFlags()
+    ): Boolean =
+        dragScalarN(label, DataType.Float, v, 3, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
 
-    fun dragVec3(label: String, v: Vec3, vSpeed: Float = 1f, vMin: Float = 0f, vMax: Float = 0f,
-                 format: String = "%.3f", flags: SliderFlags = SliderFlag.None.i): Boolean =
-            dragScalarN(label, DataType.Float, v to _fa, 3, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
-                    .also { v put _fa }
+    fun dragVec3(
+        label: String, v: Vec3, vSpeed: Float = 1f, vMin: Float = 0f, vMax: Float = 0f,
+        format: String = "%.3f", flags: SliderFlags = emptyFlags()
+    ): Boolean =
+        dragScalarN(label, DataType.Float, v to _fa, 3, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
+            .also { v put _fa }
 
-    fun dragFloat4(label: String, v: FloatArray, vSpeed: Float = 1f, vMin: Float = 0f, vMax: Float = 0f,
-                   format: String = "%.3f", flags: SliderFlags = SliderFlag.None.i): Boolean =
-            dragScalarN(label, DataType.Float, v, 4, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
+    fun dragFloat4(
+        label: String, v: FloatArray, vSpeed: Float = 1f, vMin: Float = 0f, vMax: Float = 0f,
+        format: String = "%.3f", flags: SliderFlags = emptyFlags()
+    ): Boolean =
+        dragScalarN(label, DataType.Float, v, 4, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
 
-    fun dragVec4(label: String, v: Vec4, vSpeed: Float = 1f, vMin: Float = 0f, vMax: Float = 0f,
-                 format: String = "%.3f", flags: SliderFlags = SliderFlag.None.i): Boolean =
-            dragScalarN(label, DataType.Float, v to _fa, 4, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
-                    .also { v put _fa }
+    fun dragVec4(
+        label: String, v: Vec4, vSpeed: Float = 1f, vMin: Float = 0f, vMax: Float = 0f,
+        format: String = "%.3f", flags: SliderFlags = emptyFlags()
+    ): Boolean =
+        dragScalarN(label, DataType.Float, v to _fa, 4, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
+            .also { v put _fa }
 
     /** NB: You likely want to specify the ImGuiSliderFlags_AlwaysClamp when using this. */
-    fun dragFloatRange2(label: String, vCurrentMinPtr: KMutableProperty0<Float>, vCurrentMaxPtr: KMutableProperty0<Float>,
-                        vSpeed: Float = 1f, vMin: Float = 0f, vMax: Float = 0f, format: String = "%.3f",
-                        formatMax: String = format, flags: SliderFlags = SliderFlag.None.i): Boolean {
+    fun dragFloatRange2(
+        label: String, vCurrentMinPtr: KMutableProperty0<Float>, vCurrentMaxPtr: KMutableProperty0<Float>,
+        vSpeed: Float = 1f, vMin: Float = 0f, vMax: Float = 0f, format: String = "%.3f",
+        formatMax: String = format, flags: SliderFlags = emptyFlags()
+    ): Boolean {
 
         val vCurrentMin by vCurrentMinPtr
         val vCurrentMax by vCurrentMaxPtr
@@ -111,15 +129,16 @@ interface widgetsDrags {
 
         var minMin = if (vMin >= vMax) -Float.MAX_VALUE else vMin
         var minMax = if (vMin >= vMax) vCurrentMax else vMax min vCurrentMax
-        val minFlags = flags or if (minMin == minMax) SliderFlag._ReadOnly else SliderFlag.None
+        val minFlags = flags or if (minMin == minMax) SliderFlag._ReadOnly else emptyFlags()
         var valueChanged = dragScalar("##min", DataType.Float, vCurrentMinPtr, vSpeed,
-                                      minMin mutableProperty { minMin = it }, minMax mutableProperty { minMax = it }, format, minFlags)
+            minMin mutableProperty { minMin = it }, minMax mutableProperty { minMax = it }, format, minFlags
+        )
         ImGui.popItemWidth()
         ImGui.sameLine(0f, ImGui.style.itemInnerSpacing.x)
 
         var maxMin = if (vMin >= vMax) vCurrentMin else vMin max vCurrentMin
         var maxMax = if (vMin >= vMax) Float.MAX_VALUE else vMax
-        val maxFlags = flags or if (maxMin == maxMax) SliderFlag._ReadOnly else SliderFlag.None
+        val maxFlags = flags or if (maxMin == maxMax) SliderFlag._ReadOnly else emptyFlags()
         val fmt = formatMax.ifEmpty { format }
         valueChanged /= dragScalar("##max", DataType.Float, vCurrentMaxPtr, vSpeed,
                                    maxMin mutableProperty { maxMin = it }, maxMax mutableProperty { maxMax = it }, fmt, maxFlags)
@@ -136,45 +155,63 @@ interface widgetsDrags {
     /** If v_min >= v_max we have no bound
      *
      *  NB: vSpeed is float to allow adjusting the drag speed with more precision     */
-    fun dragInt(label: String, v: IntArray, ptr: Int, vSpeed: Float = 1f, vMin: Int = 0, vMax: Int = 0,
-                format: String? = "%d", flags: SliderFlags = SliderFlag.None.i): Boolean =
-            withInt(v, ptr) { dragInt(label, it, vSpeed, vMin, vMax, format, flags) }
+    fun dragInt(
+        label: String, v: IntArray, ptr: Int, vSpeed: Float = 1f, vMin: Int = 0, vMax: Int = 0,
+        format: String? = "%d", flags: SliderFlags = emptyFlags()
+    ): Boolean =
+        withInt(v, ptr) { dragInt(label, it, vSpeed, vMin, vMax, format, flags) }
 
-    fun dragInt(label: String, v: KMutableProperty0<Int>, vSpeed: Float = 1f, vMin: Int = 0, vMax: Int = 0,
-                format: String? = "%d", flags: SliderFlags = SliderFlag.None.i): Boolean =
-            dragScalar(label, DataType.Int, v, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
+    fun dragInt(
+        label: String, v: KMutableProperty0<Int>, vSpeed: Float = 1f, vMin: Int = 0, vMax: Int = 0,
+        format: String? = "%d", flags: SliderFlags = emptyFlags()
+    ): Boolean =
+        dragScalar(label, DataType.Int, v, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
 
-    fun dragInt2(label: String, v: IntArray, vSpeed: Float = 1f, vMin: Int = 0, vMax: Int = 0,
-                 format: String = "%d", flags: SliderFlags = SliderFlag.None.i): Boolean =
-            dragScalarN(label, DataType.Int, v, 2, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
+    fun dragInt2(
+        label: String, v: IntArray, vSpeed: Float = 1f, vMin: Int = 0, vMax: Int = 0,
+        format: String = "%d", flags: SliderFlags = emptyFlags()
+    ): Boolean =
+        dragScalarN(label, DataType.Int, v, 2, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
 
-    fun dragVec2i(label: String, v: Vec2i, vSpeed: Float = 1f, vMin: Int = 0, vMax: Int = 0,
-                  format: String = "%d", flags: SliderFlags = SliderFlag.None.i): Boolean =
-            dragScalarN(label, DataType.Int, v to _ia, 2, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
-                    .also { v put _ia }
+    fun dragVec2i(
+        label: String, v: Vec2i, vSpeed: Float = 1f, vMin: Int = 0, vMax: Int = 0,
+        format: String = "%d", flags: SliderFlags = emptyFlags()
+    ): Boolean =
+        dragScalarN(label, DataType.Int, v to _ia, 2, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
+            .also { v put _ia }
 
-    fun dragInt3(label: String, v: IntArray, vSpeed: Float = 1f, vMin: Int = 0, vMax: Int = 0,
-                 format: String = "%d", flags: SliderFlags = SliderFlag.None.i): Boolean =
-            dragScalarN(label, DataType.Int, v, 3, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
+    fun dragInt3(
+        label: String, v: IntArray, vSpeed: Float = 1f, vMin: Int = 0, vMax: Int = 0,
+        format: String = "%d", flags: SliderFlags = emptyFlags()
+    ): Boolean =
+        dragScalarN(label, DataType.Int, v, 3, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
 
-    fun dragVec3i(label: String, v: Vec3i, vSpeed: Float = 1f, vMin: Int = 0, vMax: Int = 0,
-                  format: String = "%d", flags: SliderFlags = SliderFlag.None.i): Boolean =
-            dragScalarN(label, DataType.Int, v to _ia, 3, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
-                    .also { v put _ia }
+    fun dragVec3i(
+        label: String, v: Vec3i, vSpeed: Float = 1f, vMin: Int = 0, vMax: Int = 0,
+        format: String = "%d", flags: SliderFlags = emptyFlags()
+    ): Boolean =
+        dragScalarN(label, DataType.Int, v to _ia, 3, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
+            .also { v put _ia }
 
-    fun dragInt4(label: String, v: IntArray, vSpeed: Float = 1f, vMin: Int = 0, vMax: Int = 0,
-                 format: String = "%d", flags: SliderFlags = SliderFlag.None.i): Boolean =
-            dragScalarN(label, DataType.Int, v, 4, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
+    fun dragInt4(
+        label: String, v: IntArray, vSpeed: Float = 1f, vMin: Int = 0, vMax: Int = 0,
+        format: String = "%d", flags: SliderFlags = emptyFlags()
+    ): Boolean =
+        dragScalarN(label, DataType.Int, v, 4, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
 
-    fun dragVec4i(label: String, v: Vec4i, vSpeed: Float = 1f, vMin: Int = 0, vMax: Int = 0,
-                  format: String = "%d", flags: SliderFlags = SliderFlag.None.i): Boolean =
-            dragScalarN(label, DataType.Int, v to _ia, 4, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
-                    .also { v put _ia }
+    fun dragVec4i(
+        label: String, v: Vec4i, vSpeed: Float = 1f, vMin: Int = 0, vMax: Int = 0,
+        format: String = "%d", flags: SliderFlags = emptyFlags()
+    ): Boolean =
+        dragScalarN(label, DataType.Int, v to _ia, 4, vSpeed, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
+            .also { v put _ia }
 
     /** NB: You likely want to specify the ImGuiSliderFlags_AlwaysClamp when using this. */
-    fun dragIntRange2(label: String, vCurrentMinPtr: KMutableProperty0<Int>, vCurrentMaxPtr: KMutableProperty0<Int>,
-                      vSpeed: Float = 1f, vMin: Int = 0, vMax: Int = 0, format: String = "%d",
-                      formatMax: String = format, flags: SliderFlags = SliderFlag.None.i): Boolean {
+    fun dragIntRange2(
+        label: String, vCurrentMinPtr: KMutableProperty0<Int>, vCurrentMaxPtr: KMutableProperty0<Int>,
+        vSpeed: Float = 1f, vMin: Int = 0, vMax: Int = 0, format: String = "%d",
+        formatMax: String = format, flags: SliderFlags = emptyFlags()
+    ): Boolean {
 
         val vCurrentMin by vCurrentMinPtr
         val vCurrentMax by vCurrentMaxPtr
@@ -187,14 +224,14 @@ interface widgetsDrags {
 
         val minMin = if (vMin >= vMax) Int.MIN_VALUE else vMin
         val minMax = if (vMin >= vMax) vCurrentMax else vMax min vCurrentMax
-        val minFlags = flags or if (minMin == minMax) SliderFlag._ReadOnly else SliderFlag.None
+        val minFlags = flags or if (minMin == minMax) SliderFlag._ReadOnly else emptyFlags()
         var valueChanged = dragInt("##min", vCurrentMinPtr, vSpeed, minMin, minMax, format, minFlags)
         popItemWidth()
         sameLine(0f, style.itemInnerSpacing.x)
 
         val maxMin = if (vMin >= vMax) vCurrentMin else vMin max vCurrentMin
         val maxMax = if (vMin >= vMax) Int.MAX_VALUE else vMax
-        val maxFlags = flags or if (maxMin == maxMax) SliderFlag._ReadOnly else SliderFlag.None
+        val maxFlags = flags or if (maxMin == maxMax) SliderFlag._ReadOnly else emptyFlags()
         val fmt = if (formatMax.isNotEmpty()) formatMax else format
         valueChanged /= dragInt("##max", vCurrentMaxPtr, vSpeed, maxMin, maxMax, fmt, maxFlags)
         popItemWidth()
@@ -213,23 +250,29 @@ interface widgetsDrags {
      *  e.g. "%.3f" -> 1.234; "%5.2f secs" -> 01.23 secs; "Biscuit: %.0f" -> Biscuit: 1; etc.
      *  Speed are per-pixel of mouse movement (vSpeed = 0.2f: mouse needs to move by 5 pixels to increase value by 1).
      *  For gamepad/keyboard navigation, minimum speed is Max(vSpeed, minimumStepAtGivenPrecision). */
-    fun dragScalar(label: String, pData: FloatArray, vSpeed: Float = 1f,
-                   pMin: KMutableProperty0<Float>? = null, pMax: KMutableProperty0<Float>? = null,
-                   format: String? = null, flags: SliderFlags = SliderFlag.None.i): Boolean =
-            dragScalar(label, pData, 0, vSpeed, pMin?.get(), pMax?.get(), format, flags)
+    fun dragScalar(
+        label: String, pData: FloatArray, vSpeed: Float = 1f,
+        pMin: KMutableProperty0<Float>? = null, pMax: KMutableProperty0<Float>? = null,
+        format: String? = null, flags: SliderFlags = emptyFlags()
+    ): Boolean =
+        dragScalar(label, pData, 0, vSpeed, pMin?.get(), pMax?.get(), format, flags)
 
     /** If vMin >= vMax we have no bound  */
-    fun dragScalar(label: String, pData: FloatArray, ptr: Int = 0, vSpeed: Float = 1f, min: Float? = null, max: Float? = null,
-                   format: String? = null, flags: SliderFlags = SliderFlag.None.i): Boolean =
-            withFloat(pData, ptr) {
-                    dragScalar(label, DataType.Float, it, vSpeed, min?.asMutableProperty, max?.asMutableProperty, format, flags)
-            }
+    fun dragScalar(
+        label: String, pData: FloatArray, ptr: Int = 0, vSpeed: Float = 1f, min: Float? = null, max: Float? = null,
+        format: String? = null, flags: SliderFlags = emptyFlags()
+    ): Boolean =
+        withFloat(pData, ptr) {
+            dragScalar(label, DataType.Float, it, vSpeed, min?.asMutableProperty, max?.asMutableProperty, format, flags)
+        }
 
     /** ote: p_data, p_min and p_max are _pointers_ to a memory address holding the data. For a Drag widget, p_min and p_max are optional.
      *  Read code of e.g. DragFloat(), DragInt() etc. or examples in 'Demo->Widgets->Data Types' to understand how to use this function directly. */
-    fun <N> dragScalar(label: String, dataType: DataType, pData: KMutableProperty0<N>, vSpeed: Float = 1f,
-                       pMin: KMutableProperty0<N>? = null, pMax: KMutableProperty0<N>? = null,
-                       format_: String? = null, flags: SliderFlags = SliderFlag.None.i): Boolean
+    fun <N> dragScalar(
+        label: String, dataType: DataType, pData: KMutableProperty0<N>, vSpeed: Float = 1f,
+        pMin: KMutableProperty0<N>? = null, pMax: KMutableProperty0<N>? = null,
+        format_: String? = null, flags: SliderFlags = emptyFlags()
+    ): Boolean
             where N : Number, N : Comparable<N> {
 
         val window = ImGui.currentWindow
@@ -244,7 +287,7 @@ interface widgetsDrags {
 
         val tempInputAllowed = flags hasnt SliderFlag.NoInput
         ImGui.itemSize(totalBb, ImGui.style.framePadding.y)
-        if (!ImGui.itemAdd(totalBb, id, frameBb, if (tempInputAllowed) ItemFlag.Inputable.i else 0))
+        if (!ImGui.itemAdd(totalBb, id, frameBb, if (tempInputAllowed) ItemFlag.Inputable else emptyFlags()))
             return false
 
         // Default format string when passing NULL
@@ -317,9 +360,11 @@ interface widgetsDrags {
      *  p_min and p_max are optional.
      *  Read code of e.g. SliderFloat(), SliderInt() etc. or examples in 'Demo->Widgets->Data Types' to understand
      *  how to use this function directly. */
-    fun <N> dragScalarN(label: String, dataType: DataType, v: Any, components: Int, vSpeed: Float = 1f,
-                        vMin: KMutableProperty0<N>? = null, vMax: KMutableProperty0<N>? = null,
-                        format: String? = null, flags: SliderFlags = SliderFlag.None.i): Boolean
+    fun <N> dragScalarN(
+        label: String, dataType: DataType, v: Any, components: Int, vSpeed: Float = 1f,
+        vMin: KMutableProperty0<N>? = null, vMax: KMutableProperty0<N>? = null,
+        format: String? = null, flags: SliderFlags = emptyFlags()
+    ): Boolean
             where N : Number, N : Comparable<N> {
 
         val window = ImGui.currentWindow

--- a/core/src/main/kotlin/imgui/api/widgetsInputWithKeyboard.kt
+++ b/core/src/main/kotlin/imgui/api/widgetsInputWithKeyboard.kt
@@ -1,6 +1,5 @@
 package imgui.api
 
-import gli_.hasnt
 import glm_.func.common.max
 import glm_.vec2.Vec2
 import glm_.vec2.Vec2i
@@ -48,8 +47,10 @@ import imgui.internal.sections.ButtonFlag as Bf
 interface widgetsInputWithKeyboard {
 
     /** String overload */
-    fun inputText(label: String, pString: KMutableProperty0<String>, flags: InputTextFlags = Itf.None.i,
-                  callback: InputTextCallback? = null, userData: Any? = null): Boolean {
+    fun inputText(
+        label: String, pString: KMutableProperty0<String>, flags: InputTextFlags = emptyFlags(),
+        callback: InputTextCallback? = null, userData: Any? = null
+    ): Boolean {
         val buf = pString.get().toByteArray()
         return inputText(label, buf, flags, callback, userData).also {
             pString.set(buf.cStr)
@@ -57,12 +58,16 @@ interface widgetsInputWithKeyboard {
     }
 
     /** String overload */
-    fun inputText(label: String, buf: String, flags: InputTextFlags = Itf.None.i,
-                  callback: InputTextCallback? = null, userData: Any? = null): Boolean =
+    fun inputText(
+        label: String, buf: String, flags: InputTextFlags = emptyFlags(),
+        callback: InputTextCallback? = null, userData: Any? = null
+    ): Boolean =
         inputText(label, buf.toByteArray(), flags, callback, userData)
 
-    fun inputText(label: String, buf: StringBuilder, flags: InputTextFlags = Itf.None.i,
-                  callback: InputTextCallback? = null, userData: Any? = null): Boolean {
+    fun inputText(
+        label: String, buf: StringBuilder, flags: InputTextFlags = emptyFlags(),
+        callback: InputTextCallback? = null, userData: Any? = null
+    ): Boolean {
         val array = buf.toString().toByteArray()
         return inputText(label, array, flags, callback, userData).also {
             buf.clear()
@@ -70,112 +75,134 @@ interface widgetsInputWithKeyboard {
         }
     }
 
-    fun inputText(label: String, buf: ByteArray, flags: InputTextFlags = Itf.None.i,
-                  callback: InputTextCallback? = null, userData: Any? = null): Boolean {
+    fun inputText(
+        label: String, buf: ByteArray, flags: InputTextFlags = emptyFlags(),
+        callback: InputTextCallback? = null, userData: Any? = null
+    ): Boolean {
         assert(flags hasnt Itf._Multiline) { "call InputTextMultiline()" }
         return inputTextEx(label, null, buf, Vec2(), flags, callback, userData)
     }
 
     /** String overload */
-    fun inputTextMultiline(label: String, buf: String, size: Vec2 = Vec2(), flags: InputTextFlags = Itf.None.i,
-                           callback: InputTextCallback? = null, userData: Any? = null): Boolean =
+    fun inputTextMultiline(
+        label: String, buf: String, size: Vec2 = Vec2(), flags: InputTextFlags = emptyFlags(),
+        callback: InputTextCallback? = null, userData: Any? = null
+    ): Boolean =
         inputTextEx(label, null, buf.toByteArray(), size, flags or Itf._Multiline, callback, userData)
 
-    fun inputTextMultiline(label: String, buf: ByteArray, size: Vec2 = Vec2(), flags: InputTextFlags = Itf.None.i,
-                           callback: InputTextCallback? = null, userData: Any? = null): Boolean =
+    fun inputTextMultiline(
+        label: String, buf: ByteArray, size: Vec2 = Vec2(), flags: InputTextFlags = emptyFlags(),
+        callback: InputTextCallback? = null, userData: Any? = null
+    ): Boolean =
         inputTextEx(label, null, buf, size, flags or Itf._Multiline, callback, userData)
 
     /** String overload */
-    fun inputTextWithHint(label: String, hint: String, buf: String, flags: InputTextFlags = Itf.None.i,
-                          callback: InputTextCallback? = null, userData: Any? = null): Boolean =
+    fun inputTextWithHint(
+        label: String, hint: String, buf: String, flags: InputTextFlags = emptyFlags(),
+        callback: InputTextCallback? = null, userData: Any? = null
+    ): Boolean =
         inputTextWithHint(label, hint, buf.toByteArray(), flags)
 
-    fun inputTextWithHint(label: String, hint: String, buf: ByteArray, flags: InputTextFlags = 0,
-                          callback: InputTextCallback? = null, userData: Any? = null): Boolean {
+    fun inputTextWithHint(
+        label: String, hint: String, buf: ByteArray, flags: InputTextFlags = emptyFlags(),
+        callback: InputTextCallback? = null, userData: Any? = null
+    ): Boolean {
         assert(flags hasnt Itf._Multiline) { "call InputTextMultiline() or InputTextEx() manually if you need multi-line + hint." }
         return inputTextEx(label, hint, buf, Vec2(), flags, callback, userData)
     }
 
 
-    fun inputFloat(label: String, v: FloatArray, step: Float = 0f, stepFast: Float = 0f,
-                   format: String = "%.3f", flags: InputTextFlags = Itf.None.i): Boolean =
+    fun inputFloat(
+        label: String, v: FloatArray, step: Float = 0f, stepFast: Float = 0f,
+        format: String = "%.3f", flags: InputTextFlags = emptyFlags()
+    ): Boolean =
         inputFloat(label, v, 0, step, stepFast, format, flags)
 
-    fun inputFloat(label: String, v: FloatArray, ptr: Int = 0, step: Float = 0f, stepFast: Float = 0f,
-                   format: String = "%.3f", flags: InputTextFlags = Itf.None.i): Boolean =
+    fun inputFloat(
+        label: String, v: FloatArray, ptr: Int = 0, step: Float = 0f, stepFast: Float = 0f,
+        format: String = "%.3f", flags: InputTextFlags = emptyFlags()
+    ): Boolean =
         withFloat(v, ptr) { inputFloat(label, it, step, stepFast, format, flags) }
 
-    fun inputFloat(label: String, v: KMutableProperty0<Float>, step: Float = 0f, stepFast: Float = 0f,
-                   format: String = "%.3f", flags_: InputTextFlags = Itf.None.i): Boolean {
+    fun inputFloat(
+        label: String, v: KMutableProperty0<Float>, step: Float = 0f, stepFast: Float = 0f,
+        format: String = "%.3f", flags_: InputTextFlags = emptyFlags()
+    ): Boolean {
         val flags = flags_ or Itf.CharsScientific
         return inputScalar(label, DataType.Float, v, step.takeIf { it > 0f }, stepFast.takeIf { it > 0f }, format, flags)
     }
 
 
-    fun inputFloat2(label: String, v: FloatArray, format: String = "%.3f", flags: InputTextFlags = Itf.None.i): Boolean =
+    fun inputFloat2(label: String, v: FloatArray, format: String = "%.3f", flags: InputTextFlags = emptyFlags()): Boolean =
         inputScalarN<Float>(label, DataType.Float, v, 2, null, null, format, flags)
 
-    fun inputVec2(label: String, v: Vec2, format: String = "%.3f", flags: InputTextFlags = Itf.None.i): Boolean =
+    fun inputVec2(label: String, v: Vec2, format: String = "%.3f", flags: InputTextFlags = emptyFlags()): Boolean =
         inputScalarN<Float>(label, DataType.Float, v to _fa, Vec2.length, null, null, format, flags)
-                .also { v put _fa }
+            .also { v put _fa }
 
-    fun inputFloat3(label: String, v: FloatArray, format: String = "%.3f", flags: InputTextFlags = Itf.None.i): Boolean =
+    fun inputFloat3(label: String, v: FloatArray, format: String = "%.3f", flags: InputTextFlags = emptyFlags()): Boolean =
         inputScalarN<Float>(label, DataType.Float, v, 3, null, null, format, flags)
 
-    fun inputVec3(label: String, v: Vec3, format: String = "%.3f", flags: InputTextFlags = Itf.None.i): Boolean =
+    fun inputVec3(label: String, v: Vec3, format: String = "%.3f", flags: InputTextFlags = emptyFlags()): Boolean =
         inputScalarN<Float>(label, DataType.Float, v to _fa, Vec3.length, null, null, format, flags)
-                .also { v put _fa }
+            .also { v put _fa }
 
-    fun inputFloat4(label: String, v: FloatArray, format: String = "%.3f", flags: InputTextFlags = Itf.None.i): Boolean =
+    fun inputFloat4(label: String, v: FloatArray, format: String = "%.3f", flags: InputTextFlags = emptyFlags()): Boolean =
         inputScalarN<Float>(label, DataType.Float, v, 4, null, null, format, flags)
 
-    fun inputVec4(label: String, v: Vec4, format: String = "%.3f", flags: InputTextFlags = Itf.None.i): Boolean =
+    fun inputVec4(label: String, v: Vec4, format: String = "%.3f", flags: InputTextFlags = emptyFlags()): Boolean =
         inputScalarN<Float>(label, DataType.Float, v to _fa, Vec4.length, null, null, format, flags)
-                .also { v put _fa }
+            .also { v put _fa }
 
-    fun inputInt(label: String, v: KMutableProperty0<Int>, step: Int = 1, stepFast: Int = 100, flags: InputTextFlags = 0): Boolean {
+    fun inputInt(label: String, v: KMutableProperty0<Int>, step: Int = 1, stepFast: Int = 100, flags: InputTextFlags = emptyFlags()): Boolean {
         /*  Hexadecimal input provided as a convenience but the flag name is awkward. Typically you'd use inputText()
             to parse your own data, if you want to handle prefixes.             */
         val format = if (flags has Itf.CharsHexadecimal) "%08X" else "%d"
         return inputScalar(label, DataType.Int, v, step.takeIf { it > 0f }, stepFast.takeIf { it > 0f }, format, flags)
     }
 
-    fun inputInt2(label: String, v: IntArray, flags: InputTextFlags = 0): Boolean =
+    fun inputInt2(label: String, v: IntArray, flags: InputTextFlags = emptyFlags()): Boolean =
         inputScalarN<Int>(label, DataType.Int, v, 2, null, null, "%d", flags)
 
-    fun inputVec2i(label: String, v: Vec2i, flags: InputTextFlags = 0): Boolean =
+    fun inputVec2i(label: String, v: Vec2i, flags: InputTextFlags = emptyFlags()): Boolean =
         inputScalarN<Int>(label, DataType.Int, v to _ia, Vec2i.length, null, null, "%d", flags)
-                .also { v put _ia }
+            .also { v put _ia }
 
-    fun inputInt3(label: String, v: IntArray, flags: InputTextFlags = 0): Boolean =
+    fun inputInt3(label: String, v: IntArray, flags: InputTextFlags = emptyFlags()): Boolean =
         inputScalarN<Int>(label, DataType.Int, v, 3, null, null, "%d", flags)
 
-    fun inputVec3i(label: String, v: Vec3i, flags: InputTextFlags = 0): Boolean =
+    fun inputVec3i(label: String, v: Vec3i, flags: InputTextFlags = emptyFlags()): Boolean =
         inputScalarN<Int>(label, DataType.Int, v to _ia, Vec3i.length, null, null, "%d", flags)
-                .also { v put _ia }
+            .also { v put _ia }
 
-    fun inputInt4(label: String, v: IntArray, flags: InputTextFlags = 0): Boolean =
+    fun inputInt4(label: String, v: IntArray, flags: InputTextFlags = emptyFlags()): Boolean =
         inputScalarN<Int>(label, DataType.Int, v, 4, null, null, "%d", flags)
 
-    fun inputVec4i(label: String, v: Vec4i, flags: InputTextFlags = 0): Boolean =
+    fun inputVec4i(label: String, v: Vec4i, flags: InputTextFlags = emptyFlags()): Boolean =
         inputScalarN<Int>(label, DataType.Int, v to _ia, Vec4i.length, null, null, "%d", flags)
-                .also { v put _ia }
+            .also { v put _ia }
 
-    fun inputDouble(label: String, v: KMutableProperty0<Double>, step: Double = 0.0, stepFast: Double = 0.0,
-                    format: String? = "%.6f", flags_: InputTextFlags = Itf.None.i): Boolean {
+    fun inputDouble(
+        label: String, v: KMutableProperty0<Double>, step: Double = 0.0, stepFast: Double = 0.0,
+        format: String? = "%.6f", flags_: InputTextFlags = emptyFlags()
+    ): Boolean {
         val flags = flags_ or Itf.CharsScientific
         /*  Ideally we'd have a minimum decimal precision of 1 to visually denote that this is a float,
             while hiding non-significant digits? %f doesn't have a minimum of 1         */
         return inputScalar(label, DataType.Double, v, step.takeIf { it > 0.0 }, stepFast.takeIf { it > 0.0 }, format, flags)
     }
 
-    fun <N> inputScalar(label: String, dataType: DataType, pData: IntArray, step: Int?, stepFast: Int?,
-                        format: String? = null, flags: InputTextFlags = Itf.None.i)
+    fun <N> inputScalar(
+        label: String, dataType: DataType, pData: IntArray, step: Int?, stepFast: Int?,
+        format: String? = null, flags: InputTextFlags = emptyFlags()
+    )
             : Boolean where N : Number, N : Comparable<N> =
         withInt(pData) { inputScalar(label, dataType, it, step, stepFast, format, flags) }
 
-    fun <N> inputScalar(label: String, dataType: DataType, pData: KMutableProperty0<N>, step: N? = null, stepFast: N? = null,
-                        format_: String? = null, flags_: InputTextFlags = Itf.None.i): Boolean where N : Number, N : Comparable<N> {
+    fun <N> inputScalar(
+        label: String, dataType: DataType, pData: KMutableProperty0<N>, step: N? = null, stepFast: N? = null,
+        format_: String? = null, flags_: InputTextFlags = emptyFlags()
+    ): Boolean where N : Number, N : Comparable<N> {
 
         var data by pData
         val window = currentWindow
@@ -245,8 +272,10 @@ interface widgetsInputWithKeyboard {
         return valueChanged
     }
 
-    fun <N> inputScalarN(label: String, dataType: DataType, v: Any, components: Int, step: N? = null, stepFast: N? = null,
-                         format: String? = null, flags: InputTextFlags = 0): Boolean where N : Number, N : Comparable<N> {
+    fun <N> inputScalarN(
+        label: String, dataType: DataType, v: Any, components: Int, step: N? = null, stepFast: N? = null,
+        format: String? = null, flags: InputTextFlags = emptyFlags()
+    ): Boolean where N : Number, N : Comparable<N> {
 
         val window = currentWindow
         if (window.skipItems) return false

--- a/core/src/main/kotlin/imgui/api/widgetsInputWithKeyboard.kt
+++ b/core/src/main/kotlin/imgui/api/widgetsInputWithKeyboard.kt
@@ -48,7 +48,7 @@ interface widgetsInputWithKeyboard {
 
     /** String overload */
     fun inputText(
-        label: String, pString: KMutableProperty0<String>, flags: InputTextFlags = emptyFlags(),
+        label: String, pString: KMutableProperty0<String>, flags: InputTextSingleFlags = emptyFlags,
         callback: InputTextCallback? = null, userData: Any? = null
     ): Boolean {
         val buf = pString.get().toByteArray()
@@ -59,13 +59,13 @@ interface widgetsInputWithKeyboard {
 
     /** String overload */
     fun inputText(
-        label: String, buf: String, flags: InputTextFlags = emptyFlags(),
+        label: String, buf: String, flags: InputTextSingleFlags = emptyFlags,
         callback: InputTextCallback? = null, userData: Any? = null
     ): Boolean =
         inputText(label, buf.toByteArray(), flags, callback, userData)
 
     fun inputText(
-        label: String, buf: StringBuilder, flags: InputTextFlags = emptyFlags(),
+        label: String, buf: StringBuilder, flags: InputTextSingleFlags = emptyFlags,
         callback: InputTextCallback? = null, userData: Any? = null
     ): Boolean {
         val array = buf.toString().toByteArray()
@@ -76,115 +76,110 @@ interface widgetsInputWithKeyboard {
     }
 
     fun inputText(
-        label: String, buf: ByteArray, flags: InputTextFlags = emptyFlags(),
+        label: String, buf: ByteArray, flags: InputTextSingleFlags = emptyFlags,
         callback: InputTextCallback? = null, userData: Any? = null
-    ): Boolean {
-        assert(flags hasnt Itf._Multiline) { "call InputTextMultiline()" }
-        return inputTextEx(label, null, buf, Vec2(), flags, callback, userData)
-    }
+    ): Boolean = inputTextEx(label, null, buf, Vec2(), flags, callback, userData)
 
     /** String overload */
     fun inputTextMultiline(
-        label: String, buf: String, size: Vec2 = Vec2(), flags: InputTextFlags = emptyFlags(),
+        label: String, buf: String, size: Vec2 = Vec2(), flags: InputTextSingleFlags = emptyFlags,
         callback: InputTextCallback? = null, userData: Any? = null
     ): Boolean =
         inputTextEx(label, null, buf.toByteArray(), size, flags or Itf._Multiline, callback, userData)
 
     fun inputTextMultiline(
-        label: String, buf: ByteArray, size: Vec2 = Vec2(), flags: InputTextFlags = emptyFlags(),
+        label: String, buf: ByteArray, size: Vec2 = Vec2(), flags: InputTextSingleFlags = emptyFlags,
         callback: InputTextCallback? = null, userData: Any? = null
     ): Boolean =
         inputTextEx(label, null, buf, size, flags or Itf._Multiline, callback, userData)
 
     /** String overload */
     fun inputTextWithHint(
-        label: String, hint: String, buf: String, flags: InputTextFlags = emptyFlags(),
+        label: String, hint: String, buf: String, flags: InputTextSingleFlags = emptyFlags,
         callback: InputTextCallback? = null, userData: Any? = null
     ): Boolean =
         inputTextWithHint(label, hint, buf.toByteArray(), flags)
 
+    /** call InputTextMultiline() or InputTextEx() manually if you need multi-line + hint. */
     fun inputTextWithHint(
-        label: String, hint: String, buf: ByteArray, flags: InputTextFlags = emptyFlags(),
+        label: String, hint: String, buf: ByteArray, flags: InputTextSingleFlags = emptyFlags,
         callback: InputTextCallback? = null, userData: Any? = null
-    ): Boolean {
-        assert(flags hasnt Itf._Multiline) { "call InputTextMultiline() or InputTextEx() manually if you need multi-line + hint." }
-        return inputTextEx(label, hint, buf, Vec2(), flags, callback, userData)
-    }
+    ): Boolean = inputTextEx(label, hint, buf, Vec2(), flags, callback, userData)
 
 
     fun inputFloat(
         label: String, v: FloatArray, step: Float = 0f, stepFast: Float = 0f,
-        format: String = "%.3f", flags: InputTextFlags = emptyFlags()
+        format: String = "%.3f", flags: InputTextSingleFlags = emptyFlags
     ): Boolean =
         inputFloat(label, v, 0, step, stepFast, format, flags)
 
     fun inputFloat(
         label: String, v: FloatArray, ptr: Int = 0, step: Float = 0f, stepFast: Float = 0f,
-        format: String = "%.3f", flags: InputTextFlags = emptyFlags()
+        format: String = "%.3f", flags: InputTextSingleFlags = emptyFlags
     ): Boolean =
         withFloat(v, ptr) { inputFloat(label, it, step, stepFast, format, flags) }
 
     fun inputFloat(
         label: String, v: KMutableProperty0<Float>, step: Float = 0f, stepFast: Float = 0f,
-        format: String = "%.3f", flags_: InputTextFlags = emptyFlags()
+        format: String = "%.3f", flags_: InputTextSingleFlags = emptyFlags
     ): Boolean {
         val flags = flags_ or Itf.CharsScientific
         return inputScalar(label, DataType.Float, v, step.takeIf { it > 0f }, stepFast.takeIf { it > 0f }, format, flags)
     }
 
 
-    fun inputFloat2(label: String, v: FloatArray, format: String = "%.3f", flags: InputTextFlags = emptyFlags()): Boolean =
+    fun inputFloat2(label: String, v: FloatArray, format: String = "%.3f", flags: InputTextSingleFlags = emptyFlags): Boolean =
         inputScalarN<Float>(label, DataType.Float, v, 2, null, null, format, flags)
 
-    fun inputVec2(label: String, v: Vec2, format: String = "%.3f", flags: InputTextFlags = emptyFlags()): Boolean =
+    fun inputVec2(label: String, v: Vec2, format: String = "%.3f", flags: InputTextSingleFlags = emptyFlags): Boolean =
         inputScalarN<Float>(label, DataType.Float, v to _fa, Vec2.length, null, null, format, flags)
             .also { v put _fa }
 
-    fun inputFloat3(label: String, v: FloatArray, format: String = "%.3f", flags: InputTextFlags = emptyFlags()): Boolean =
+    fun inputFloat3(label: String, v: FloatArray, format: String = "%.3f", flags: InputTextSingleFlags = emptyFlags): Boolean =
         inputScalarN<Float>(label, DataType.Float, v, 3, null, null, format, flags)
 
-    fun inputVec3(label: String, v: Vec3, format: String = "%.3f", flags: InputTextFlags = emptyFlags()): Boolean =
+    fun inputVec3(label: String, v: Vec3, format: String = "%.3f", flags: InputTextSingleFlags = emptyFlags): Boolean =
         inputScalarN<Float>(label, DataType.Float, v to _fa, Vec3.length, null, null, format, flags)
             .also { v put _fa }
 
-    fun inputFloat4(label: String, v: FloatArray, format: String = "%.3f", flags: InputTextFlags = emptyFlags()): Boolean =
+    fun inputFloat4(label: String, v: FloatArray, format: String = "%.3f", flags: InputTextSingleFlags = emptyFlags): Boolean =
         inputScalarN<Float>(label, DataType.Float, v, 4, null, null, format, flags)
 
-    fun inputVec4(label: String, v: Vec4, format: String = "%.3f", flags: InputTextFlags = emptyFlags()): Boolean =
+    fun inputVec4(label: String, v: Vec4, format: String = "%.3f", flags: InputTextSingleFlags = emptyFlags): Boolean =
         inputScalarN<Float>(label, DataType.Float, v to _fa, Vec4.length, null, null, format, flags)
             .also { v put _fa }
 
-    fun inputInt(label: String, v: KMutableProperty0<Int>, step: Int = 1, stepFast: Int = 100, flags: InputTextFlags = emptyFlags()): Boolean {
+    fun inputInt(label: String, v: KMutableProperty0<Int>, step: Int = 1, stepFast: Int = 100, flags: InputTextSingleFlags = emptyFlags): Boolean {
         /*  Hexadecimal input provided as a convenience but the flag name is awkward. Typically you'd use inputText()
             to parse your own data, if you want to handle prefixes.             */
         val format = if (flags has Itf.CharsHexadecimal) "%08X" else "%d"
         return inputScalar(label, DataType.Int, v, step.takeIf { it > 0f }, stepFast.takeIf { it > 0f }, format, flags)
     }
 
-    fun inputInt2(label: String, v: IntArray, flags: InputTextFlags = emptyFlags()): Boolean =
+    fun inputInt2(label: String, v: IntArray, flags: InputTextSingleFlags = emptyFlags): Boolean =
         inputScalarN<Int>(label, DataType.Int, v, 2, null, null, "%d", flags)
 
-    fun inputVec2i(label: String, v: Vec2i, flags: InputTextFlags = emptyFlags()): Boolean =
+    fun inputVec2i(label: String, v: Vec2i, flags: InputTextSingleFlags = emptyFlags): Boolean =
         inputScalarN<Int>(label, DataType.Int, v to _ia, Vec2i.length, null, null, "%d", flags)
             .also { v put _ia }
 
-    fun inputInt3(label: String, v: IntArray, flags: InputTextFlags = emptyFlags()): Boolean =
+    fun inputInt3(label: String, v: IntArray, flags: InputTextSingleFlags = emptyFlags): Boolean =
         inputScalarN<Int>(label, DataType.Int, v, 3, null, null, "%d", flags)
 
-    fun inputVec3i(label: String, v: Vec3i, flags: InputTextFlags = emptyFlags()): Boolean =
+    fun inputVec3i(label: String, v: Vec3i, flags: InputTextSingleFlags = emptyFlags): Boolean =
         inputScalarN<Int>(label, DataType.Int, v to _ia, Vec3i.length, null, null, "%d", flags)
             .also { v put _ia }
 
-    fun inputInt4(label: String, v: IntArray, flags: InputTextFlags = emptyFlags()): Boolean =
+    fun inputInt4(label: String, v: IntArray, flags: InputTextSingleFlags = emptyFlags): Boolean =
         inputScalarN<Int>(label, DataType.Int, v, 4, null, null, "%d", flags)
 
-    fun inputVec4i(label: String, v: Vec4i, flags: InputTextFlags = emptyFlags()): Boolean =
+    fun inputVec4i(label: String, v: Vec4i, flags: InputTextSingleFlags = emptyFlags): Boolean =
         inputScalarN<Int>(label, DataType.Int, v to _ia, Vec4i.length, null, null, "%d", flags)
             .also { v put _ia }
 
     fun inputDouble(
         label: String, v: KMutableProperty0<Double>, step: Double = 0.0, stepFast: Double = 0.0,
-        format: String? = "%.6f", flags_: InputTextFlags = emptyFlags()
+        format: String? = "%.6f", flags_: InputTextSingleFlags = emptyFlags
     ): Boolean {
         val flags = flags_ or Itf.CharsScientific
         /*  Ideally we'd have a minimum decimal precision of 1 to visually denote that this is a float,
@@ -194,14 +189,14 @@ interface widgetsInputWithKeyboard {
 
     fun <N> inputScalar(
         label: String, dataType: DataType, pData: IntArray, step: Int?, stepFast: Int?,
-        format: String? = null, flags: InputTextFlags = emptyFlags()
+        format: String? = null, flags: InputTextSingleFlags = emptyFlags
     )
             : Boolean where N : Number, N : Comparable<N> =
         withInt(pData) { inputScalar(label, dataType, it, step, stepFast, format, flags) }
 
     fun <N> inputScalar(
         label: String, dataType: DataType, pData: KMutableProperty0<N>, step: N? = null, stepFast: N? = null,
-        format_: String? = null, flags_: InputTextFlags = emptyFlags()
+        format_: String? = null, flags_: InputTextSingleFlags = emptyFlags
     ): Boolean where N : Number, N : Comparable<N> {
 
         var data by pData
@@ -213,6 +208,7 @@ interface widgetsInputWithKeyboard {
                 DataType.Float, DataType.Double -> "%f"
                 else -> "%d"
             }
+
             else -> format_
         }
 
@@ -274,7 +270,7 @@ interface widgetsInputWithKeyboard {
 
     fun <N> inputScalarN(
         label: String, dataType: DataType, v: Any, components: Int, step: N? = null, stepFast: N? = null,
-        format: String? = null, flags: InputTextFlags = emptyFlags()
+        format: String? = null, flags: InputTextSingleFlags = emptyFlags
     ): Boolean where N : Number, N : Comparable<N> {
 
         val window = currentWindow

--- a/core/src/main/kotlin/imgui/api/widgetsListBoxes.kt
+++ b/core/src/main/kotlin/imgui/api/widgetsListBoxes.kt
@@ -25,7 +25,6 @@ import imgui.ImGui.style
 import imgui.ImGui.textLineHeightWithSpacing
 import imgui.WindowFlag
 import imgui.classes.ListClipper
-import imgui.has
 import imgui.internal.classes.Rect
 import imgui.internal.floor
 import imgui.withBool

--- a/core/src/main/kotlin/imgui/api/widgetsListBoxes.kt
+++ b/core/src/main/kotlin/imgui/api/widgetsListBoxes.kt
@@ -25,6 +25,7 @@ import imgui.ImGui.style
 import imgui.ImGui.textLineHeightWithSpacing
 import imgui.WindowFlag
 import imgui.classes.ListClipper
+import imgui.has
 import imgui.internal.classes.Rect
 import imgui.internal.floor
 import imgui.withBool

--- a/core/src/main/kotlin/imgui/api/widgetsMain.kt
+++ b/core/src/main/kotlin/imgui/api/widgetsMain.kt
@@ -1,8 +1,8 @@
 package imgui.api
 
-import glm_.*
+import glm_.glm
+import glm_.max
 import glm_.vec2.Vec2
-import glm_.vec4.Vec4
 import imgui.*
 import imgui.ImGui.arrowButtonEx
 import imgui.ImGui.buttonBehavior
@@ -12,14 +12,10 @@ import imgui.ImGui.calcItemWidth
 import imgui.ImGui.calcTextSize
 import imgui.ImGui.currentWindow
 import imgui.ImGui.frameHeight
-import imgui.ImGui.getColorU32
-import imgui.ImGui.imageButtonEx
 import imgui.ImGui.itemAdd
 import imgui.ImGui.itemSize
 import imgui.ImGui.logRenderedText
 import imgui.ImGui.markItemEdited
-import imgui.ImGui.popID
-import imgui.ImGui.pushID
 import imgui.ImGui.renderBullet
 import imgui.ImGui.renderCheckMark
 import imgui.ImGui.renderFrame
@@ -34,7 +30,10 @@ import imgui.internal.floor
 import imgui.internal.lerp
 import imgui.internal.round
 import imgui.internal.saturate
-import imgui.internal.sections.*
+import imgui.internal.sections.ButtonFlags
+import imgui.internal.sections.IMGUI_TEST_ENGINE_ITEM_INFO
+import imgui.internal.sections.ItemFlag
+import imgui.internal.sections.ItemStatusFlag
 import kool.getValue
 import kool.setValue
 import kotlin.reflect.KMutableProperty0
@@ -61,14 +60,14 @@ val S32_MAX: Int = Integer.MAX_VALUE
 interface widgetsMain {
 
     /** button  */
-    fun button(label: String, sizeArg: Vec2 = Vec2()): Boolean = buttonEx(label, sizeArg, Bf.None.i)
+    fun button(label: String, sizeArg: Vec2 = Vec2()): Boolean = buttonEx(label, sizeArg, emptyFlags())
 
     /** button with FramePadding = (0,0) to easily embed within text
      *  Small buttons fits within text without additional vertical spacing.     */
     fun smallButton(label: String): Boolean {
         val backupPaddingY = style.framePadding.y
         style.framePadding.y = 0f
-        val pressed = buttonEx(label, Vec2(), Bf.AlignTextBaseLine.i)
+        val pressed = buttonEx(label, Vec2(), Bf.AlignTextBaseLine)
         style.framePadding.y = backupPaddingY
         return pressed
     }
@@ -78,7 +77,7 @@ interface widgetsMain {
      *  Tip: use pushId()/popId() to push indices or pointers in the ID stack.
      *  Then you can keep 'strid' empty or the same for all your buttons (instead of creating a string based on a
      *  non-string id)  */
-    fun invisibleButton(strId: String, sizeArg: Vec2, flags: ButtonFlags = Bf.None.i): Boolean {
+    fun invisibleButton(strId: String, sizeArg: Vec2, flags: ButtonFlags = emptyFlags()): Boolean {
         val window = currentWindow
         if (window.skipItems) return false
 
@@ -96,7 +95,7 @@ interface widgetsMain {
         return pressed
     }
 
-    fun arrowButton(id: String, dir: Dir): Boolean = arrowButtonEx(id, dir, Vec2(frameHeight), Bf.None.i)
+    fun arrowButton(id: String, dir: Dir): Boolean = arrowButtonEx(id, dir, Vec2(frameHeight), emptyFlags())
 
     fun checkbox(label: String, v: BooleanArray) = checkbox(label, v, 0)
     fun checkbox(label: String, v: BooleanArray, i: Int): Boolean {
@@ -120,7 +119,7 @@ interface widgetsMain {
         val totalBb = Rect(pos, pos + Vec2(squareSz + if (labelSize.x > 0f) style.itemInnerSpacing.x + labelSize.x else 0f, labelSize.y + style.framePadding.y * 2f))
         itemSize(totalBb, style.framePadding.y)
         if (!itemAdd(totalBb, id)) {
-            IMGUI_TEST_ENGINE_ITEM_INFO(id, label, g.lastItemData.statusFlags or ItemStatusFlag.Checkable or if(v) ItemStatusFlag.Checked else ItemStatusFlag.None)
+            IMGUI_TEST_ENGINE_ITEM_INFO(id, label, g.lastItemData.statusFlags or ItemStatusFlag.Checkable or if (v) ItemStatusFlag.Checked else emptyFlags())
             return false
         }
 
@@ -152,14 +151,14 @@ interface widgetsMain {
         if (labelSize.x > 0f)
             renderText(renderTextPos, label)
 
-        val flags = ItemStatusFlag.Checkable or if(v) ItemStatusFlag.Checked else ItemStatusFlag.None
+        val flags = ItemStatusFlag.Checkable or if (v) ItemStatusFlag.Checked else emptyFlags()
         IMGUI_TEST_ENGINE_ITEM_INFO(id, label, g.lastItemData.statusFlags or flags)
 
         return pressed
     }
 
-    fun checkboxFlags(label: String, flags: IntArray, flagsValue: Int): Boolean {
-        _b = (flags[0] and flagsValue) == flagsValue // ~allOn
+    fun <F : Flag<F>> checkboxFlags(label: String, flags: FlagArray<F>, flagsValue: Flag<F>): Boolean {
+        _b = flagsValue in flags[0] // ~allOn
         val anyOn = flags[0] has flagsValue
         val pressed = when {
             !_b && anyOn -> {
@@ -180,9 +179,9 @@ interface widgetsMain {
         return pressed
     }
 
-    fun checkboxFlags(label: String, flagsPtr: KMutableProperty0<Int>, flagsValue: Int): Boolean {
+    fun <F : Flag<F>> checkboxFlags(label: String, flagsPtr: KMutableProperty0<Flag<F>>, flagsValue: Flag<F>): Boolean {
         var flags by flagsPtr
-        val v = booleanArrayOf((flags and flagsValue) == flagsValue)
+        val v = booleanArrayOf(flagsValue in flags)
         val pressed = checkbox(label, v)
         if (pressed)
             flags = when {

--- a/core/src/main/kotlin/imgui/api/widgetsMain.kt
+++ b/core/src/main/kotlin/imgui/api/widgetsMain.kt
@@ -157,6 +157,10 @@ interface widgetsMain {
         return pressed
     }
 
+    // We use JvmName to ensure that the function can be seen in Java as checkboxFlags
+    // Suppressing the warning since we're in an interface.
+    @Suppress("INAPPLICABLE_JVM_NAME")
+    @JvmName("checkboxFlags")
     fun <F : Flag<F>> checkboxFlags(label: String, flags: FlagArray<F>, flagsValue: Flag<F>): Boolean {
         _b = flagsValue in flags[0] // ~allOn
         val anyOn = flags[0] has flagsValue

--- a/core/src/main/kotlin/imgui/api/widgetsMain.kt
+++ b/core/src/main/kotlin/imgui/api/widgetsMain.kt
@@ -60,7 +60,7 @@ val S32_MAX: Int = Integer.MAX_VALUE
 interface widgetsMain {
 
     /** button  */
-    fun button(label: String, sizeArg: Vec2 = Vec2()): Boolean = buttonEx(label, sizeArg, emptyFlags())
+    fun button(label: String, sizeArg: Vec2 = Vec2()): Boolean = buttonEx(label, sizeArg, emptyFlags)
 
     /** button with FramePadding = (0,0) to easily embed within text
      *  Small buttons fits within text without additional vertical spacing.     */
@@ -77,7 +77,7 @@ interface widgetsMain {
      *  Tip: use pushId()/popId() to push indices or pointers in the ID stack.
      *  Then you can keep 'strid' empty or the same for all your buttons (instead of creating a string based on a
      *  non-string id)  */
-    fun invisibleButton(strId: String, sizeArg: Vec2, flags: ButtonFlags = emptyFlags()): Boolean {
+    fun invisibleButton(strId: String, sizeArg: Vec2, flags: ButtonFlags = emptyFlags): Boolean {
         val window = currentWindow
         if (window.skipItems) return false
 
@@ -95,7 +95,7 @@ interface widgetsMain {
         return pressed
     }
 
-    fun arrowButton(id: String, dir: Dir): Boolean = arrowButtonEx(id, dir, Vec2(frameHeight), emptyFlags())
+    fun arrowButton(id: String, dir: Dir): Boolean = arrowButtonEx(id, dir, Vec2(frameHeight), emptyFlags)
 
     fun checkbox(label: String, v: BooleanArray) = checkbox(label, v, 0)
     fun checkbox(label: String, v: BooleanArray, i: Int): Boolean {
@@ -119,7 +119,7 @@ interface widgetsMain {
         val totalBb = Rect(pos, pos + Vec2(squareSz + if (labelSize.x > 0f) style.itemInnerSpacing.x + labelSize.x else 0f, labelSize.y + style.framePadding.y * 2f))
         itemSize(totalBb, style.framePadding.y)
         if (!itemAdd(totalBb, id)) {
-            IMGUI_TEST_ENGINE_ITEM_INFO(id, label, g.lastItemData.statusFlags or ItemStatusFlag.Checkable or if (v) ItemStatusFlag.Checked else emptyFlags())
+            IMGUI_TEST_ENGINE_ITEM_INFO(id, label, g.lastItemData.statusFlags or ItemStatusFlag.Checkable or if (v) ItemStatusFlag.Checked else emptyFlags)
             return false
         }
 
@@ -151,7 +151,7 @@ interface widgetsMain {
         if (labelSize.x > 0f)
             renderText(renderTextPos, label)
 
-        val flags = ItemStatusFlag.Checkable or if (v) ItemStatusFlag.Checked else emptyFlags()
+        val flags = ItemStatusFlag.Checkable or if (v) ItemStatusFlag.Checked else emptyFlags
         IMGUI_TEST_ENGINE_ITEM_INFO(id, label, g.lastItemData.statusFlags or flags)
 
         return pressed

--- a/core/src/main/kotlin/imgui/api/widgetsSelectables.kt
+++ b/core/src/main/kotlin/imgui/api/widgetsSelectables.kt
@@ -2,17 +2,17 @@ package imgui.api
 
 import glm_.vec2.Vec2
 import imgui.*
+import imgui.ImGui.beginDisabled
 import imgui.ImGui.buttonBehavior
 import imgui.ImGui.calcTextSize
 import imgui.ImGui.closeCurrentPopup
 import imgui.ImGui.currentWindow
+import imgui.ImGui.endDisabled
 import imgui.ImGui.itemAdd
 import imgui.ImGui.itemSize
 import imgui.ImGui.markItemEdited
 import imgui.ImGui.popColumnsBackground
-import imgui.ImGui.endDisabled
 import imgui.ImGui.pushColumnsBackground
-import imgui.ImGui.beginDisabled
 import imgui.ImGui.renderFrame
 import imgui.ImGui.renderNavHighlight
 import imgui.ImGui.renderTextClipped
@@ -23,7 +23,10 @@ import imgui.ImGui.tablePopBackgroundChannel
 import imgui.ImGui.tablePushBackgroundChannel
 import imgui.internal.classes.Rect
 import imgui.internal.floor
-import imgui.internal.sections.*
+import imgui.internal.sections.ButtonFlags
+import imgui.internal.sections.IMGUI_TEST_ENGINE_ITEM_INFO
+import imgui.internal.sections.ItemStatusFlag
+import imgui.internal.sections.NavHighlightFlag
 import kool.getValue
 import kool.setValue
 import kotlin.reflect.KMutableProperty0
@@ -50,7 +53,7 @@ interface widgetsSelectables {
      *  size.x > 0f -> specify width
      *  size.y == 0f -> use label height
      *  size.y > 0f -> specify height   */
-    fun selectable(label: String, selected_: Boolean = false, flags: SelectableFlags = 0, sizeArg: Vec2 = Vec2()): Boolean {
+    fun selectable(label: String, selected_: Boolean = false, flags: SelectableFlags = emptyFlags(), sizeArg: Vec2 = Vec2()): Boolean {
 
         var selected = selected_
         val window = currentWindow
@@ -100,7 +103,7 @@ interface widgetsSelectables {
         }
 
         val disabledItem = flags has Sf.Disabled
-        val itemAdd = itemAdd(bb, id, null, if(disabledItem) If.Disabled.i else If.None.i)
+        val itemAdd = itemAdd(bb, id, null, if (disabledItem) If.Disabled else emptyFlags())
 
         if (spanAllColumns) {
             window.clipRect.min.x = backupClipRectMinX
@@ -122,7 +125,7 @@ interface widgetsSelectables {
             tablePushBackgroundChannel()
 
         // We use NoHoldingActiveID on menus so user can click and _hold_ on a menu then drag to browse child entries
-        var buttonFlags = 0
+        var buttonFlags: ButtonFlags = emptyFlags()
         if (flags has Sf._NoHoldingActiveID) buttonFlags /= Bf.NoHoldingActiveId
         if (flags has Sf._NoSetKeyOwner) buttonFlags /= Bf.NoSetKeyOwner
         if (flags has Sf._SelectOnClick) buttonFlags /= Bf.PressedOnClick
@@ -189,11 +192,11 @@ interface widgetsSelectables {
     }
 
     /** "bool* p_selected" point to the selection state (read-write), as a convenient helper.   */
-    fun selectable(label: String, selected: BooleanArray, index: Int, flags: SelectableFlags = 0, size: Vec2 = Vec2()): Boolean =
-            selectable(label, selected mutablePropertyAt index, flags, size)
+    fun selectable(label: String, selected: BooleanArray, index: Int, flags: SelectableFlags = emptyFlags(), size: Vec2 = Vec2()): Boolean =
+        selectable(label, selected mutablePropertyAt index, flags, size)
 
     /** "bool* p_selected" point to the selection state (read-write), as a convenient helper.   */
-    fun selectable(label: String, selectedPtr: KMutableProperty0<Boolean>, flags: SelectableFlags = 0, size: Vec2 = Vec2()): Boolean {
+    fun selectable(label: String, selectedPtr: KMutableProperty0<Boolean>, flags: SelectableFlags = emptyFlags(), size: Vec2 = Vec2()): Boolean {
         var selected by selectedPtr
         return if (selectable(label, selected, flags, size)) {
             selected = !selected

--- a/core/src/main/kotlin/imgui/api/widgetsSelectables.kt
+++ b/core/src/main/kotlin/imgui/api/widgetsSelectables.kt
@@ -53,7 +53,7 @@ interface widgetsSelectables {
      *  size.x > 0f -> specify width
      *  size.y == 0f -> use label height
      *  size.y > 0f -> specify height   */
-    fun selectable(label: String, selected_: Boolean = false, flags: SelectableFlags = emptyFlags(), sizeArg: Vec2 = Vec2()): Boolean {
+    fun selectable(label: String, selected_: Boolean = false, flags: SelectableFlags = emptyFlags, sizeArg: Vec2 = Vec2()): Boolean {
 
         var selected = selected_
         val window = currentWindow
@@ -83,7 +83,7 @@ interface widgetsSelectables {
         // Selectables are meant to be tightly packed together with no click-gap, so we extend their box to cover spacing between selectable.
         val bb = Rect(minX, pos.y, textMax.x, textMax.y)
         if (flags hasnt Sf._NoPadWithHalfSpacing) {
-            val spacingX = if(spanAllColumns) 0f else style.itemSpacing.x
+            val spacingX = if (spanAllColumns) 0f else style.itemSpacing.x
             val spacingY = style.itemSpacing.y
             val spacingL = floor(spacingX * 0.5f)
             val spacingU = floor(spacingY * 0.5f)
@@ -103,7 +103,7 @@ interface widgetsSelectables {
         }
 
         val disabledItem = flags has Sf.Disabled
-        val itemAdd = itemAdd(bb, id, null, if (disabledItem) If.Disabled else emptyFlags())
+        val itemAdd = itemAdd(bb, id, null, if (disabledItem) If.Disabled else emptyFlags)
 
         if (spanAllColumns) {
             window.clipRect.min.x = backupClipRectMinX
@@ -125,7 +125,7 @@ interface widgetsSelectables {
             tablePushBackgroundChannel()
 
         // We use NoHoldingActiveID on menus so user can click and _hold_ on a menu then drag to browse child entries
-        var buttonFlags: ButtonFlags = emptyFlags()
+        var buttonFlags: ButtonFlags = emptyFlags
         if (flags has Sf._NoHoldingActiveID) buttonFlags /= Bf.NoHoldingActiveId
         if (flags has Sf._NoSetKeyOwner) buttonFlags /= Bf.NoSetKeyOwner
         if (flags has Sf._SelectOnClick) buttonFlags /= Bf.PressedOnClick
@@ -146,9 +146,9 @@ interface widgetsSelectables {
         //   - (2) usage will fail with clipped items
         //   The multi-select API aim to fix those issues, e.g. may be replaced with a BeginSelection() API.
         if (flags has Sf._SelectOnNav && g.navJustMovedToId != 0 && g.navJustMovedToFocusScopeId == g.currentFocusScopeId)
-        if (g.navJustMovedToId == id) {
-            selected = true; pressed = true
-        }
+            if (g.navJustMovedToId == id) {
+                selected = true; pressed = true
+            }
 
         // Update NavId when clicking or when Hovering (this doesn't happen on most widgets), so navigation can be resumed with gamepad/keyboard
         if (pressed || (hovered && flags has Sf._SetNavIdOnHover))
@@ -192,11 +192,11 @@ interface widgetsSelectables {
     }
 
     /** "bool* p_selected" point to the selection state (read-write), as a convenient helper.   */
-    fun selectable(label: String, selected: BooleanArray, index: Int, flags: SelectableFlags = emptyFlags(), size: Vec2 = Vec2()): Boolean =
+    fun selectable(label: String, selected: BooleanArray, index: Int, flags: SelectableFlags = emptyFlags, size: Vec2 = Vec2()): Boolean =
         selectable(label, selected mutablePropertyAt index, flags, size)
 
     /** "bool* p_selected" point to the selection state (read-write), as a convenient helper.   */
-    fun selectable(label: String, selectedPtr: KMutableProperty0<Boolean>, flags: SelectableFlags = emptyFlags(), size: Vec2 = Vec2()): Boolean {
+    fun selectable(label: String, selectedPtr: KMutableProperty0<Boolean>, flags: SelectableFlags = emptyFlags, size: Vec2 = Vec2()): Boolean {
         var selected by selectedPtr
         return if (selectable(label, selected, flags, size)) {
             selected = !selected

--- a/core/src/main/kotlin/imgui/api/widgetsSliders.kt
+++ b/core/src/main/kotlin/imgui/api/widgetsSliders.kt
@@ -41,7 +41,7 @@ interface widgetsSliders {
      *  adjust format to decorate the value with a prefix or a suffix for in-slider labels or unit display. Use power!=1.0 for power curve sliders */
     fun sliderFloat(
         label: String, v: FloatArray, ptr: Int, vMin: Float, vMax: Float,
-        format: String = "%.3f", flags: SliderFlags = emptyFlags()
+        format: String = "%.3f", flags: SliderFlags = emptyFlags
     ): Boolean =
         withFloat(v, ptr) { sliderFloat(label, it, vMin, vMax, format, flags) }
 
@@ -53,52 +53,52 @@ interface widgetsSliders {
      *  adjust format to decorate the value with a prefix or a suffix for in-slider labels or unit display. Use power!=1.0 for power curve sliders */
     fun sliderFloat(
         label: String, v: KMutableProperty0<Float>, vMin: Float, vMax: Float,
-        format: String = "%.3f", flags: SliderFlags = emptyFlags()
+        format: String = "%.3f", flags: SliderFlags = emptyFlags
     ): Boolean =
         sliderScalar(label, DataType.Float, v, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
 
     fun sliderFloat2(
         label: String, v: FloatArray, vMin: Float, vMax: Float,
-        format: String = "%.3f", flags: SliderFlags = emptyFlags()
+        format: String = "%.3f", flags: SliderFlags = emptyFlags
     ): Boolean =
         sliderScalarN(label, DataType.Float, v, 2, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
 
     fun sliderVec2(
         label: String, v: Vec2, vMin: Float, vMax: Float,
-        format: String = "%.3f", flags: SliderFlags = emptyFlags()
+        format: String = "%.3f", flags: SliderFlags = emptyFlags
     ): Boolean =
         sliderScalarN(label, DataType.Float, v to _fa, 2, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
             .also { v put _fa }
 
     fun sliderFloat3(
         label: String, v: FloatArray, vMin: Float, vMax: Float,
-        format: String = "%.3f", flags: SliderFlags = emptyFlags()
+        format: String = "%.3f", flags: SliderFlags = emptyFlags
     ): Boolean =
         sliderScalarN(label, DataType.Float, v, 3, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
 
     fun sliderVec3(
         label: String, v: Vec3, vMin: Float, vMax: Float,
-        format: String = "%.3f", flags: SliderFlags = emptyFlags()
+        format: String = "%.3f", flags: SliderFlags = emptyFlags
     ): Boolean =
         sliderScalarN(label, DataType.Float, v to _fa, 3, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
             .also { v put _fa }
 
     fun sliderFloat4(
         label: String, v: FloatArray, vMin: Float, vMax: Float,
-        format: String = "%.3f", flags: SliderFlags = emptyFlags()
+        format: String = "%.3f", flags: SliderFlags = emptyFlags
     ): Boolean =
         sliderScalarN(label, DataType.Float, v, 4, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
 
     fun sliderVec4(
         label: String, v: Vec4, vMin: Float, vMax: Float,
-        format: String = "%.3f", flags: SliderFlags = emptyFlags()
+        format: String = "%.3f", flags: SliderFlags = emptyFlags
     ): Boolean =
         sliderScalarN(label, DataType.Float, v to _fa, 4, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
             .also { v put _fa }
 
     fun sliderAngle(
         label: String, vRadPtr: KMutableProperty0<Float>, vDegreesMin: Float = -360f, vDegreesMax: Float = 360f,
-        format_: String = "%.0f deg", flags: SliderFlags = emptyFlags()
+        format_: String = "%.0f deg", flags: SliderFlags = emptyFlags
     ): Boolean {
         val format = format_.ifEmpty { "%.0f deg" }
         var vRad by vRadPtr
@@ -109,51 +109,51 @@ interface widgetsSliders {
 
     fun sliderInt(
         label: String, v: IntArray, ptr: Int, vMin: Int, vMax: Int,
-        format: String = "%d", flags: SliderFlags = emptyFlags()
+        format: String = "%d", flags: SliderFlags = emptyFlags
     ): Boolean =
         withInt(v, ptr) { sliderInt(label, it, vMin, vMax, format, flags) }
 
     fun sliderInt(
         label: String, v: KMutableProperty0<Int>, vMin: Int, vMax: Int,
-        format: String = "%d", flags: SliderFlags = emptyFlags()
+        format: String = "%d", flags: SliderFlags = emptyFlags
     ): Boolean =
         sliderScalar(label, DataType.Int, v, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
 
     fun sliderInt2(
         label: String, v: IntArray, vMin: Int, vMax: Int,
-        format: String = "%d", flags: SliderFlags = emptyFlags()
+        format: String = "%d", flags: SliderFlags = emptyFlags
     ): Boolean =
         sliderScalarN(label, DataType.Int, v, 2, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
 
     fun sliderVec2i(
         label: String, v: Vec2i, vMin: Int, vMax: Int,
-        format: String = "%d", flags: SliderFlags = emptyFlags()
+        format: String = "%d", flags: SliderFlags = emptyFlags
     ): Boolean =
         sliderScalarN(label, DataType.Int, v to _ia, 2, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
             .also { v put _ia }
 
     fun sliderInt3(
         label: String, v: IntArray, vMin: Int, vMax: Int,
-        format: String = "%d", flags: SliderFlags = emptyFlags()
+        format: String = "%d", flags: SliderFlags = emptyFlags
     ): Boolean =
         sliderScalarN(label, DataType.Int, v, 3, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
 
     fun sliderVec3i(
         label: String, v: Vec3i, vMin: Int, vMax: Int,
-        format: String = "%d", flags: SliderFlags = emptyFlags()
+        format: String = "%d", flags: SliderFlags = emptyFlags
     ): Boolean =
         sliderScalarN(label, DataType.Int, v to _ia, 3, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
             .also { v put _ia }
 
     fun sliderInt4(
         label: String, v: IntArray, vMin: Int, vMax: Int,
-        format: String = "%d", flags: SliderFlags = emptyFlags()
+        format: String = "%d", flags: SliderFlags = emptyFlags
     ): Boolean =
         sliderScalarN(label, DataType.Int, v, 4, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
 
     fun sliderVec4i(
         label: String, v: Vec4i, vMin: Int, vMax: Int,
-        format: String = "%d", flags: SliderFlags = emptyFlags()
+        format: String = "%d", flags: SliderFlags = emptyFlags
     ): Boolean =
         sliderScalarN(label, DataType.Int, v to _ia, 4, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
             .also { v put _ia }
@@ -170,7 +170,7 @@ interface widgetsSliders {
     fun <N> sliderScalar(
         label: String, dataType: DataType, pData: KMutableProperty0<N>,
         pMin: KMutableProperty0<N>? = null, pMax: KMutableProperty0<N>? = null,
-        format_: String? = null, flags: SliderFlags = emptyFlags()
+        format_: String? = null, flags: SliderFlags = emptyFlags
     ): Boolean
             where N : Number, N : Comparable<N> {
 
@@ -186,7 +186,7 @@ interface widgetsSliders {
 
         val tempInputAllowed = flags hasnt SliderFlag.NoInput
         ImGui.itemSize(totalBb, ImGui.style.framePadding.y)
-        if (!ImGui.itemAdd(totalBb, id, frameBb, if (tempInputAllowed) ItemFlag.Inputable else emptyFlags()))
+        if (!ImGui.itemAdd(totalBb, id, frameBb, if (tempInputAllowed) ItemFlag.Inputable else emptyFlags))
             return false
 
         // Default format string when passing NULL
@@ -260,7 +260,7 @@ interface widgetsSliders {
     fun <N> sliderScalarN(
         label: String, dataType: DataType, pData: Any, components: Int,
         pMin: KMutableProperty0<N>? = null, pMax: KMutableProperty0<N>? = null,
-        format: String? = null, flags: SliderFlags = emptyFlags()
+        format: String? = null, flags: SliderFlags = emptyFlags
     ): Boolean
             where N : Number, N : Comparable<N> {
 
@@ -302,14 +302,14 @@ interface widgetsSliders {
 
     fun <N> vSliderFloat(
         label: String, size: Vec2, v: KMutableProperty0<N>, vMin: Float, vMax: Float,
-        format: String = "%.3f", flags: SliderFlags = emptyFlags()
+        format: String = "%.3f", flags: SliderFlags = emptyFlags
     ): Boolean
             where N : Number, N : Comparable<N> =
         vSliderScalar(label, size, DataType.Float, v, (vMin as N).asMutableProperty, (vMax as N).asMutableProperty, format, flags)
 
     fun <N> vSliderInt(
         label: String, size: Vec2, v: KMutableProperty0<N>, vMin: Int, vMax: Int,
-        format: String = "%d", flags: SliderFlags = emptyFlags()
+        format: String = "%d", flags: SliderFlags = emptyFlags
     ): Boolean
             where N : Number, N : Comparable<N> =
         vSliderScalar(label, size, DataType.Int, v, (vMin as N).asMutableProperty, (vMax as N).asMutableProperty, format, flags)
@@ -318,7 +318,7 @@ interface widgetsSliders {
     fun <N> vSliderScalar(
         label: String, size: Vec2, dataType: DataType, pData: KMutableProperty0<N>,
         pMin: KMutableProperty0<N>? = null, pMax: KMutableProperty0<N>? = null,
-        format_: String? = null, flags: SliderFlags = emptyFlags()
+        format_: String? = null, flags: SliderFlags = emptyFlags
     ): Boolean
             where N : Number, N : Comparable<N> {
 

--- a/core/src/main/kotlin/imgui/api/widgetsSliders.kt
+++ b/core/src/main/kotlin/imgui/api/widgetsSliders.kt
@@ -39,9 +39,11 @@ interface widgetsSliders {
      *  "Gold: %.0f"   Gold: 1
      *  Use power != 1.0f for non-linear sliders.
      *  adjust format to decorate the value with a prefix or a suffix for in-slider labels or unit display. Use power!=1.0 for power curve sliders */
-    fun sliderFloat(label: String, v: FloatArray, ptr: Int, vMin: Float, vMax: Float,
-                    format: String = "%.3f", flags: SliderFlags = SliderFlag.None.i): Boolean =
-            withFloat(v, ptr) { sliderFloat(label, it, vMin, vMax, format, flags) }
+    fun sliderFloat(
+        label: String, v: FloatArray, ptr: Int, vMin: Float, vMax: Float,
+        format: String = "%.3f", flags: SliderFlags = emptyFlags()
+    ): Boolean =
+        withFloat(v, ptr) { sliderFloat(label, it, vMin, vMax, format, flags) }
 
     /** Adjust format to decorate the value with a prefix or a suffix.
      *  "%.3f"         1.234
@@ -49,80 +51,112 @@ interface widgetsSliders {
      *  "Gold: %.0f"   Gold: 1
      *  Use power != 1.0f for non-linear sliders.
      *  adjust format to decorate the value with a prefix or a suffix for in-slider labels or unit display. Use power!=1.0 for power curve sliders */
-    fun sliderFloat(label: String, v: KMutableProperty0<Float>, vMin: Float, vMax: Float,
-                    format: String = "%.3f", flags: SliderFlags = SliderFlag.None.i): Boolean =
-            sliderScalar(label, DataType.Float, v, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
+    fun sliderFloat(
+        label: String, v: KMutableProperty0<Float>, vMin: Float, vMax: Float,
+        format: String = "%.3f", flags: SliderFlags = emptyFlags()
+    ): Boolean =
+        sliderScalar(label, DataType.Float, v, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
 
-    fun sliderFloat2(label: String, v: FloatArray, vMin: Float, vMax: Float,
-                     format: String = "%.3f", flags: SliderFlags = SliderFlag.None.i): Boolean =
-            sliderScalarN(label, DataType.Float, v, 2, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
+    fun sliderFloat2(
+        label: String, v: FloatArray, vMin: Float, vMax: Float,
+        format: String = "%.3f", flags: SliderFlags = emptyFlags()
+    ): Boolean =
+        sliderScalarN(label, DataType.Float, v, 2, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
 
-    fun sliderVec2(label: String, v: Vec2, vMin: Float, vMax: Float,
-                   format: String = "%.3f", flags: SliderFlags = SliderFlag.None.i): Boolean =
-            sliderScalarN(label, DataType.Float, v to _fa, 2, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
-                    .also { v put _fa }
+    fun sliderVec2(
+        label: String, v: Vec2, vMin: Float, vMax: Float,
+        format: String = "%.3f", flags: SliderFlags = emptyFlags()
+    ): Boolean =
+        sliderScalarN(label, DataType.Float, v to _fa, 2, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
+            .also { v put _fa }
 
-    fun sliderFloat3(label: String, v: FloatArray, vMin: Float, vMax: Float,
-                     format: String = "%.3f", flags: SliderFlags = SliderFlag.None.i): Boolean =
-            sliderScalarN(label, DataType.Float, v, 3, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
+    fun sliderFloat3(
+        label: String, v: FloatArray, vMin: Float, vMax: Float,
+        format: String = "%.3f", flags: SliderFlags = emptyFlags()
+    ): Boolean =
+        sliderScalarN(label, DataType.Float, v, 3, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
 
-    fun sliderVec3(label: String, v: Vec3, vMin: Float, vMax: Float,
-                   format: String = "%.3f", flags: SliderFlags = SliderFlag.None.i): Boolean =
-            sliderScalarN(label, DataType.Float, v to _fa, 3, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
-                    .also { v put _fa }
+    fun sliderVec3(
+        label: String, v: Vec3, vMin: Float, vMax: Float,
+        format: String = "%.3f", flags: SliderFlags = emptyFlags()
+    ): Boolean =
+        sliderScalarN(label, DataType.Float, v to _fa, 3, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
+            .also { v put _fa }
 
-    fun sliderFloat4(label: String, v: FloatArray, vMin: Float, vMax: Float,
-                     format: String = "%.3f", flags: SliderFlags = SliderFlag.None.i): Boolean =
-            sliderScalarN(label, DataType.Float, v, 4, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
+    fun sliderFloat4(
+        label: String, v: FloatArray, vMin: Float, vMax: Float,
+        format: String = "%.3f", flags: SliderFlags = emptyFlags()
+    ): Boolean =
+        sliderScalarN(label, DataType.Float, v, 4, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
 
-    fun sliderVec4(label: String, v: Vec4, vMin: Float, vMax: Float,
-                   format: String = "%.3f", flags: SliderFlags = SliderFlag.None.i): Boolean =
-            sliderScalarN(label, DataType.Float, v to _fa, 4, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
-                    .also { v put _fa }
+    fun sliderVec4(
+        label: String, v: Vec4, vMin: Float, vMax: Float,
+        format: String = "%.3f", flags: SliderFlags = emptyFlags()
+    ): Boolean =
+        sliderScalarN(label, DataType.Float, v to _fa, 4, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
+            .also { v put _fa }
 
-    fun sliderAngle(label: String, vRadPtr: KMutableProperty0<Float>, vDegreesMin: Float = -360f, vDegreesMax: Float = 360f,
-                    format_: String = "%.0f deg", flags: SliderFlags = SliderFlag.None.i): Boolean {
+    fun sliderAngle(
+        label: String, vRadPtr: KMutableProperty0<Float>, vDegreesMin: Float = -360f, vDegreesMax: Float = 360f,
+        format_: String = "%.0f deg", flags: SliderFlags = emptyFlags()
+    ): Boolean {
         val format = format_.ifEmpty { "%.0f deg" }
         var vRad by vRadPtr
         vRad = vRad.deg
         return sliderFloat(label, vRadPtr, vDegreesMin, vDegreesMax, format, flags)
-                .also { vRad = vRad.rad }
+            .also { vRad = vRad.rad }
     }
 
-    fun sliderInt(label: String, v: IntArray, ptr: Int, vMin: Int, vMax: Int,
-                  format: String = "%d", flags: SliderFlags = SliderFlag.None.i): Boolean =
-            withInt(v, ptr) { sliderInt(label, it, vMin, vMax, format, flags) }
+    fun sliderInt(
+        label: String, v: IntArray, ptr: Int, vMin: Int, vMax: Int,
+        format: String = "%d", flags: SliderFlags = emptyFlags()
+    ): Boolean =
+        withInt(v, ptr) { sliderInt(label, it, vMin, vMax, format, flags) }
 
-    fun sliderInt(label: String, v: KMutableProperty0<Int>, vMin: Int, vMax: Int,
-                  format: String = "%d", flags: SliderFlags = SliderFlag.None.i): Boolean =
-            sliderScalar(label, DataType.Int, v, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
+    fun sliderInt(
+        label: String, v: KMutableProperty0<Int>, vMin: Int, vMax: Int,
+        format: String = "%d", flags: SliderFlags = emptyFlags()
+    ): Boolean =
+        sliderScalar(label, DataType.Int, v, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
 
-    fun sliderInt2(label: String, v: IntArray, vMin: Int, vMax: Int,
-                   format: String = "%d", flags: SliderFlags = SliderFlag.None.i): Boolean =
-            sliderScalarN(label, DataType.Int, v, 2, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
+    fun sliderInt2(
+        label: String, v: IntArray, vMin: Int, vMax: Int,
+        format: String = "%d", flags: SliderFlags = emptyFlags()
+    ): Boolean =
+        sliderScalarN(label, DataType.Int, v, 2, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
 
-    fun sliderVec2i(label: String, v: Vec2i, vMin: Int, vMax: Int,
-                    format: String = "%d", flags: SliderFlags = SliderFlag.None.i): Boolean =
-            sliderScalarN(label, DataType.Int, v to _ia, 2, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
-                    .also { v put _ia }
+    fun sliderVec2i(
+        label: String, v: Vec2i, vMin: Int, vMax: Int,
+        format: String = "%d", flags: SliderFlags = emptyFlags()
+    ): Boolean =
+        sliderScalarN(label, DataType.Int, v to _ia, 2, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
+            .also { v put _ia }
 
-    fun sliderInt3(label: String, v: IntArray, vMin: Int, vMax: Int,
-                   format: String = "%d", flags: SliderFlags = SliderFlag.None.i): Boolean =
-            sliderScalarN(label, DataType.Int, v, 3, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
+    fun sliderInt3(
+        label: String, v: IntArray, vMin: Int, vMax: Int,
+        format: String = "%d", flags: SliderFlags = emptyFlags()
+    ): Boolean =
+        sliderScalarN(label, DataType.Int, v, 3, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
 
-    fun sliderVec3i(label: String, v: Vec3i, vMin: Int, vMax: Int,
-                    format: String = "%d", flags: SliderFlags = SliderFlag.None.i): Boolean =
-            sliderScalarN(label, DataType.Int, v to _ia, 3, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
-                        .also { v put _ia }
+    fun sliderVec3i(
+        label: String, v: Vec3i, vMin: Int, vMax: Int,
+        format: String = "%d", flags: SliderFlags = emptyFlags()
+    ): Boolean =
+        sliderScalarN(label, DataType.Int, v to _ia, 3, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
+            .also { v put _ia }
 
-    fun sliderInt4(label: String, v: IntArray, vMin: Int, vMax: Int,
-                   format: String = "%d", flags: SliderFlags = SliderFlag.None.i): Boolean =
-            sliderScalarN(label, DataType.Int, v, 4, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
+    fun sliderInt4(
+        label: String, v: IntArray, vMin: Int, vMax: Int,
+        format: String = "%d", flags: SliderFlags = emptyFlags()
+    ): Boolean =
+        sliderScalarN(label, DataType.Int, v, 4, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
 
-    fun sliderVec4i(label: String, v: Vec4i, vMin: Int, vMax: Int,
-                    format: String = "%d", flags: SliderFlags = SliderFlag.None.i): Boolean =
-            sliderScalarN(label, DataType.Int, v to _ia, 4, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
-                        .also { v put _ia }
+    fun sliderVec4i(
+        label: String, v: Vec4i, vMin: Int, vMax: Int,
+        format: String = "%d", flags: SliderFlags = emptyFlags()
+    ): Boolean =
+        sliderScalarN(label, DataType.Int, v to _ia, 4, vMin.asMutableProperty, vMax.asMutableProperty, format, flags)
+            .also { v put _ia }
 
     /** Adjust format to decorate the value with a prefix or a suffix.
      *  "%.3f"         1.234
@@ -133,9 +167,11 @@ interface widgetsSliders {
      *
      *  Note: p_data, p_min and p_max are _pointers_ to a memory address holding the data. For a slider, they are all required.
      *  Read code of e.g. SliderFloat(), SliderInt() etc. or examples in 'Demo->Widgets->Data Types' to understand how to use this function directly. */
-    fun <N> sliderScalar(label: String, dataType: DataType, pData: KMutableProperty0<N>,
-                         pMin: KMutableProperty0<N>? = null, pMax: KMutableProperty0<N>? = null,
-                         format_: String? = null, flags: SliderFlags = 0): Boolean
+    fun <N> sliderScalar(
+        label: String, dataType: DataType, pData: KMutableProperty0<N>,
+        pMin: KMutableProperty0<N>? = null, pMax: KMutableProperty0<N>? = null,
+        format_: String? = null, flags: SliderFlags = emptyFlags()
+    ): Boolean
             where N : Number, N : Comparable<N> {
 
         val window = ImGui.currentWindow
@@ -150,7 +186,7 @@ interface widgetsSliders {
 
         val tempInputAllowed = flags hasnt SliderFlag.NoInput
         ImGui.itemSize(totalBb, ImGui.style.framePadding.y)
-        if (!ImGui.itemAdd(totalBb, id, frameBb, if (tempInputAllowed) ItemFlag.Inputable.i else 0))
+        if (!ImGui.itemAdd(totalBb, id, frameBb, if (tempInputAllowed) ItemFlag.Inputable else emptyFlags()))
             return false
 
         // Default format string when passing NULL
@@ -221,9 +257,11 @@ interface widgetsSliders {
     }
 
     /** Add multiple sliders on 1 line for compact edition of multiple components */
-    fun <N> sliderScalarN(label: String, dataType: DataType, pData: Any, components: Int,
-                          pMin: KMutableProperty0<N>? = null, pMax: KMutableProperty0<N>? = null,
-                          format: String? = null, flags: SliderFlags = 0): Boolean
+    fun <N> sliderScalarN(
+        label: String, dataType: DataType, pData: Any, components: Int,
+        pMin: KMutableProperty0<N>? = null, pMax: KMutableProperty0<N>? = null,
+        format: String? = null, flags: SliderFlags = emptyFlags()
+    ): Boolean
             where N : Number, N : Comparable<N> {
 
         val window = ImGui.currentWindow
@@ -262,20 +300,26 @@ interface widgetsSliders {
         return valueChanged
     }
 
-    fun <N> vSliderFloat(label: String, size: Vec2, v: KMutableProperty0<N>, vMin: Float, vMax: Float,
-                         format: String = "%.3f", flags: SliderFlags = SliderFlag.None.i): Boolean
+    fun <N> vSliderFloat(
+        label: String, size: Vec2, v: KMutableProperty0<N>, vMin: Float, vMax: Float,
+        format: String = "%.3f", flags: SliderFlags = emptyFlags()
+    ): Boolean
             where N : Number, N : Comparable<N> =
-            vSliderScalar(label, size, DataType.Float, v, (vMin as N).asMutableProperty, (vMax as N).asMutableProperty, format, flags)
+        vSliderScalar(label, size, DataType.Float, v, (vMin as N).asMutableProperty, (vMax as N).asMutableProperty, format, flags)
 
-    fun <N> vSliderInt(label: String, size: Vec2, v: KMutableProperty0<N>, vMin: Int, vMax: Int,
-                       format: String = "%d", flags: SliderFlags = SliderFlag.None.i): Boolean
+    fun <N> vSliderInt(
+        label: String, size: Vec2, v: KMutableProperty0<N>, vMin: Int, vMax: Int,
+        format: String = "%d", flags: SliderFlags = emptyFlags()
+    ): Boolean
             where N : Number, N : Comparable<N> =
-            vSliderScalar(label, size, DataType.Int, v, (vMin as N).asMutableProperty, (vMax as N).asMutableProperty, format, flags)
+        vSliderScalar(label, size, DataType.Int, v, (vMin as N).asMutableProperty, (vMax as N).asMutableProperty, format, flags)
 
     /** Internal implementation */
-    fun <N> vSliderScalar(label: String, size: Vec2, dataType: DataType, pData: KMutableProperty0<N>,
-                          pMin: KMutableProperty0<N>? = null, pMax: KMutableProperty0<N>? = null,
-                          format_: String? = null, flags: SliderFlags = 0): Boolean
+    fun <N> vSliderScalar(
+        label: String, size: Vec2, dataType: DataType, pData: KMutableProperty0<N>,
+        pMin: KMutableProperty0<N>? = null, pMax: KMutableProperty0<N>? = null,
+        format_: String? = null, flags: SliderFlags = emptyFlags()
+    ): Boolean
             where N : Number, N : Comparable<N> {
 
         val window = ImGui.currentWindow
@@ -314,7 +358,7 @@ interface widgetsSliders {
         ImGui.renderFrame(frameBb.min, frameBb.max, frameCol.u32, true, ImGui.style.frameRounding)
         // Slider behavior
         val grabBb = Rect()
-        val valueChanged = ImGui.sliderBehavior(frameBb, id, dataType, pData, pMin!!, pMax!!, format, flags or SliderFlag._Vertical.i, grabBb)
+        val valueChanged = ImGui.sliderBehavior(frameBb, id, dataType, pData, pMin!!, pMax!!, format, flags or SliderFlag._Vertical, grabBb)
 
         if (valueChanged)
             ImGui.markItemEdited(id)

--- a/core/src/main/kotlin/imgui/api/widgetsText.kt
+++ b/core/src/main/kotlin/imgui/api/widgetsText.kt
@@ -3,7 +3,7 @@ package imgui.api
 import glm_.max
 import glm_.vec2.Vec2
 import glm_.vec4.Vec4
-import imgui.*
+import imgui.Col
 import imgui.ImGui.calcItemWidth
 import imgui.ImGui.calcTextSize
 import imgui.ImGui.currentWindow
@@ -18,10 +18,11 @@ import imgui.ImGui.renderText
 import imgui.ImGui.renderTextClipped
 import imgui.ImGui.style
 import imgui.ImGui.textEx
+import imgui.dsl
+import imgui.get
 import imgui.internal.classes.Rect
-import imgui.internal.sections.TextFlag
-import imgui.internal.formatString
 import imgui.internal.formatStringToTempBuffer
+import imgui.internal.sections.TextFlag
 
 
 /** Widgets: Text */
@@ -39,7 +40,7 @@ interface widgetsText {
         if (window.skipItems) return
 
         val textEnd = formatStringToTempBuffer(fmt, *args)
-        textEx(g.tempBuffer, textEnd, TextFlag.NoWidthForLargeClippedText.i)
+        textEx(g.tempBuffer, textEnd, TextFlag.NoWidthForLargeClippedText)
     }
 
     /** shortcut for

--- a/core/src/main/kotlin/imgui/api/widgetsTrees.kt
+++ b/core/src/main/kotlin/imgui/api/widgetsTrees.kt
@@ -3,8 +3,7 @@ package imgui.api
 import gli_.has
 import glm_.max
 import glm_.vec2.Vec2
-import imgui.Cond
-import imgui.Dir
+import imgui.*
 import imgui.ImGui.closeButton
 import imgui.ImGui.currentWindow
 import imgui.ImGui.getIDWithSeed
@@ -17,8 +16,6 @@ import imgui.ImGui.setNavID
 import imgui.ImGui.style
 import imgui.ImGui.treeNodeBehavior
 import imgui.ImGui.unindent
-import imgui.TreeNodeFlags
-import imgui.emptyFlags
 import imgui.internal.classes.Rect
 import imgui.internal.formatStringToTempBuffer
 import imgui.internal.sections.NextItemDataFlag
@@ -39,17 +36,17 @@ interface widgetsTrees {
 
     /** read the FAQ about why and how to use ID. to align arbitrary text at the same level as a TreeNode() you can use
      *  Bullet().   */
-    fun treeNode(strID: String, fmt: String, vararg args: Any): Boolean = treeNodeEx(strID, emptyFlags(), fmt, *args)
+    fun treeNode(strID: String, fmt: String, vararg args: Any): Boolean = treeNodeEx(strID, emptyFlags, fmt, *args)
 
     /** read the FAQ about why and how to use ID. to align arbitrary text at the same level as a TreeNode() you can use
      *  Bullet().   */
-    fun treeNode(ptrID: Any, fmt: String, vararg args: Any): Boolean = treeNodeEx(ptrID, emptyFlags(), fmt, *args)
+    fun treeNode(ptrID: Any, fmt: String, vararg args: Any): Boolean = treeNodeEx(ptrID, emptyFlags, fmt, *args)
 
     /** read the FAQ about why and how to use ID. to align arbitrary text at the same level as a TreeNode() you can use
      *  Bullet().   */
-    fun treeNode(intPtr: Long, fmt: String, vararg args: Any): Boolean = treeNodeEx(intPtr, emptyFlags(), fmt, *args)
+    fun treeNode(intPtr: Long, fmt: String, vararg args: Any): Boolean = treeNodeEx(intPtr, emptyFlags, fmt, *args)
 
-    fun treeNodeEx(label: String, flags: TreeNodeFlags = emptyFlags()): Boolean {
+    fun treeNodeEx(label: String, flags: TreeNodeFlags = emptyFlags): Boolean {
         val window = currentWindow
         if (window.skipItems) return false
 
@@ -125,7 +122,7 @@ interface widgetsTrees {
      *      treeNodeEx(label, TreeNodeFlag.CollapsingHeader)
      *  You can remove the _NoTreePushOnOpen flag if you want behavior closer to normal TreeNode().
      *  If returning 'true' the header is open. doesn't indent nor push on ID stack. user doesn't have to call TreePop().   */
-    fun collapsingHeader(label: String, flags: TreeNodeFlags = emptyFlags()): Boolean {
+    fun collapsingHeader(label: String, flags: TreeNodeFlags = emptyFlags): Boolean {
 
         val window = currentWindow
         if (window.skipItems)
@@ -140,7 +137,7 @@ interface widgetsTrees {
      *  p_visible != NULL && *p_visible == true  : show a small close button on the corner of the header, clicking the button will set *p_visible = false
      *  p_visible != NULL && *p_visible == false : do not show the header at all
      *  Do not mistake this with the Open state of the header itself, which you can adjust with SetNextItemOpen() or ImGuiTreeNodeFlags_DefaultOpen. */
-    fun collapsingHeader(label: String, visible: KMutableProperty0<Boolean>?, flags_: TreeNodeFlags = emptyFlags()): Boolean {
+    fun collapsingHeader(label: String, visible: KMutableProperty0<Boolean>?, flags_: TreeNodeFlags = emptyFlags): Boolean {
 
         val window = currentWindow
         if (window.skipItems) return false

--- a/core/src/main/kotlin/imgui/api/widgetsTrees.kt
+++ b/core/src/main/kotlin/imgui/api/widgetsTrees.kt
@@ -3,7 +3,8 @@ package imgui.api
 import gli_.has
 import glm_.max
 import glm_.vec2.Vec2
-import imgui.*
+import imgui.Cond
+import imgui.Dir
 import imgui.ImGui.closeButton
 import imgui.ImGui.currentWindow
 import imgui.ImGui.getIDWithSeed
@@ -16,6 +17,8 @@ import imgui.ImGui.setNavID
 import imgui.ImGui.style
 import imgui.ImGui.treeNodeBehavior
 import imgui.ImGui.unindent
+import imgui.TreeNodeFlags
+import imgui.emptyFlags
 import imgui.internal.classes.Rect
 import imgui.internal.formatStringToTempBuffer
 import imgui.internal.sections.NextItemDataFlag
@@ -31,22 +34,22 @@ interface widgetsTrees {
     fun treeNode(label: String): Boolean {
         val window = currentWindow
         if (window.skipItems) return false
-        return treeNodeBehavior(window.getID(label), 0, label)
+        return treeNodeBehavior(window.getID(label), label = label)
     }
 
     /** read the FAQ about why and how to use ID. to align arbitrary text at the same level as a TreeNode() you can use
      *  Bullet().   */
-    fun treeNode(strID: String, fmt: String, vararg args: Any): Boolean = treeNodeEx(strID, 0, fmt, *args)
+    fun treeNode(strID: String, fmt: String, vararg args: Any): Boolean = treeNodeEx(strID, emptyFlags(), fmt, *args)
 
     /** read the FAQ about why and how to use ID. to align arbitrary text at the same level as a TreeNode() you can use
      *  Bullet().   */
-    fun treeNode(ptrID: Any, fmt: String, vararg args: Any): Boolean = treeNodeEx(ptrID, 0, fmt, *args)
+    fun treeNode(ptrID: Any, fmt: String, vararg args: Any): Boolean = treeNodeEx(ptrID, emptyFlags(), fmt, *args)
 
     /** read the FAQ about why and how to use ID. to align arbitrary text at the same level as a TreeNode() you can use
      *  Bullet().   */
-    fun treeNode(intPtr: Long, fmt: String, vararg args: Any): Boolean = treeNodeEx(intPtr, 0, fmt, *args)
+    fun treeNode(intPtr: Long, fmt: String, vararg args: Any): Boolean = treeNodeEx(intPtr, emptyFlags(), fmt, *args)
 
-    fun treeNodeEx(label: String, flags: TreeNodeFlags = 0): Boolean {
+    fun treeNodeEx(label: String, flags: TreeNodeFlags = emptyFlags()): Boolean {
         val window = currentWindow
         if (window.skipItems) return false
 
@@ -122,7 +125,7 @@ interface widgetsTrees {
      *      treeNodeEx(label, TreeNodeFlag.CollapsingHeader)
      *  You can remove the _NoTreePushOnOpen flag if you want behavior closer to normal TreeNode().
      *  If returning 'true' the header is open. doesn't indent nor push on ID stack. user doesn't have to call TreePop().   */
-    fun collapsingHeader(label: String, flags: TreeNodeFlags = 0): Boolean {
+    fun collapsingHeader(label: String, flags: TreeNodeFlags = emptyFlags()): Boolean {
 
         val window = currentWindow
         if (window.skipItems)
@@ -137,7 +140,7 @@ interface widgetsTrees {
      *  p_visible != NULL && *p_visible == true  : show a small close button on the corner of the header, clicking the button will set *p_visible = false
      *  p_visible != NULL && *p_visible == false : do not show the header at all
      *  Do not mistake this with the Open state of the header itself, which you can adjust with SetNextItemOpen() or ImGuiTreeNodeFlags_DefaultOpen. */
-    fun collapsingHeader(label: String, visible: KMutableProperty0<Boolean>?, flags_: TreeNodeFlags = 0): Boolean {
+    fun collapsingHeader(label: String, visible: KMutableProperty0<Boolean>?, flags_: TreeNodeFlags = emptyFlags()): Boolean {
 
         val window = currentWindow
         if (window.skipItems) return false

--- a/core/src/main/kotlin/imgui/api/windows.kt
+++ b/core/src/main/kotlin/imgui/api/windows.kt
@@ -76,7 +76,7 @@ interface windows {
 
     @return isOpen
      */
-    fun begin(name: String, pOpen: KMutableProperty0<Boolean>? = null, flags_: WindowFlags = emptyFlags()): Boolean {
+    fun begin(name: String, pOpen: KMutableProperty0<Boolean>? = null, flags_: WindowFlags = emptyFlags): Boolean {
 
         assert(name.isNotEmpty()) { "Window name required" }
         assert(g.withinFrameScope) { "Forgot to call ImGui::newFrame()" }
@@ -434,7 +434,7 @@ interface windows {
                 assert(window.idStack.size == 1)
                 val id = window.idStack.pop() // As window->IDStack[0] == window->ID here, make sure TestEngine doesn't erroneously see window as parent of itself.
                 IMGUI_TEST_ENGINE_ITEM_ADD(window.rect(), window.id)
-                IMGUI_TEST_ENGINE_ITEM_INFO(window.id, window.name, if (g.hoveredWindow === window) ItemStatusFlag.HoveredRect else emptyFlags())
+                IMGUI_TEST_ENGINE_ITEM_INFO(window.id, window.name, if (g.hoveredWindow === window) ItemStatusFlag.HoveredRect else emptyFlags)
                 window.idStack += id
             }
 
@@ -471,7 +471,7 @@ interface windows {
                 if (window.scrollbar.x && !window.scrollbar.y) window.scrollbar.y =
                     neededSizeFromLastFrame.y > sizeYforScrollbars && flags hasnt Wf.NoScrollbar
                 window.scrollbarSizes.put(if (window.scrollbar.y) style.scrollbarSize else 0f,
-                                          if (window.scrollbar.x) style.scrollbarSize else 0f)
+                    if (window.scrollbar.x) style.scrollbarSize else 0f)
 
                 // Amend the partially filled window->DecorationXXX values.
                 window.decoOuterSizeX2 += window.scrollbarSizes.x
@@ -505,9 +505,9 @@ interface windows {
                 // - NavUpdatePageUpPageDown()
                 // - Scrollbar()
                 innerRect.put(minX = pos.x + decoOuterSizeX1,
-                              minY = pos.y + decoOuterSizeY1,
-                              maxX = pos.x + size.x - decoOuterSizeX2,
-                              maxY = pos.y + size.y - decoOuterSizeY2)
+                    minY = pos.y + decoOuterSizeY1,
+                    maxX = pos.x + size.x - decoOuterSizeX2,
+                    maxY = pos.y + size.y - decoOuterSizeY2)
 
                 // Inner clipping rectangle.
                 // Will extend a little bit outside the normal work region.
@@ -602,7 +602,7 @@ interface windows {
                     else -> max(if (allowScrollbarY) window.contentSize.y else 0f, size.y - windowPadding.y * 2f - (decoOuterSizeY1 + decoOuterSizeY2))
                 }
                 workRect.min.put(floor(innerRect.min.x - scroll.x + max(windowPadding.x, windowBorderSize)),
-                                 floor(innerRect.min.y - scroll.y + max(windowPadding.y, windowBorderSize)))
+                    floor(innerRect.min.y - scroll.y + max(windowPadding.y, windowBorderSize)))
                 workRect.max.put(workRect.min.x + workRectSizeX, workRect.min.y + workRectSizeY)
                 parentWorkRect put workRect
 
@@ -612,9 +612,9 @@ interface windows {
                 // Used by:
                 // - Mouse wheel scrolling + many other things
                 contentRegionRect.min.put(pos.x - scroll.x + windowPadding.x + decoOuterSizeX1,
-                                          pos.y - scroll.y + windowPadding.y + decoOuterSizeY1)
+                    pos.y - scroll.y + windowPadding.y + decoOuterSizeY1)
                 contentRegionRect.max.put(contentRegionRect.min.x + if (contentSizeExplicit.x != 0f) contentSizeExplicit.x else size.x - windowPadding.x * 2f - (decoOuterSizeX1 + decoOuterSizeX2),
-                                          contentRegionRect.min.y + if (contentSizeExplicit.y != 0f) contentSizeExplicit.y else size.y - windowPadding.y * 2f - (decoOuterSizeY1 + decoOuterSizeY2))
+                    contentRegionRect.min.y + if (contentSizeExplicit.y != 0f) contentSizeExplicit.y else size.y - windowPadding.y * 2f - (decoOuterSizeY1 + decoOuterSizeY2))
 
                 // Setup drawing context
                 // (NB: That term "drawing context / DC" lost its meaning a long time ago. Initially was meant to hold transient data only. Nowadays difference between window-> and window->DC-> is dubious.)
@@ -688,7 +688,7 @@ interface windows {
 
             // We fill last item data based on Title Bar/Tab, in order for IsItemHovered() and IsItemActive() to be usable after Begin().
             // This is useful to allow creating context menus on title bar only, etc.
-            val itemFlag = if (isMouseHoveringRect(titleBarRect.min, titleBarRect.max, false)) ItemStatusFlag.HoveredRect else emptyFlags()
+            val itemFlag = if (isMouseHoveringRect(titleBarRect.min, titleBarRect.max, false)) ItemStatusFlag.HoveredRect else emptyFlags
             setLastItemData(window.moveId, g.currentItemFlags, itemFlag, titleBarRect)
 
             // [DEBUG]

--- a/core/src/main/kotlin/imgui/api/windows.kt
+++ b/core/src/main/kotlin/imgui/api/windows.kt
@@ -1,7 +1,5 @@
 package imgui.api
 
-import gli_.has
-import gli_.hasnt
 import glm_.d
 import glm_.f
 import glm_.max
@@ -78,7 +76,7 @@ interface windows {
 
     @return isOpen
      */
-    fun begin(name: String, pOpen: KMutableProperty0<Boolean>? = null, flags_: WindowFlags = 0): Boolean {
+    fun begin(name: String, pOpen: KMutableProperty0<Boolean>? = null, flags_: WindowFlags = emptyFlags()): Boolean {
 
         assert(name.isNotEmpty()) { "Window name required" }
         assert(g.withinFrameScope) { "Forgot to call ImGui::newFrame()" }
@@ -91,7 +89,7 @@ interface windows {
         val window = findWindowByName(name) ?: createNewWindow(name, flags).also { windowJustCreated = true }
 
         // Automatically disable manual moving/resizing when NoInputs is set
-        if ((flags and Wf.NoInputs) == Wf.NoInputs.i)
+        if (Wf.NoInputs in flags)
             flags = flags or Wf.NoMove or Wf.NoResize
 
         if (flags has Wf._NavFlattened)
@@ -110,7 +108,7 @@ interface windows {
         }
         window.appearing = windowJustActivatedByUser
         if (window.appearing)
-            window.setConditionAllowFlags(Cond.Appearing.i, true)
+            window.setConditionAllowFlags(Cond.Appearing, true)
 
         // Update Flags, LastFrameActive, BeginOrderXXX fields
         if (firstBeginOfTheFrame) {
@@ -175,7 +173,7 @@ interface windows {
                     FIXME: Look into removing the branch so everything can go through this same code path for consistency.  */
                 window.setWindowPosVal put g.nextWindowData.posVal
                 window.setWindowPosPivot put g.nextWindowData.posPivotVal
-                window.setWindowPosAllowFlags = window.setWindowPosAllowFlags and (Cond.Once or Cond.FirstUseEver or Cond.Appearing).inv()
+                window.setWindowPosAllowFlags = window.setWindowPosAllowFlags wo (Cond.Once or Cond.FirstUseEver or Cond.Appearing)
             } else window.setPos(g.nextWindowData.posVal, g.nextWindowData.posCond)
         }
         if (g.nextWindowData.flags has NextWindowDataFlag.HasSize) {
@@ -201,7 +199,7 @@ interface windows {
             window.setCollapsed(g.nextWindowData.collapsedVal, g.nextWindowData.collapsedCond)
         if (g.nextWindowData.flags has NextWindowDataFlag.HasFocus) focusWindow(window)
         if (window.appearing)
-            window.setConditionAllowFlags(Cond.Appearing.i, false)
+            window.setConditionAllowFlags(Cond.Appearing, false)
 
         // When reusing window again multiple times a frame, just append content (don't need to setup again)
         if (firstBeginOfTheFrame) {
@@ -436,7 +434,7 @@ interface windows {
                 assert(window.idStack.size == 1)
                 val id = window.idStack.pop() // As window->IDStack[0] == window->ID here, make sure TestEngine doesn't erroneously see window as parent of itself.
                 IMGUI_TEST_ENGINE_ITEM_ADD(window.rect(), window.id)
-                IMGUI_TEST_ENGINE_ITEM_INFO(window.id, window.name, if (g.hoveredWindow === window) ItemStatusFlag.HoveredRect.i else ItemStatusFlag.None.i)
+                IMGUI_TEST_ENGINE_ITEM_INFO(window.id, window.name, if (g.hoveredWindow === window) ItemStatusFlag.HoveredRect else emptyFlags())
                 window.idStack += id
             }
 
@@ -690,8 +688,8 @@ interface windows {
 
             // We fill last item data based on Title Bar/Tab, in order for IsItemHovered() and IsItemActive() to be usable after Begin().
             // This is useful to allow creating context menus on title bar only, etc.
-            val itemFlag = if (isMouseHoveringRect(titleBarRect.min, titleBarRect.max, false)) ItemStatusFlag.HoveredRect else ItemStatusFlag.None
-            setLastItemData(window.moveId, g.currentItemFlags, itemFlag.i, titleBarRect)
+            val itemFlag = if (isMouseHoveringRect(titleBarRect.min, titleBarRect.max, false)) ItemStatusFlag.HoveredRect else emptyFlags()
+            setLastItemData(window.moveId, g.currentItemFlags, itemFlag, titleBarRect)
 
             // [DEBUG]
             if (!IMGUI_DISABLE_DEBUG_TOOLS)

--- a/core/src/main/kotlin/imgui/api/windowsUtilities.kt
+++ b/core/src/main/kotlin/imgui/api/windowsUtilities.kt
@@ -1,6 +1,5 @@
 package imgui.api
 
-import glm_.hasnt
 import glm_.vec2.Vec2
 import imgui.*
 import imgui.ImGui.currentWindow
@@ -31,10 +30,7 @@ interface windowsUtilities {
         get() = currentWindowRead!!.collapsed
 
     /** is current window focused? or its root/child, depending on flags. see flags for options.    */
-    fun isWindowFocused(flag: Ff): Boolean = isWindowFocused(flag.i)
-
-    /** is current window focused? or its root/child, depending on flags. see flags for options.    */
-    fun isWindowFocused(flags: FocusedFlags = Ff.None.i): Boolean {
+    fun isWindowFocused(flags: FocusedFlags = emptyFlags()): Boolean {
 
         val refWindow = g.navWindow ?: return false
         var curWindow = g.currentWindow
@@ -44,22 +40,20 @@ interface windowsUtilities {
 
         check(curWindow != null) { "Not inside a Begin() / End()" }
         val popupHierarchy = flags hasnt Ff.NoPopupHierarchy
-        if (flags has Hf.RootWindow)
+        if (flags has Ff.RootWindow)
             curWindow = getCombinedRootWindow(curWindow, popupHierarchy)
 
         return when {
-            flags has Hf.ChildWindows -> refWindow.isChildOf(curWindow, popupHierarchy)
+            flags has Ff.ChildWindows -> refWindow.isChildOf(curWindow, popupHierarchy)
             else -> refWindow === curWindow
         }
     }
 
-    /** iis current window hovered (and typically: not blocked by a popup/modal)? see flag for options. */
-    fun isWindowHovered(flag: Hf) = isWindowHovered(flag.i)
 
     /** Is current window hovered (and typically: not blocked by a popup/modal)? see flags for options.
      *  NB: If you are trying to check whether your mouse should be dispatched to imgui or to your app, you should use
      *  the 'io.wantCaptureMouse' boolean for that! Please read the FAQ!    */
-    fun isWindowHovered(flags: HoveredFlags = Hf.None.i): Boolean {
+    fun isWindowHovered(flags: HoveredFlags = emptyFlags()): Boolean {
         assert(flags hasnt (Hf.AllowWhenOverlapped or Hf.AllowWhenDisabled)) { "Flags not supported by this function" }
         val refWindow = g.hoveredWindow ?: return false
         var curWindow = g.currentWindow

--- a/core/src/main/kotlin/imgui/api/windowsUtilities.kt
+++ b/core/src/main/kotlin/imgui/api/windowsUtilities.kt
@@ -30,7 +30,7 @@ interface windowsUtilities {
         get() = currentWindowRead!!.collapsed
 
     /** is current window focused? or its root/child, depending on flags. see flags for options.    */
-    fun isWindowFocused(flags: FocusedFlags = emptyFlags()): Boolean {
+    fun isWindowFocused(flags: FocusedFlags = emptyFlags): Boolean {
 
         val refWindow = g.navWindow ?: return false
         var curWindow = g.currentWindow
@@ -53,8 +53,7 @@ interface windowsUtilities {
     /** Is current window hovered (and typically: not blocked by a popup/modal)? see flags for options.
      *  NB: If you are trying to check whether your mouse should be dispatched to imgui or to your app, you should use
      *  the 'io.wantCaptureMouse' boolean for that! Please read the FAQ!    */
-    fun isWindowHovered(flags: HoveredFlags = emptyFlags()): Boolean {
-        assert(flags hasnt (Hf.AllowWhenOverlapped or Hf.AllowWhenDisabled)) { "Flags not supported by this function" }
+    fun isWindowHovered(flags: WindowHoveredFlags = emptyFlags): Boolean {
         val refWindow = g.hoveredWindow ?: return false
         var curWindow = g.currentWindow
 

--- a/core/src/main/kotlin/imgui/classes/Context.kt
+++ b/core/src/main/kotlin/imgui/classes/Context.kt
@@ -218,7 +218,7 @@ class Context(sharedFontAtlas: FontAtlas? = null) {
     var currentFocusScopeId: ID = 0
 
     /** == g.ItemFlagsStack.back() */
-    var currentItemFlags: ItemFlags = emptyFlags()
+    var currentItemFlags: ItemFlags = emptyFlags
 
     /** Storage for DebugLocateItemOnHover() feature: this is read by ItemAdd() so we keep it in a hot/cached location */
     var debugLocateId: ID = 0
@@ -291,7 +291,7 @@ class Context(sharedFontAtlas: FontAtlas? = null) {
     /** ~~ IsKeyPressed(ImGuiKey_Enter) || IsKeyPressed(ImGuiKey_NavGamepadInput) ? NavId : 0; ImGuiActivateFlags_PreferInput will be set and NavActivateId will be 0.  */
     var navActivateInputId: ID = 0
 
-    var navActivateFlags: ActivateFlags = emptyFlags()
+    var navActivateFlags: ActivateFlags = emptyFlags
 
     /** Just navigated to this id (result of a successfully MoveRequest)    */
     var navJustMovedToId: ID = 0
@@ -304,7 +304,7 @@ class Context(sharedFontAtlas: FontAtlas? = null) {
     /** Set by ActivateItem(), queued until next frame  */
     var navNextActivateId: ID = 0
 
-    var navNextActivateFlags: ActivateFlags = emptyFlags()
+    var navNextActivateFlags: ActivateFlags = emptyFlags
 
     /** Keyboard or Gamepad mode? THIS WILL ONLY BE None or NavGamepad or NavKeyboard.  */
     var navInputSource = InputSource.None
@@ -352,9 +352,9 @@ class Context(sharedFontAtlas: FontAtlas? = null) {
 
     var navMoveForwardToNextFrame = false
 
-    var navMoveFlags: NavMoveFlags = emptyFlags()
+    var navMoveFlags: NavMoveFlags = emptyFlags
 
-    var navMoveScrollFlags: ScrollFlags = emptyFlags()
+    var navMoveScrollFlags: ScrollFlags = emptyFlags
 
     var navMoveKeyMods: KeyChord = Key.Mod_None
 
@@ -445,7 +445,7 @@ class Context(sharedFontAtlas: FontAtlas? = null) {
     /** Set when within a BeginDragDropXXX/EndDragDropXXX block for a drag target. */
     var dragDropWithinTarget = false
 
-    var dragDropSourceFlags: DragDropFlags = emptyFlags()
+    var dragDropSourceFlags: DragDropFlags = emptyFlags
 
     var dragDropSourceFrameCount = -1
 
@@ -458,7 +458,7 @@ class Context(sharedFontAtlas: FontAtlas? = null) {
 
     var dragDropTargetId: ID = 0
 
-    var dragDropAcceptFlags: DragDropFlags = emptyFlags()
+    var dragDropAcceptFlags: DragDropFlags = emptyFlags
 
     /** Target item surface (we resolve overlapping targets by prioritizing the smaller surface) */
     var dragDropAcceptIdCurrRectSurface = 0f

--- a/core/src/main/kotlin/imgui/classes/Context.kt
+++ b/core/src/main/kotlin/imgui/classes/Context.kt
@@ -12,7 +12,6 @@ import imgui.api.g
 import imgui.api.gImGui
 import imgui.font.Font
 import imgui.font.FontAtlas
-import imgui.internal.BitArray
 import imgui.internal.DrawChannel
 import imgui.internal.classes.*
 import imgui.internal.hashStr
@@ -21,7 +20,6 @@ import imgui.static.*
 import java.io.File
 import java.nio.ByteBuffer
 import java.util.*
-import kotlin.collections.ArrayList
 
 /** Main Dear ImGui context
  *
@@ -182,7 +180,7 @@ class Context(sharedFontAtlas: FontAtlas? = null) {
     /** Activating with mouse or nav (gamepad/keyboard) */
     var activeIdSource = InputSource.None
 
-    var activeIdMouseButton = -1
+    var activeIdMouseButton = MouseButton.None
 
     var activeIdPreviousFrame: ID = 0
 
@@ -220,7 +218,7 @@ class Context(sharedFontAtlas: FontAtlas? = null) {
     var currentFocusScopeId: ID = 0
 
     /** == g.ItemFlagsStack.back() */
-    var currentItemFlags = ItemFlag.None.i
+    var currentItemFlags: ItemFlags = emptyFlags()
 
     /** Storage for DebugLocateItemOnHover() feature: this is read by ItemAdd() so we keep it in a hot/cached location */
     var debugLocateId: ID = 0
@@ -293,7 +291,7 @@ class Context(sharedFontAtlas: FontAtlas? = null) {
     /** ~~ IsKeyPressed(ImGuiKey_Enter) || IsKeyPressed(ImGuiKey_NavGamepadInput) ? NavId : 0; ImGuiActivateFlags_PreferInput will be set and NavActivateId will be 0.  */
     var navActivateInputId: ID = 0
 
-    var navActivateFlags = ActivateFlag.None.i
+    var navActivateFlags: ActivateFlags = emptyFlags()
 
     /** Just navigated to this id (result of a successfully MoveRequest)    */
     var navJustMovedToId: ID = 0
@@ -301,12 +299,12 @@ class Context(sharedFontAtlas: FontAtlas? = null) {
     /** Just navigated to this focus scope id (result of a successfully MoveRequest). */
     var navJustMovedToFocusScopeId: ID = 0
 
-    var navJustMovedToKeyMods: KeyChord = Key.Mod_None.i
+    var navJustMovedToKeyMods: KeyChord = Key.Mod_None
 
     /** Set by ActivateItem(), queued until next frame  */
     var navNextActivateId: ID = 0
 
-    var navNextActivateFlags = ActivateFlag.None.i
+    var navNextActivateFlags: ActivateFlags = emptyFlags()
 
     /** Keyboard or Gamepad mode? THIS WILL ONLY BE None or NavGamepad or NavKeyboard.  */
     var navInputSource = InputSource.None
@@ -354,11 +352,11 @@ class Context(sharedFontAtlas: FontAtlas? = null) {
 
     var navMoveForwardToNextFrame = false
 
-    var navMoveFlags: NavMoveFlags = NavMoveFlag.None.i
+    var navMoveFlags: NavMoveFlags = emptyFlags()
 
-    var navMoveScrollFlags = ScrollFlag.None.i
+    var navMoveScrollFlags: ScrollFlags = emptyFlags()
 
-    var navMoveKeyMods: KeyChord = Key.Mod_None.i
+    var navMoveKeyMods: KeyChord = Key.Mod_None
 
     /** Direction of the move request (left/right/up/down), direction of the previous move request  */
     var navMoveDir = Dir.None
@@ -447,7 +445,7 @@ class Context(sharedFontAtlas: FontAtlas? = null) {
     /** Set when within a BeginDragDropXXX/EndDragDropXXX block for a drag target. */
     var dragDropWithinTarget = false
 
-    var dragDropSourceFlags = DragDropFlag.None.i
+    var dragDropSourceFlags: DragDropFlags = emptyFlags()
 
     var dragDropSourceFrameCount = -1
 
@@ -460,7 +458,7 @@ class Context(sharedFontAtlas: FontAtlas? = null) {
 
     var dragDropTargetId: ID = 0
 
-    var dragDropAcceptFlags = DragDropFlag.None.i
+    var dragDropAcceptFlags: DragDropFlags = emptyFlags()
 
     /** Target item surface (we resolve overlapping targets by prioritizing the smaller surface) */
     var dragDropAcceptIdCurrRectSurface = 0f
@@ -534,7 +532,7 @@ class Context(sharedFontAtlas: FontAtlas? = null) {
     var tempInputId: ID = 0
 
     /** Store user options for color edit widgets   */
-    var colorEditOptions: ColorEditFlags = ColorEditFlag.DefaultOptions.i
+    var colorEditOptions: ColorEditFlags = ColorEditFlag.DefaultOptions
 
     /** Backup of last Hue associated to LastColor, so we can restore Hue in lossy RGB<>HSV round trips */
     var colorEditLastHue = 0f
@@ -659,7 +657,7 @@ class Context(sharedFontAtlas: FontAtlas? = null) {
 
     // Debug Tools
 
-    var debugLogFlags = DebugLogFlag.OutputToTTY or DebugLogFlag.EventMask_ wo DebugLogFlag.EventClipper
+    var debugLogFlags: DebugLogFlags = DebugLogFlag.OutputToTTY or DebugLogFlag.EventMask wo DebugLogFlag.EventClipper
     val debugLogBuf = StringBuilder()
 
     val debugLogIndex = TextIndex()

--- a/core/src/main/kotlin/imgui/classes/DrawList.kt
+++ b/core/src/main/kotlin/imgui/classes/DrawList.kt
@@ -57,7 +57,7 @@ class DrawList(sharedData: DrawListSharedData?) {
     var vtxBuffer = DrawVert_Buffer(0)
 
     /** Flags, you may poke into these to adjust anti-aliasing settings per-primitive. */
-    var flags: DrawListFlags = emptyFlags()
+    var flags: DrawListFlags = emptyFlags
 
 
     // -----------------------------------------------------------------------------------------------------------------
@@ -173,7 +173,7 @@ class DrawList(sharedData: DrawListSharedData?) {
      * @param pMin: upper-left
      * @param pMax: lower-right
      * (== upper-left + size)   */
-    fun addRect(pMin: Vec2, pMax: Vec2, col: Int, rounding: Float = 0f, flags: DrawFlags = emptyFlags(), thickness: Float = 1f) {
+    fun addRect(pMin: Vec2, pMax: Vec2, col: Int, rounding: Float = 0f, flags: DrawFlags = emptyFlags, thickness: Float = 1f) {
         if (col hasnt COL32_A_MASK) return
         if (this.flags has DrawListFlag.AntiAliasedLines)
             pathRect(pMin + 0.5f, pMax - 0.5f, rounding, flags)
@@ -185,9 +185,9 @@ class DrawList(sharedData: DrawListSharedData?) {
     /** @param pMin: upper-left
      *  @param pMax: lower-right
      *  (== upper-left + size) */
-    fun addRectFilled(pMin: Vec2, pMax: Vec2, col: Int, rounding: Float = 0f, flags: DrawFlags = emptyFlags()) {
+    fun addRectFilled(pMin: Vec2, pMax: Vec2, col: Int, rounding: Float = 0f, flags: DrawFlags = emptyFlags) {
         if (col hasnt COL32_A_MASK) return
-        if (rounding < 0.5f || (flags and DrawFlag.RoundCornersMask) eq DrawFlag.RoundCornersNone) {
+        if (rounding < 0.5f || (flags and DrawFlag.RoundCornersMask) == DrawFlag.RoundCornersNone) {
             primReserve(6, 4)
             primRect(Vec2(pMin), pMax, col) // [JVM] `pMin` safety first
         } else {
@@ -733,7 +733,7 @@ class DrawList(sharedData: DrawListSharedData?) {
     fun addImage(
         userTextureId: TextureID, pMin: Vec2, pMax: Vec2,
         uvMin: Vec2 = Vec2(0), uvMax: Vec2 = Vec2(1), col: Int = COL32_WHITE,
-                ) {
+    ) {
 
         if (col hasnt COL32_A_MASK) return
 
@@ -750,7 +750,7 @@ class DrawList(sharedData: DrawListSharedData?) {
         userTextureId: TextureID, p1: Vec2, p2: Vec2, p3: Vec2, p4: Vec2,
         uv1: Vec2 = Vec2(0), uv2: Vec2 = Vec2(1, 0),
         uv3: Vec2 = Vec2(1), uv4: Vec2 = Vec2(0, 1), col: Int = COL32_WHITE,
-                    ) {
+    ) {
 
         if (col hasnt COL32_A_MASK) return
 
@@ -765,12 +765,12 @@ class DrawList(sharedData: DrawListSharedData?) {
             popTextureID()
     }
 
-    fun addImageRounded(userTextureId: TextureID, pMin: Vec2, pMax: Vec2, uvMin: Vec2, uvMax: Vec2, col: Int, rounding: Float, flags_: DrawFlags = emptyFlags()) {
+    fun addImageRounded(userTextureId: TextureID, pMin: Vec2, pMax: Vec2, uvMin: Vec2, uvMax: Vec2, col: Int, rounding: Float, flags_: DrawFlags = emptyFlags) {
         if (col hasnt COL32_A_MASK)
             return
 
         val flags = fixRectCornerFlags(flags_)
-        if (rounding < 0.5f || (flags and DrawFlag.RoundCornersMask) eq DrawFlag.RoundCornersNone) {
+        if (rounding < 0.5f || (flags and DrawFlag.RoundCornersMask) == DrawFlag.RoundCornersNone) {
             addImage(userTextureId, pMin, pMax, uvMin, uvMax, col)
             return
         }
@@ -803,7 +803,7 @@ class DrawList(sharedData: DrawListSharedData?) {
     fun pathFillConvex(col: Int) = addConvexPolyFilled(_path, col).also { pathClear() }
 
     /** rounding_corners_flags: 4 bits corresponding to which corner to round   */
-    fun pathStroke(col: Int, flags: DrawFlags = emptyFlags(), thickness: Float = 1.0f) =
+    fun pathStroke(col: Int, flags: DrawFlags = emptyFlags, thickness: Float = 1.0f) =
         addPolyline(_path, col, flags, thickness).also { pathClear() }
 
     /** @param center must be a new instance */
@@ -958,14 +958,14 @@ class DrawList(sharedData: DrawListSharedData?) {
         }
     }
 
-    fun pathRect(a: Vec2, b: Vec2, rounding_: Float = 0f, flags_: DrawFlags = emptyFlags()) {
+    fun pathRect(a: Vec2, b: Vec2, rounding_: Float = 0f, flags_: DrawFlags = emptyFlags) {
         val flags = fixRectCornerFlags(flags_)
         var cond = (DrawFlag.RoundCornersTop in flags) or (DrawFlag.RoundCornersBottom in flags)
         var rounding = rounding_ min ((b.x - a.x).abs * (if (cond) 0.5f else 1f) - 1f)
         cond = (DrawFlag.RoundCornersLeft in flags) or (DrawFlag.RoundCornersRight in flags)
         rounding = rounding min ((b.y - a.y).abs * (if (cond) 0.5f else 1f) - 1f)
 
-        if (rounding < 0.5f || (flags and DrawFlag.RoundCornersMask) eq DrawFlag.RoundCornersNone) {
+        if (rounding < 0.5f || (flags and DrawFlag.RoundCornersMask) == DrawFlag.RoundCornersNone) {
             pathLineTo(a)
             pathLineTo(Vec2(b.x, a.y))
             pathLineTo(b)
@@ -1196,7 +1196,7 @@ class DrawList(sharedData: DrawListSharedData?) {
             idxBuffer = idxBuffer.resize(0)
             vtxBuffer = vtxBuffer.resize(0)
         }
-        flags = emptyFlags()
+        flags = emptyFlags
         _vtxCurrentIdx = 0
         _vtxWritePtr = 0
         _idxWritePtr = 0
@@ -1352,7 +1352,7 @@ class DrawList(sharedData: DrawListSharedData?) {
 
                 val s = _data.arcFastVtx[sampleIndex]
                 _path += Vec2(center.x + s.x * radius,
-                              center.y + s.y * radius)
+                    center.y + s.y * radius)
 
                 a += aStep; sampleIndex += aStep; aStep = aNextStep
             }
@@ -1365,7 +1365,7 @@ class DrawList(sharedData: DrawListSharedData?) {
 
                 val s = _data.arcFastVtx[sampleIndex]
                 _path += Vec2(center.x + s.x * radius,
-                              center.y + s.y * radius)
+                    center.y + s.y * radius)
 
                 a -= aStep; sampleIndex -= aStep; aStep = aNextStep
             }
@@ -1378,7 +1378,7 @@ class DrawList(sharedData: DrawListSharedData?) {
 
             val s = _data.arcFastVtx[normalizedMaxSample]
             _path += Vec2(center.x + s.x * radius,
-                          center.y + s.y * radius)
+                center.y + s.y * radius)
         }
 
         //        IM_ASSERT_PARANOID(_Path.Data + _Path.Size == out_ptr)

--- a/core/src/main/kotlin/imgui/classes/DrawList.kt
+++ b/core/src/main/kotlin/imgui/classes/DrawList.kt
@@ -57,7 +57,7 @@ class DrawList(sharedData: DrawListSharedData?) {
     var vtxBuffer = DrawVert_Buffer(0)
 
     /** Flags, you may poke into these to adjust anti-aliasing settings per-primitive. */
-    var flags: DrawListFlags = DrawListFlag.None.i
+    var flags: DrawListFlags = emptyFlags()
 
 
     // -----------------------------------------------------------------------------------------------------------------
@@ -166,28 +166,28 @@ class DrawList(sharedData: DrawListSharedData?) {
         if (col hasnt COL32_A_MASK) return
         pathLineTo(p1 + Vec2(0.5f))
         pathLineTo(p2 + Vec2(0.5f))
-        pathStroke(col, 0, thickness)
+        pathStroke(col, thickness = thickness)
     }
 
     /** Note we don't render 1 pixels sized rectangles properly.
      * @param pMin: upper-left
      * @param pMax: lower-right
      * (== upper-left + size)   */
-    fun addRect(pMin: Vec2, pMax: Vec2, col: Int, rounding: Float = 0f, flags: DrawFlags = 0, thickness: Float = 1f) {
+    fun addRect(pMin: Vec2, pMax: Vec2, col: Int, rounding: Float = 0f, flags: DrawFlags = emptyFlags(), thickness: Float = 1f) {
         if (col hasnt COL32_A_MASK) return
         if (this.flags has DrawListFlag.AntiAliasedLines)
             pathRect(pMin + 0.5f, pMax - 0.5f, rounding, flags)
         else    // Better looking lower-right corner and rounded non-AA shapes.
             pathRect(pMin + 0.5f, pMax - 0.49f, rounding, flags)
-        pathStroke(col, DrawFlag.Closed.i, thickness)
+        pathStroke(col, DrawFlag.Closed, thickness)
     }
 
     /** @param pMin: upper-left
      *  @param pMax: lower-right
      *  (== upper-left + size) */
-    fun addRectFilled(pMin: Vec2, pMax: Vec2, col: Int, rounding: Float = 0f, flags: DrawFlags = 0) {
+    fun addRectFilled(pMin: Vec2, pMax: Vec2, col: Int, rounding: Float = 0f, flags: DrawFlags = emptyFlags()) {
         if (col hasnt COL32_A_MASK) return
-        if (rounding < 0.5f || (flags and DrawFlag.RoundCornersMask_) == DrawFlag.RoundCornersNone.i) {
+        if (rounding < 0.5f || (flags and DrawFlag.RoundCornersMask) eq DrawFlag.RoundCornersNone) {
             primReserve(6, 4)
             primRect(Vec2(pMin), pMax, col) // [JVM] `pMin` safety first
         } else {
@@ -224,7 +224,7 @@ class DrawList(sharedData: DrawListSharedData?) {
         pathLineTo(p2)
         pathLineTo(p3)
         pathLineTo(p4)
-        pathStroke(col, DrawFlag.Closed.i, thickness)
+        pathStroke(col, DrawFlag.Closed, thickness)
     }
 
     fun addQuadFilled(p1: Vec2, p2: Vec2, p3: Vec2, p4: Vec2, col: Int) {
@@ -245,7 +245,7 @@ class DrawList(sharedData: DrawListSharedData?) {
         pathLineTo(p1)
         pathLineTo(p2)
         pathLineTo(p3)
-        pathStroke(col, DrawFlag.Closed.i, thickness)
+        pathStroke(col, DrawFlag.Closed, thickness)
     }
 
     fun addTriangleFilled(p1: Vec2, p2: Vec2, p3: Vec2, col: Int) {
@@ -276,7 +276,7 @@ class DrawList(sharedData: DrawListSharedData?) {
             pathArcTo(center, radius - 0.5f, 0f, aMax, numSegments - 1)
         }
 
-        pathStroke(col, DrawFlag.Closed.i, thickness)
+        pathStroke(col, DrawFlag.Closed, thickness)
     }
 
     fun addCircleFilled(center: Vec2, radius: Float, col: Int, numSegments_: Int = 0) {
@@ -308,7 +308,7 @@ class DrawList(sharedData: DrawListSharedData?) {
         // Because we are filling a closed shape we remove 1 from the count of segments/points
         val aMax = (glm.πf * 2f) * (numSegments.f - 1f) / numSegments.f
         pathArcTo(center, radius - 0.5f, 0f, aMax, numSegments - 1)
-        pathStroke(col, DrawFlag.Closed.i, thickness)
+        pathStroke(col, DrawFlag.Closed, thickness)
     }
 
     /** Guaranteed to honor 'num_segments' */
@@ -385,7 +385,7 @@ class DrawList(sharedData: DrawListSharedData?) {
             // - If AA_SIZE is not 1.0f we cannot use the texture path.
             val useTexture = this.flags has DrawListFlag.AntiAliasedLinesUseTex && integerThickness < DRAWLIST_TEX_LINES_WIDTH_MAX && fractionalThickness <= 0.00001f && AA_SIZE == 1f
 
-            ASSERT_PARANOID(!useTexture || _data.font!!.containerAtlas.flags hasnt FontAtlas.Flag.NoBakedLines.i) { "We should never hit this, because NewFrame() doesn't set ImDrawListFlags_AntiAliasedLinesUseTex unless ImFontAtlasFlags_NoBakedLines is off" }
+            ASSERT_PARANOID(!useTexture || _data.font!!.containerAtlas.flags hasnt FontAtlas.Flag.NoBakedLines) { "We should never hit this, because NewFrame() doesn't set ImDrawListFlags_AntiAliasedLinesUseTex unless ImFontAtlasFlags_NoBakedLines is off" }
 
             val idxCount = if (useTexture) count * 6 else (count * if (thickLine) 18 else 12)
             val vtxCount = if (useTexture) pointsCount * 2 else (pointsCount * if (thickLine) 4 else 3)
@@ -707,7 +707,7 @@ class DrawList(sharedData: DrawListSharedData?) {
 
         pathLineTo(p1)
         pathBezierCubicCurveTo(p2, p3, p4, numSegments)
-        pathStroke(col, 0, thickness)
+        pathStroke(col, thickness = thickness)
     }
 
     /** Quad Bezier (3 control points)
@@ -719,7 +719,7 @@ class DrawList(sharedData: DrawListSharedData?) {
 
         pathLineTo(p1)
         pathBezierQuadraticCurveTo(p2, p3, numSegments)
-        pathStroke(col, 0, thickness)
+        pathStroke(col, thickness = thickness)
     }
 
 
@@ -765,12 +765,12 @@ class DrawList(sharedData: DrawListSharedData?) {
             popTextureID()
     }
 
-    fun addImageRounded(userTextureId: TextureID, pMin: Vec2, pMax: Vec2, uvMin: Vec2, uvMax: Vec2, col: Int, rounding: Float, flags_: DrawFlags = 0) {
+    fun addImageRounded(userTextureId: TextureID, pMin: Vec2, pMax: Vec2, uvMin: Vec2, uvMax: Vec2, col: Int, rounding: Float, flags_: DrawFlags = emptyFlags()) {
         if (col hasnt COL32_A_MASK)
             return
 
         val flags = fixRectCornerFlags(flags_)
-        if (rounding < 0.5f || (flags and DrawFlag.RoundCornersMask_) == DrawFlag.RoundCornersNone.i) {
+        if (rounding < 0.5f || (flags and DrawFlag.RoundCornersMask) eq DrawFlag.RoundCornersNone) {
             addImage(userTextureId, pMin, pMax, uvMin, uvMax, col)
             return
         }
@@ -803,7 +803,8 @@ class DrawList(sharedData: DrawListSharedData?) {
     fun pathFillConvex(col: Int) = addConvexPolyFilled(_path, col).also { pathClear() }
 
     /** rounding_corners_flags: 4 bits corresponding to which corner to round   */
-    fun pathStroke(col: Int, flags: DrawFlags = 0, thickness: Float = 1.0f) = addPolyline(_path, col, flags, thickness).also { pathClear() }
+    fun pathStroke(col: Int, flags: DrawFlags = emptyFlags(), thickness: Float = 1.0f) =
+        addPolyline(_path, col, flags, thickness).also { pathClear() }
 
     /** @param center must be a new instance */
     fun pathArcTo(center: Vec2, radius: Float, aMin: Float, aMax: Float, numSegments: Int = 0) {
@@ -928,9 +929,11 @@ class DrawList(sharedData: DrawListSharedData?) {
         var flags = flags_
         // If this triggers, please update your code replacing hardcoded values with new ImDrawFlags_RoundCorners* values.
         // Note that ImDrawFlags_Closed (== 0x01) is an invalid flag for AddRect(), AddRectFilled(), PathRect() etc...
-        check(flags hasnt 0x0F) { "Misuse of legacy hardcoded ImDrawCornerFlags values!" }
+        // [JVM]: Since we're using type-safe flags, this shouldn't be an issue. THe only DrawFlag that could've
+        // triggered the previous type-unsafe version of this is Df.Closed, and so we handle it here.
+        check(flags hasnt DrawFlag.Closed) { "Misuse of legacy hardcoded ImDrawCornerFlags values!" }
 
-        if (flags hasnt DrawFlag.RoundCornersMask_)
+        if (flags hasnt DrawFlag.RoundCornersMask)
             flags = flags or DrawFlag.RoundCornersAll
 
         return flags
@@ -955,14 +958,14 @@ class DrawList(sharedData: DrawListSharedData?) {
         }
     }
 
-    fun pathRect(a: Vec2, b: Vec2, rounding_: Float = 0f, flags_: DrawFlags = 0) {
+    fun pathRect(a: Vec2, b: Vec2, rounding_: Float = 0f, flags_: DrawFlags = emptyFlags()) {
         val flags = fixRectCornerFlags(flags_)
-        var cond = ((flags and DrawFlag.RoundCornersTop) == DrawFlag.RoundCornersTop.i) or ((flags and DrawFlag.RoundCornersBottom) == DrawFlag.RoundCornersBottom.i)
+        var cond = (DrawFlag.RoundCornersTop in flags) or (DrawFlag.RoundCornersBottom in flags)
         var rounding = rounding_ min ((b.x - a.x).abs * (if (cond) 0.5f else 1f) - 1f)
-        cond = ((flags and DrawFlag.RoundCornersLeft) == DrawFlag.RoundCornersLeft.i) or ((flags and DrawFlag.RoundCornersRight) == DrawFlag.RoundCornersRight.i)
+        cond = (DrawFlag.RoundCornersLeft in flags) or (DrawFlag.RoundCornersRight in flags)
         rounding = rounding min ((b.y - a.y).abs * (if (cond) 0.5f else 1f) - 1f)
 
-        if (rounding < 0.5f || (flags and DrawFlag.RoundCornersMask_) == DrawFlag.RoundCornersNone.i) {
+        if (rounding < 0.5f || (flags and DrawFlag.RoundCornersMask) eq DrawFlag.RoundCornersNone) {
             pathLineTo(a)
             pathLineTo(Vec2(b.x, a.y))
             pathLineTo(b)
@@ -1193,7 +1196,7 @@ class DrawList(sharedData: DrawListSharedData?) {
             idxBuffer = idxBuffer.resize(0)
             vtxBuffer = vtxBuffer.resize(0)
         }
-        flags = DrawListFlag.None.i
+        flags = emptyFlags()
         _vtxCurrentIdx = 0
         _vtxWritePtr = 0
         _idxWritePtr = 0

--- a/core/src/main/kotlin/imgui/classes/IO.kt
+++ b/core/src/main/kotlin/imgui/classes/IO.kt
@@ -53,10 +53,10 @@ class IO(sharedFontAtlas: FontAtlas? = null) {
     //------------------------------------------------------------------
 
     /** See ConfigFlags enum. Set by user/application. Gamepad/keyboard navigation options, etc. */
-    var configFlags: ConfigFlags = ConfigFlag.None.i
+    var configFlags: ConfigFlags = emptyFlags()
 
     /** Set ImGuiBackendFlags_ enum. Set by imgui_impl_xxx files or custom backend to communicate features supported by the backend. */
-    var backendFlags: BackendFlags = BackendFlag.None.i
+    var backendFlags: BackendFlags = emptyFlags()
 
     /** Main display size, in pixels (generally == GetMainViewport()->Size). May change every frame.   */
     var displaySize = Vec2i(-1)
@@ -224,7 +224,7 @@ class IO(sharedFontAtlas: FontAtlas? = null) {
             backendUsingLegacyNavInputArray = false
 
         // Filter duplicate (in particular: key mods and gamepad analog values are commonly spammed)
-        val latestEvent = findLatestInputEvent<InputEvent.Key>(key.i)
+        val latestEvent = findLatestInputEvent(key)
         val keyData = key.data
         val latestKeyDown = latestEvent?.down ?: keyData.down
         val latestKeyAnalog = latestEvent?.analogValue ?: keyData.analogValue
@@ -254,15 +254,14 @@ class IO(sharedFontAtlas: FontAtlas? = null) {
     }
 
     /** Queue a mouse button change */
-    fun addMouseButtonEvent(mouseButton: Int, down: Boolean) {
+    fun addMouseButtonEvent(mouseButton: MouseButton, down: Boolean) {
         assert(g.io === this) { "Can only add events to current context." }
-        assert(mouseButton >= 0 && mouseButton < MouseButton.COUNT)
         if (!appAcceptingEvents)
             return
 
         // Filter duplicate
-        val latestEvent = findLatestInputEvent<InputEvent.MouseButton>(mouseButton)
-        val latestButtonDown = latestEvent?.down ?: g.io.mouseDown[mouseButton]
+        val latestEvent = findLatestInputEvent(mouseButton)
+        val latestButtonDown = latestEvent?.down ?: g.io.mouseDown[mouseButton.i]
         if (latestButtonDown == down)
             return
 
@@ -376,7 +375,7 @@ class IO(sharedFontAtlas: FontAtlas? = null) {
             keyData.downDurationPrev = -1f
         }
         keyCtrl = false; keyShift = false; keyAlt = false; keySuper = false
-        keyMods = Key.Mod_None.i
+        keyMods = Key.Mod_None
         mousePos put -Float.MAX_VALUE
         for (n in mouseDown.indices) {
             mouseDown[n] = false
@@ -477,7 +476,7 @@ class IO(sharedFontAtlas: FontAtlas? = null) {
 
 
     /** Key mods flags (any of ImGuiMod_Ctrl/ImGuiMod_Shift/ImGuiMod_Alt/ImGuiMod_Super flags, same as io.KeyCtrl/KeyShift/KeyAlt/KeySuper but merged into flags. DOES NOT CONTAINS ImGuiMod_Shortcut which is pretranslated). Read-only, updated by NewFrame() */
-    var keyMods: KeyChord = 0
+    var keyMods: KeyChord = emptyFlags()
 
     /** Key state for all known keys. Use IsKeyXXX() functions to access this. */
     val keysData = Array(Key.COUNT) { KeyData().apply { downDuration = -1f; downDurationPrev = -1f } }

--- a/core/src/main/kotlin/imgui/classes/IO.kt
+++ b/core/src/main/kotlin/imgui/classes/IO.kt
@@ -53,10 +53,10 @@ class IO(sharedFontAtlas: FontAtlas? = null) {
     //------------------------------------------------------------------
 
     /** See ConfigFlags enum. Set by user/application. Gamepad/keyboard navigation options, etc. */
-    var configFlags: ConfigFlags = emptyFlags()
+    var configFlags: ConfigFlags = emptyFlags
 
     /** Set ImGuiBackendFlags_ enum. Set by imgui_impl_xxx files or custom backend to communicate features supported by the backend. */
-    var backendFlags: BackendFlags = emptyFlags()
+    var backendFlags: BackendFlags = emptyFlags
 
     /** Main display size, in pixels (generally == GetMainViewport()->Size). May change every frame.   */
     var displaySize = Vec2i(-1)
@@ -476,7 +476,7 @@ class IO(sharedFontAtlas: FontAtlas? = null) {
 
 
     /** Key mods flags (any of ImGuiMod_Ctrl/ImGuiMod_Shift/ImGuiMod_Alt/ImGuiMod_Super flags, same as io.KeyCtrl/KeyShift/KeyAlt/KeySuper but merged into flags. DOES NOT CONTAINS ImGuiMod_Shortcut which is pretranslated). Read-only, updated by NewFrame() */
-    var keyMods: KeyChord = emptyFlags()
+    var keyMods: KeyChord = emptyFlags
 
     /** Key state for all known keys. Use IsKeyXXX() functions to access this. */
     val keysData = Array(Key.COUNT) { KeyData().apply { downDuration = -1f; downDurationPrev = -1f } }

--- a/core/src/main/kotlin/imgui/classes/InputTextCallbackData.kt
+++ b/core/src/main/kotlin/imgui/classes/InputTextCallbackData.kt
@@ -23,10 +23,10 @@ import kotlin.math.max
 class InputTextCallbackData {
 
     /** One ImGuiInputTextFlags_Callback*    // Read-only */
-    var eventFlag: InputTextFlags = 0
+    var eventFlag: InputTextFlags = emptyFlags()
 
     /** What user passed to InputText()      // Read-only */
-    var flags: InputTextFlags = 0
+    var flags: InputTextFlags = emptyFlags()
 
     /** What user passed to InputText()      // Read-only */
     var userData: Any? = null

--- a/core/src/main/kotlin/imgui/classes/InputTextCallbackData.kt
+++ b/core/src/main/kotlin/imgui/classes/InputTextCallbackData.kt
@@ -23,10 +23,10 @@ import kotlin.math.max
 class InputTextCallbackData {
 
     /** One ImGuiInputTextFlags_Callback*    // Read-only */
-    var eventFlag: InputTextFlags = emptyFlags()
+    var eventFlag: InputTextFlags = emptyFlags
 
     /** What user passed to InputText()      // Read-only */
-    var flags: InputTextFlags = emptyFlags()
+    var flags: InputTextFlags = emptyFlags
 
     /** What user passed to InputText()      // Read-only */
     var userData: Any? = null
@@ -40,7 +40,7 @@ class InputTextCallbackData {
     var eventChar = NUL
 
     /** Key pressed (Up/Down/TAB)           Read-only    [Completion,History] */
-    var eventKey = Key.Tab
+    var eventKey: Key = Key.Tab
 
     /** Text buffer                 Read-write   [Resize] Can replace pointer / [Completion,History,Always] Only write to pointed data, don't replace the actual pointer! */
     var buf = ByteArray(0)

--- a/core/src/main/kotlin/imgui/classes/ListClipper.kt
+++ b/core/src/main/kotlin/imgui/classes/ListClipper.kt
@@ -6,6 +6,7 @@ import imgui.ImGui.endRow
 import imgui.ImGui.rectRelToAbs
 import imgui.api.g
 import imgui.clamp
+import imgui.has
 import imgui.internal.isAboveGuaranteedIntegerPrecision
 import imgui.internal.sections.IMGUI_DEBUG_LOG_CLIPPER
 import imgui.internal.sections.ListClipperData

--- a/core/src/main/kotlin/imgui/classes/ListClipper.kt
+++ b/core/src/main/kotlin/imgui/classes/ListClipper.kt
@@ -6,7 +6,6 @@ import imgui.ImGui.endRow
 import imgui.ImGui.rectRelToAbs
 import imgui.api.g
 import imgui.clamp
-import imgui.has
 import imgui.internal.isAboveGuaranteedIntegerPrecision
 import imgui.internal.sections.IMGUI_DEBUG_LOG_CLIPPER
 import imgui.internal.sections.ListClipperData

--- a/core/src/main/kotlin/imgui/demo/ExampleApp.kt
+++ b/core/src/main/kotlin/imgui/demo/ExampleApp.kt
@@ -119,7 +119,7 @@ object ExampleApp {
                 StyleEditor()
             }
 
-        var windowFlags: WindowFlags = emptyFlags()
+        var windowFlags: WindowFlags = emptyFlags
         if (noTitlebar) windowFlags = windowFlags or Wf.NoTitleBar
         if (noScrollbar) windowFlags = windowFlags or Wf.NoScrollbar
         if (!noMenu) windowFlags = windowFlags or Wf.MenuBar
@@ -192,7 +192,7 @@ object ExampleApp {
             bulletText("Sections below are demonstrating many aspects of the library.")
             bulletText("The \"Examples\" menu above leads to more demo contents.")
             bulletText("The \"Tools\" menu above gives access to: About Box, Style Editor,\n" +
-                               "and Metrics/Debugger (general purpose Dear ImGui debugging tool).")
+                "and Metrics/Debugger (general purpose Dear ImGui debugging tool).")
             separator()
 
             text("PROGRAMMER GUIDE:")

--- a/core/src/main/kotlin/imgui/demo/ExampleApp.kt
+++ b/core/src/main/kotlin/imgui/demo/ExampleApp.kt
@@ -119,7 +119,7 @@ object ExampleApp {
                 StyleEditor()
             }
 
-        var windowFlags = 0
+        var windowFlags: WindowFlags = emptyFlags()
         if (noTitlebar) windowFlags = windowFlags or Wf.NoTitleBar
         if (noScrollbar) windowFlags = windowFlags or Wf.NoScrollbar
         if (!noMenu) windowFlags = windowFlags or Wf.MenuBar
@@ -212,13 +212,13 @@ object ExampleApp {
 
             treeNode("Configuration##2") {
 
-                checkboxFlags("io.ConfigFlags: NavEnableKeyboard", io::configFlags, ConfigFlag.NavEnableKeyboard.i)
+                checkboxFlags("io.ConfigFlags: NavEnableKeyboard", io::configFlags, ConfigFlag.NavEnableKeyboard)
                 sameLine(); helpMarker("Enable keyboard controls.")
-                checkboxFlags("io.ConfigFlags: NavEnableGamepad", io::configFlags, ConfigFlag.NavEnableGamepad.i)
+                checkboxFlags("io.ConfigFlags: NavEnableGamepad", io::configFlags, ConfigFlag.NavEnableGamepad)
                 sameLine(); helpMarker("Enable gamepad controls. Require backend to feed in gamepad inputs in io.NavInputs[] and set io.BackendFlags |= ImGuiBackendFlags_HasGamepad.\n\nRead instructions in imgui.cpp for details.")
-                checkboxFlags("io.ConfigFlags: NavEnableSetMousePos", io::configFlags, ConfigFlag.NavEnableSetMousePos.i)
+                checkboxFlags("io.ConfigFlags: NavEnableSetMousePos", io::configFlags, ConfigFlag.NavEnableSetMousePos)
                 sameLine(); helpMarker("Instruct navigation to move the mouse cursor. See comment for ImGuiConfigFlags_NavEnableSetMousePos.")
-                checkboxFlags("io.ConfigFlags: NoMouse", io::configFlags, ConfigFlag.NoMouse.i)
+                checkboxFlags("io.ConfigFlags: NoMouse", io::configFlags, ConfigFlag.NoMouse)
                 if (io.configFlags has ConfigFlag.NoMouse) {
                     // The "NoMouse" option can get us stuck with a disabled mouse! Let's provide an alternative way to fix it:
                     if ((time.f % 0.4f) < 0.2f) {
@@ -228,7 +228,7 @@ object ExampleApp {
                     if (Key.Space.isPressed)
                         io.configFlags = io.configFlags wo ConfigFlag.NoMouse
                 }
-                checkboxFlags("io.ConfigFlags: NoMouseCursorChange", io::configFlags, ConfigFlag.NoMouseCursorChange.i)
+                checkboxFlags("io.ConfigFlags: NoMouseCursorChange", io::configFlags, ConfigFlag.NoMouseCursorChange)
                 sameLine(); helpMarker("Instruct backend to not alter mouse cursor shape and visibility.")
                 checkbox("io.ConfigInputTrickleEventQueue", io::configInputTrickleEventQueue)
                 sameLine(); helpMarker("Enable input queue trickling: some types of events submitted during the same frame (e.g. button down + up) will be spread over multiple frames, improving interactions with low framerates.")
@@ -247,17 +247,19 @@ object ExampleApp {
                 separator()
             }
             treeNode("Backend Flags") {
-                helpMarker("""
+                helpMarker(
+                    """
                     Those flags are set by the backends (imgui_impl_xxx files) to specify their capabilities.
-                    Here we expose them as read-only fields to avoid breaking interactions with your backend.""".trimIndent())
+                    Here we expose them as read-only fields to avoid breaking interactions with your backend.""".trimIndent()
+                )
 
                 // Make a local copy to avoid modifying actual backend flags.
                 // FIXME: We don't use BeginDisabled() to keep label bright, maybe we need a BeginReadonly() equivalent..
-                val backendFlags = intArrayOf(io.backendFlags)
-                checkboxFlags("io.BackendFlags: HasGamepad", backendFlags, BackendFlag.HasGamepad.i)
-                checkboxFlags("io.BackendFlags: HasMouseCursors", backendFlags, BackendFlag.HasMouseCursors.i)
-                checkboxFlags("io.BackendFlags: HasSetMousePos", backendFlags, BackendFlag.HasSetMousePos.i)
-                checkboxFlags("io.BackendFlags: RendererHasVtxOffset", backendFlags, BackendFlag.RendererHasVtxOffset.i)
+                val backendFlags = flagArrayOf(io.backendFlags)
+                checkboxFlags("io.BackendFlags: HasGamepad", backendFlags, BackendFlag.HasGamepad)
+                checkboxFlags("io.BackendFlags: HasMouseCursors", backendFlags, BackendFlag.HasMouseCursors)
+                checkboxFlags("io.BackendFlags: HasSetMousePos", backendFlags, BackendFlag.HasSetMousePos)
+                checkboxFlags("io.BackendFlags: RendererHasVtxOffset", backendFlags, BackendFlag.RendererHasVtxOffset)
                 separator()
             }
 

--- a/core/src/main/kotlin/imgui/demo/ShowDemoWindowColumns.kt
+++ b/core/src/main/kotlin/imgui/demo/ShowDemoWindowColumns.kt
@@ -66,7 +66,7 @@ object ShowDemoWindowColumns {
         treeNode("Horizontal Scrolling") {
             setNextWindowContentSize(Vec2(1500f, 0f))
             val childSize = Vec2(0f, fontSize * 20f)
-            child("##ScrollingRegion", childSize, false, WindowFlag.HorizontalScrollbar.i) {
+            child("##ScrollingRegion", childSize, false, WindowFlag.HorizontalScrollbar) {
                 columns(10)
 
                 // Also demonstrate using clipper for large vertical lists
@@ -142,7 +142,7 @@ object ShowDemoWindowColumns {
                 val names = listOf("One", "Two", "Three")
                 val paths = listOf("/path/one", "/path/two", "/path/three")
                 for (i in 0..2) {
-                    selectable("%04d".format(style.locale, i), selected == i, SelectableFlag.SpanAllColumns.i) {
+                    selectable("%04d".format(style.locale, i), selected == i, SelectableFlag.SpanAllColumns) {
                         selected = i
                     }
                     nextColumn()

--- a/core/src/main/kotlin/imgui/demo/ShowDemoWindowInputs.kt
+++ b/core/src/main/kotlin/imgui/demo/ShowDemoWindowInputs.kt
@@ -65,7 +65,7 @@ object ShowDemoWindowInputs {
                 // User code should never have to go through such hoops: old code may use native keycodes, new code may use ImGuiKey codes.
 
                 text("Keys down:")
-                for (key in Key.values().take(Key.Count.ordinal)) {
+                for (key in Key.values.take(Key.Count.ordinal)) {
                     if (!key.isDown) continue
                     sameLine(); text('"' + key.name + '"'); sameLine(); text("(%.02f)", key.data.downDuration)
                 }

--- a/core/src/main/kotlin/imgui/demo/ShowDemoWindowInputs.kt
+++ b/core/src/main/kotlin/imgui/demo/ShowDemoWindowInputs.kt
@@ -65,8 +65,7 @@ object ShowDemoWindowInputs {
                 // User code should never have to go through such hoops: old code may use native keycodes, new code may use ImGuiKey codes.
 
                 text("Keys down:")
-                for (keyIdx in 0 until Key.Count.ordinal) {
-                    val key = Key of keyIdx
+                for (key in Key.values().take(Key.Count.ordinal)) {
                     if (!key.isDown) continue
                     sameLine(); text('"' + key.name + '"'); sameLine(); text("(%.02f)", key.data.downDuration)
                 }
@@ -109,9 +108,9 @@ object ShowDemoWindowInputs {
                                 "Notice how normally (when set to none), the value of io.WantCaptureKeyboard would be false when hovering and true when clicking.")
                     val captureOverrideDesc = listOf("None", "Set to false", "Set to true")
                     setNextItemWidth(ImGui.fontSize * 15)
-                    sliderInt("SetNextFrameWantCaptureMouse() on hover", ::captureOverrideMouse, -1, +1, captureOverrideDesc[captureOverrideMouse + 1], SliderFlag.AlwaysClamp.i)
+                    sliderInt("SetNextFrameWantCaptureMouse() on hover", ::captureOverrideMouse, -1, +1, captureOverrideDesc[captureOverrideMouse + 1], SliderFlag.AlwaysClamp)
                     setNextItemWidth(ImGui.fontSize * 15)
-                    sliderInt("SetNextFrameWantCaptureKeyboard() on hover", ::captureOverrideKeyboard, -1, +1, captureOverrideDesc[captureOverrideKeyboard + 1], SliderFlag.AlwaysClamp.i)
+                    sliderInt("SetNextFrameWantCaptureKeyboard() on hover", ::captureOverrideKeyboard, -1, +1, captureOverrideDesc[captureOverrideKeyboard + 1], SliderFlag.AlwaysClamp)
 
                     colorButton("##panel", Vec4(0.7f, 0.1f, 0.7f, 1f), ColorEditFlag.NoTooltip or ColorEditFlag.NoDragDrop, Vec2(128f, 96f)) // Dummy item
                     if (ImGui.isItemHovered() && captureOverrideMouse != -1)
@@ -130,7 +129,7 @@ object ShowDemoWindowInputs {
                 val current = ImGui.mouseCursor
                 text("Current mouse cursor = ${current.i}: $current")
                 beginDisabled(true)
-                checkboxFlags("io.BackendFlags: HasMouseCursors", io::backendFlags, BackendFlag.HasMouseCursors.i)
+                checkboxFlags("io.BackendFlags: HasMouseCursors", io::backendFlags, BackendFlag.HasMouseCursors)
                 endDisabled()
 
                 text("Hover to see mouse cursors:")

--- a/core/src/main/kotlin/imgui/demo/ShowDemoWindowLayout.kt
+++ b/core/src/main/kotlin/imgui/demo/ShowDemoWindowLayout.kt
@@ -305,7 +305,7 @@ object ShowDemoWindowLayout {
 
                 // Child 2: rounded border
                 run {
-                    var windowFlags: WindowFlags = emptyFlags()
+                    var windowFlags: WindowFlags = emptyFlags
                     if (disableMouseWheel)
                         windowFlags = windowFlags or Wf.NoScrollWithMouse
                     if (!disableMenu)
@@ -581,7 +581,7 @@ object ShowDemoWindowLayout {
                         val names = arrayOf("Top", "25%%", "Center", "75%%", "Bottom") // double quote for ::format escaping
                         textUnformatted(names[i])
 
-                        val childFlags = if (enableExtraDecorations) Wf.MenuBar else emptyFlags()
+                        val childFlags = if (enableExtraDecorations) Wf.MenuBar else emptyFlags
                         val childId = getID(i.L)
                         val childIsVisible = beginChild(childId, Vec2(childW, 200f), true, childFlags)
                         menuBar { textUnformatted("abc") }
@@ -615,7 +615,7 @@ object ShowDemoWindowLayout {
                 pushID("##HorizontalScrolling")
                 for (i in 0..4) {
                     val childHeight = textLineHeight + style.scrollbarSize + style.windowPadding.y * 2f
-                    val childFlags = Wf.HorizontalScrollbar or if (enableExtraDecorations) Wf.AlwaysVerticalScrollbar else emptyFlags()
+                    val childFlags = Wf.HorizontalScrollbar or if (enableExtraDecorations) Wf.AlwaysVerticalScrollbar else emptyFlags
                     val childId = getID(i.L)
                     val childIsVisible = beginChild(childId, Vec2(-100f, childHeight), true, childFlags)
                     if (scrollToOff)
@@ -697,7 +697,7 @@ object ShowDemoWindowLayout {
                 if (showHorizontalContentsSizeDemoWindow) {
                     if (explicitContentSize)
                         setNextWindowContentSize(Vec2(contentsSizeX, 0f))
-                    begin("Horizontal contents size demo window", ::showHorizontalContentsSizeDemoWindow, if (showHscrollbar) Wf.HorizontalScrollbar else emptyFlags())
+                    begin("Horizontal contents size demo window", ::showHorizontalContentsSizeDemoWindow, if (showHscrollbar) Wf.HorizontalScrollbar else emptyFlags)
                     pushStyleVar(StyleVar.ItemSpacing, Vec2(2, 0))
                     pushStyleVar(StyleVar.FramePadding, Vec2(2, 0))
                     helpMarker("Test of different widgets react and impact the work rectangle growing when horizontal scrolling is enabled.\n\nUse 'Metrics->Tools->Show windows rectangles' to visualize rectangles.")

--- a/core/src/main/kotlin/imgui/demo/ShowDemoWindowLayout.kt
+++ b/core/src/main/kotlin/imgui/demo/ShowDemoWindowLayout.kt
@@ -293,7 +293,7 @@ object ShowDemoWindowLayout {
 
                 // Child 1: no border, enable horizontal scrollbar
                 run {
-                    var windowFlags = Wf.HorizontalScrollbar.i
+                    var windowFlags: WindowFlags = Wf.HorizontalScrollbar
                     if (disableMouseWheel)
                         windowFlags = windowFlags or Wf.NoScrollWithMouse
                     child("ChildL", Vec2(contentRegionAvail.x * 0.5f, 260), false, windowFlags) {
@@ -305,7 +305,7 @@ object ShowDemoWindowLayout {
 
                 // Child 2: rounded border
                 run {
-                    var windowFlags = Wf.None.i
+                    var windowFlags: WindowFlags = emptyFlags()
                     if (disableMouseWheel)
                         windowFlags = windowFlags or Wf.NoScrollWithMouse
                     if (!disableMenu)
@@ -347,7 +347,7 @@ object ShowDemoWindowLayout {
 
                     ImGui.cursorPosX += offsetX
                     withStyleColor(Col.ChildBg, COL32(255, 0, 0, 100)) {
-                        beginChild("Red", Vec2(200, 100), true, Wf.None.i)
+                        beginChild("Red", Vec2(200, 100), true)
                         for (n in 0..49)
                             text("Some test $n")
                         endChild()
@@ -581,9 +581,9 @@ object ShowDemoWindowLayout {
                         val names = arrayOf("Top", "25%%", "Center", "75%%", "Bottom") // double quote for ::format escaping
                         textUnformatted(names[i])
 
-                        val childFlags = if (enableExtraDecorations) Wf.MenuBar else Wf.None
+                        val childFlags = if (enableExtraDecorations) Wf.MenuBar else emptyFlags()
                         val childId = getID(i.L)
-                        val childIsVisible = beginChild(childId, Vec2(childW, 200f), true, childFlags.i)
+                        val childIsVisible = beginChild(childId, Vec2(childW, 200f), true, childFlags)
                         menuBar { textUnformatted("abc") }
                         if (scrollToOff)
                             scrollY = scrollToOffPx
@@ -615,7 +615,7 @@ object ShowDemoWindowLayout {
                 pushID("##HorizontalScrolling")
                 for (i in 0..4) {
                     val childHeight = textLineHeight + style.scrollbarSize + style.windowPadding.y * 2f
-                    val childFlags = Wf.HorizontalScrollbar or if (enableExtraDecorations) Wf.AlwaysVerticalScrollbar else Wf.None
+                    val childFlags = Wf.HorizontalScrollbar or if (enableExtraDecorations) Wf.AlwaysVerticalScrollbar else emptyFlags()
                     val childId = getID(i.L)
                     val childIsVisible = beginChild(childId, Vec2(-100f, childHeight), true, childFlags)
                     if (scrollToOff)
@@ -648,7 +648,7 @@ object ShowDemoWindowLayout {
                 pushStyleVar(StyleVar.FrameRounding, 3f)
                 pushStyleVar(StyleVar.FramePadding, Vec2(2f, 1f))
                 val scrollingChildSize = Vec2(0f, ImGui.frameHeightWithSpacing * 7 + 30)
-                beginChild("scrolling", scrollingChildSize, true, Wf.HorizontalScrollbar.i)
+                beginChild("scrolling", scrollingChildSize, true, Wf.HorizontalScrollbar)
                 for (line in 0 until lines) {
                     // Display random stuff. For the sake of this trivial demo we are using basic Button() + SameLine()
                     // If you want to create your own time line for a real application you may be better off manipulating
@@ -697,7 +697,7 @@ object ShowDemoWindowLayout {
                 if (showHorizontalContentsSizeDemoWindow) {
                     if (explicitContentSize)
                         setNextWindowContentSize(Vec2(contentsSizeX, 0f))
-                    begin("Horizontal contents size demo window", ::showHorizontalContentsSizeDemoWindow, if (showHscrollbar) Wf.HorizontalScrollbar.i else Wf.None.i)
+                    begin("Horizontal contents size demo window", ::showHorizontalContentsSizeDemoWindow, if (showHscrollbar) Wf.HorizontalScrollbar else emptyFlags())
                     pushStyleVar(StyleVar.ItemSpacing, Vec2(2, 0))
                     pushStyleVar(StyleVar.FramePadding, Vec2(2, 0))
                     helpMarker("Test of different widgets react and impact the work rectangle growing when horizontal scrolling is enabled.\n\nUse 'Metrics->Tools->Show windows rectangles' to visualize rectangles.")
@@ -736,7 +736,7 @@ object ShowDemoWindowLayout {
                         textWrapped("This text should automatically wrap on the edge of the work rectangle.")
                     if (showColumns) {
                         text("Tables:")
-                        if (beginTable("table", 4, TableFlag.Borders.i)) {
+                        if (beginTable("table", 4, TableFlag.Borders)) {
                             for (n in 0..3) {
                                 tableNextColumn()
                                 text("Width %.2f", ImGui.contentRegionAvail.x)

--- a/core/src/main/kotlin/imgui/demo/ShowDemoWindowPopus.kt
+++ b/core/src/main/kotlin/imgui/demo/ShowDemoWindowPopus.kt
@@ -1,6 +1,5 @@
 package imgui.demo
 
-import glm_.glm
 import glm_.vec2.Vec2
 import glm_.vec4.Vec4
 import imgui.*
@@ -34,17 +33,15 @@ import imgui.ImGui.text
 import imgui.ImGui.textEx
 import imgui.ImGui.textWrapped
 import imgui.api.demoDebugInformations.Companion.helpMarker
+import imgui.demo.showExampleApp.MenuFile
 import imgui.dsl.button
 import imgui.dsl.menu
+import imgui.dsl.menuBar
 import imgui.dsl.popup
 import imgui.dsl.popupContextItem
 import imgui.dsl.popupModal
 import imgui.dsl.treeNode
-import imgui.dsl.withID
-import imgui.dsl.withItemWidth
 import imgui.dsl.withStyleVar
-import imgui.demo.showExampleApp.MenuFile
-import imgui.dsl.menuBar
 import imgui.WindowFlag as Wf
 
 object ShowDemoWindowPopups {
@@ -137,7 +134,7 @@ object ShowDemoWindowPopups {
 
                 // Call the more complete ShowExampleMenuFile which we use in various places of this demo
                 if (button("With a menu.."))
-                    openPopup("my_file_popup", Wf.MenuBar.i)
+                    openPopup("my_file_popup")
                 popup("my_file_popup") {
                     menuBar {
                         menu("File") {
@@ -210,7 +207,7 @@ object ShowDemoWindowPopups {
                     // Here we make it that right-clicking this other text element opens the same popup as above.
                     // The popup itself will be submitted by the code above.
                     text("(2) Or right-click this text")
-                    openPopupOnItemClick("my popup", PopupFlag.MouseButtonRight.i)
+                    openPopupOnItemClick("my popup", PopupFlag.MouseButtonRight)
 
                     // Back to square one: manually open the same popup.
                     if (button("(3) Or click this button"))
@@ -253,7 +250,7 @@ object ShowDemoWindowPopups {
                 val center = mainViewport.center
                 setNextWindowPos(center, Cond.Appearing, Vec2(0.5f))
 
-                popupModal("Delete?", null, Wf.AlwaysAutoResize.i) {
+                popupModal("Delete?", null, Wf.AlwaysAutoResize) {
 
                     text("All those beautiful files will be deleted.\nThis operation cannot be undone!\n\n")
                     separator()
@@ -261,7 +258,9 @@ object ShowDemoWindowPopups {
                     //static int unused_i = 0;
                     //ImGui::Combo("Combo", &unused_i, "Delete\0Delete harder\0");
 
-                    withStyleVar(StyleVar.FramePadding, Vec2()) { checkbox("Don't ask me next time", ::dontAskMeNextTime) }
+                    withStyleVar(StyleVar.FramePadding, Vec2()) {
+                        checkbox("Don't ask me next time", ::dontAskMeNextTime)
+                    }
 
                     button("OK", Vec2(120, 0)) { closeCurrentPopup() }
                     setItemDefaultFocus()
@@ -270,7 +269,7 @@ object ShowDemoWindowPopups {
                 }
 
                 button("Stacked modals..") { openPopup("Stacked 1") }
-                popupModal("Stacked 1", null, Wf.MenuBar.i) {
+                popupModal("Stacked 1", null, Wf.MenuBar) {
 
                     if (beginMenuBar()) {
                         if (beginMenu("File")) {

--- a/core/src/main/kotlin/imgui/demo/ShowDemoWindowTables.kt
+++ b/core/src/main/kotlin/imgui/demo/ShowDemoWindowTables.kt
@@ -112,6 +112,7 @@ object ShowDemoWindowTables {
         EnumDesc(Tf.SizingStretchSame, "ImGuiTableFlags_SizingStretchSame", "Columns default to _WidthStretch with same weights.")
     )
 
+    @JvmName("editTableSizingFlags")
     /** Show a combo box with a choice of sizing policies */
     fun editTableSizingFlags(flags: FlagArray<Tf>, ptr: Int) {
         var flag by flags.mutablePropertyAt(ptr)

--- a/core/src/main/kotlin/imgui/demo/ShowDemoWindowTables.kt
+++ b/core/src/main/kotlin/imgui/demo/ShowDemoWindowTables.kt
@@ -67,7 +67,6 @@ import imgui.ImGui.textWrapped
 import imgui.ImGui.treeNodeEx
 import imgui.ImGui.treePop
 import imgui.ImGui.unindent
-import imgui.TableColumnFlag
 import imgui.api.demoDebugInformations.Companion.helpMarker
 import imgui.classes.DrawList
 import imgui.classes.ListClipper
@@ -105,7 +104,7 @@ object ShowDemoWindowTables {
     class EnumDesc(val value: TableFlags, val name: String, val tooltip: String)
 
     val policies = arrayOf(
-        EnumDesc(emptyFlags(), "Default", "Use default sizing policy:\n- ImGuiTableFlags_SizingFixedFit if ScrollX is on or if host window has ImGuiWindowFlags_AlwaysAutoResize.\n- ImGuiTableFlags_SizingStretchSame otherwise."),
+        EnumDesc(emptyFlags, "Default", "Use default sizing policy:\n- ImGuiTableFlags_SizingFixedFit if ScrollX is on or if host window has ImGuiWindowFlags_AlwaysAutoResize.\n- ImGuiTableFlags_SizingStretchSame otherwise."),
         EnumDesc(Tf.SizingFixedFit, "ImGuiTableFlags_SizingFixedFit", "Columns default to _WidthFixed (if resizable) or _WidthAuto (if not resizable), matching contents width."),
         EnumDesc(Tf.SizingFixedSame, "ImGuiTableFlags_SizingFixedSame", "Columns are all the same width, matching the maximum contents width.\nImplicitly disable ImGuiTableFlags_Resizable and enable ImGuiTableFlags_NoKeepColumnsVisible."),
         EnumDesc(Tf.SizingStretchProp, "ImGuiTableFlags_SizingStretchProp", "Columns default to _WidthStretch with weights proportional to their widths."),
@@ -116,7 +115,7 @@ object ShowDemoWindowTables {
     /** Show a combo box with a choice of sizing policies */
     fun editTableSizingFlags(flags: FlagArray<Tf>, ptr: Int) {
         var flag by flags.mutablePropertyAt(ptr)
-        val idx = policies.indexOfFirst { it.value eq (flag and Tf._SizingMask) }
+        val idx = policies.indexOfFirst { it.value == (flag and Tf._SizingMask) }
         val previewText = policies.getOrNull(idx)?.name?.substringAfter("ImGuiTableFlags") ?: ""
         useCombo("Sizing Policy", previewText) {
             for (n in policies.indices)
@@ -139,7 +138,7 @@ object ShowDemoWindowTables {
             }
     }
 
-    fun editTableColumnsFlags(flags: TableColumnFlags): TableColumnFlags {
+    fun editTableColumnsFlags(flags: TableColumnSetupFlags): TableColumnSetupFlags {
         val flagsRef = flags.mutableReference
         var flags by flagsRef
         checkboxFlags("_Disabled", flagsRef, Tcf.Disabled); sameLine(); helpMarker("Master disable flag (also hide from context menu)")
@@ -981,8 +980,8 @@ object ShowDemoWindowTables {
     object `Columns flags` {
         var columnCount = 3
         val columnNames = arrayOf("One", "Two", "Three")
-        val columnFlags = flagArrayOf(Tcf.DefaultSort, emptyFlags(), Tcf.DefaultHide)
-        val columnFlagsOut = FlagArray<TableColumnFlag>(columnCount)// Output from TableGetColumnFlags()
+        val columnFlags = flagArrayOf(Tcf.DefaultSort, emptyFlags, Tcf.DefaultHide)
+        val columnFlagsOut = FlagArray<Tcf<*>>(columnCount)// Output from TableGetColumnFlags()
 
         operator fun invoke() {
             treeNode("Columns flags") {
@@ -1038,7 +1037,7 @@ object ShowDemoWindowTables {
 
     object `Columns widths` {
         var flags1 = Tf.Borders or Tf.NoBordersInBodyUntilResize
-        var flags2: TableFlags = emptyFlags()
+        var flags2: TableFlags = emptyFlags
         operator fun invoke() {
             treeNode("Columns widths") {
                 helpMarker("Using TableSetupColumn() to setup default width.")
@@ -1683,7 +1682,7 @@ object ShowDemoWindowTables {
                     tableSetupColumn("Name", Tcf.WidthFixed, 0f, MyItemColumnID.Name.ordinal)
                     tableSetupColumn("Action", Tcf.NoSort or Tcf.WidthFixed, 0f, MyItemColumnID.Action.ordinal)
                     tableSetupColumn("Quantity", Tcf.PreferSortDescending, 0f, MyItemColumnID.Quantity.ordinal)
-                    tableSetupColumn("Description", if (flags has Tf.NoHostExtendX) emptyFlags() else Tcf.WidthStretch, 0f, MyItemColumnID.Description.ordinal)
+                    tableSetupColumn("Description", if (flags has Tf.NoHostExtendX) emptyFlags else Tcf.WidthStretch, 0f, MyItemColumnID.Description.ordinal)
                     tableSetupColumn("Hidden", Tcf.DefaultHide or Tcf.NoSort)
                     tableSetupScrollFreeze(freezeCols, freezeRows)
 
@@ -1745,7 +1744,7 @@ object ShowDemoWindowTables {
                             else if (type == ContentsType.Selectable || type == ContentsType.SelectableSpanRow) {
                                 val selectableFlags = when (type) {
                                     ContentsType.SelectableSpanRow -> SelectableFlag.SpanAllColumns or SelectableFlag.AllowItemOverlap
-                                    else -> emptyFlags()
+                                    else -> emptyFlags
                                 }
                                 if (selectable(label, itemIsSelected, selectableFlags, Vec2(0f, rowMinHeight)))
                                     if (io.keyCtrl)

--- a/core/src/main/kotlin/imgui/demo/ShowDemoWindowWidgets.kt
+++ b/core/src/main/kotlin/imgui/demo/ShowDemoWindowWidgets.kt
@@ -167,8 +167,6 @@ import imgui.dsl.withItemWidth
 import imgui.dsl.withStyleColor
 import imgui.dsl.withStyleVar
 import imgui.dsl.withTextWrapPos
-import imgui.internal.sections.ItemFlags
-import imgui.or
 import unsigned.Ubyte
 import unsigned.Uint
 import unsigned.Ulong
@@ -202,7 +200,7 @@ object ShowDemoWindowWidgets {
     /* Text Input */
     object Funcs2 {
         val MyResizeCallback: InputTextCallback = { data ->
-            if (data.eventFlag == Itf.CallbackResize.i) {
+            if (data.eventFlag eq Itf.CallbackResize) {
                 val myString = data.userData as ByteArray
                 assert(myString.contentEquals(data.buf))
                 data.userData = ByteArray(data.bufSize)  // NB: On resizing calls, generally data->BufSize == data->BufTextLen + 1
@@ -213,7 +211,7 @@ object ShowDemoWindowWidgets {
 
         // Note: Because ImGui:: is a namespace you would typically add your own function into the namespace.
         // For example, you code may declare a function 'ImGui::InputText(const char* label, MyString* my_str)'
-        val MyInputTextMultiline: (label: String, myStr: ByteArray, size: Vec2, flags: ItemFlags) -> Boolean =
+        val MyInputTextMultiline: (label: String, myStr: ByteArray, size: Vec2, flags: InputTextFlags) -> Boolean =
             { label, myStr, size, flags ->
                 assert(flags hasnt Itf.CallbackResize)
                 inputTextMultiline(label, String(myStr), size, flags or Itf.CallbackResize, MyResizeCallback, myStr)
@@ -395,7 +393,7 @@ object ShowDemoWindowWidgets {
                     Hold SHIFT/ALT for faster/slower edit.
                     Double-click or CTRL+click to input value.""".trimIndent())
 
-                    dragInt("drag int 0..100", ::i2, 1f, 0, 100, "%d%%", SliderFlag.AlwaysClamp.i)
+                    dragInt("drag int 0..100", ::i2, 1f, 0, 100, "%d%%", SliderFlag.AlwaysClamp)
 
                     dragFloat("drag float", ::f2, 0.005f)
                     dragFloat("drag small float", ::f3, 0.0001f, 0f, 0f, "%.06f ns")
@@ -498,10 +496,10 @@ object ShowDemoWindowWidgets {
                     helpMarker("""
                     This is a more typical looking tree with selectable nodes.
                     Click to select, CTRL+Click to toggle, click on arrows or double-click to open.""".trimIndent())
-                    checkboxFlags("ImGuiTreeNodeFlags_OpenOnArrow", ::baseFlags, Tnf.OpenOnArrow.i)
-                    checkboxFlags("ImGuiTreeNodeFlags_OpenOnDoubleClick", ::baseFlags, Tnf.OpenOnDoubleClick.i)
-                    checkboxFlags("ImGuiTreeNodeFlags_SpanAvailWidth", ::baseFlags, Tnf.SpanAvailWidth.i); sameLine(); helpMarker("Extend hit area to all available width instead of allowing more items to be laid out after the node.")
-                    checkboxFlags("ImGuiTreeNodeFlags_SpanFullWidth", ::baseFlags, Tnf.SpanFullWidth.i)
+                    checkboxFlags("ImGuiTreeNodeFlags_OpenOnArrow", ::baseFlags, Tnf.OpenOnArrow)
+                    checkboxFlags("ImGuiTreeNodeFlags_OpenOnDoubleClick", ::baseFlags, Tnf.OpenOnDoubleClick)
+                    checkboxFlags("ImGuiTreeNodeFlags_SpanAvailWidth", ::baseFlags, Tnf.SpanAvailWidth); sameLine(); helpMarker("Extend hit area to all available width instead of allowing more items to be laid out after the node.")
+                    checkboxFlags("ImGuiTreeNodeFlags_SpanFullWidth", ::baseFlags, Tnf.SpanFullWidth)
                     checkbox("Align label with current X position", ::alignLabelWithCurrentXposition)
                     checkbox("Test tree node as drag source", ::testDragAndDrop)
                     text("Hello!")
@@ -567,7 +565,7 @@ object ShowDemoWindowWidgets {
         operator fun invoke() {
             treeNode("Collapsing Headers") {
                 checkbox("Show 2nd header", ::closableGroup)
-                collapsingHeader("Header", Tnf.None.i) {
+                collapsingHeader("Header") {
                     text("IsItemHovered: ${isItemHovered()}")
                     for (i in 0..4) text("Some content $i")
                 }
@@ -729,7 +727,7 @@ object ShowDemoWindowWidgets {
     }
 
     object Combo {
-        var flags = ComboFlag.None.i
+        var flags: ComboFlags = emptyFlags()
         var itemCurrentIdx = 0
         var itemCurrent2 = 0
         var itemCurrent3 = 0
@@ -746,11 +744,11 @@ object ShowDemoWindowWidgets {
             treeNode("Combo") {
                 // Combo Boxes are also called "Dropdown" in other systems
                 // Expose flags as checkbox for the demo
-                checkboxFlags("ComboFlag.PopupAlignLeft", ::flags, ComboFlag.PopupAlignLeft.i)
+                checkboxFlags("ComboFlag.PopupAlignLeft", ::flags, ComboFlag.PopupAlignLeft)
                 sameLine(); helpMarker("Only makes a difference if the popup is larger than the combo")
-                if (checkboxFlags("ComboFlag.NoArrowButton", ::flags, ComboFlag.NoArrowButton.i))
+                if (checkboxFlags("ComboFlag.NoArrowButton", ::flags, ComboFlag.NoArrowButton))
                     flags = flags wo ComboFlag.NoPreview     // Clear the other flag, as we cannot combine both
-                if (checkboxFlags("ComboFlag.NoPreview", ::flags, ComboFlag.NoPreview.i))
+                if (checkboxFlags("ComboFlag.NoPreview", ::flags, ComboFlag.NoPreview))
                     flags = flags wo ComboFlag.NoArrowButton // Clear the other flag, as we cannot combine both
 
                 // Using the generic BeginCombo() API, you have full control over how to display the combo contents.
@@ -849,7 +847,7 @@ object ShowDemoWindowWidgets {
                     selectable("2. I am selectable", selection0, 1)
                     text("(I am not selectable)")
                     selectable("4. I am selectable", selection0, 2)
-                    if (selectable("5. I am double clickable", selection0[3], Sf.AllowDoubleClick.i))
+                    if (selectable("5. I am double clickable", selection0[3], Sf.AllowDoubleClick))
                         if (isMouseDoubleClicked(MouseButton.Left)) selection0[3] = !selection0[3]
                 }
                 treeNode("Selection State: Single Selection") {
@@ -888,7 +886,7 @@ object ShowDemoWindowWidgets {
                             val label = "Item $i"
                             tableNextRow()
                             tableNextColumn()
-                            selectable(label, selected2, i, imgui.SelectableFlag.SpanAllColumns.i)
+                            selectable(label, selected2, i, imgui.SelectableFlag.SpanAllColumns)
                             tableNextColumn()
                             text("Some other contents")
                             tableNextColumn()
@@ -910,7 +908,7 @@ object ShowDemoWindowWidgets {
                             if (x > 0)
                                 sameLine()
                             pushID(y * 4 + x)
-                            if (selectable("Sailor", selected3[y][x] != 0, 0, Vec2(50))) {
+                            if (selectable("Sailor", selected3[y][x] != 0, sizeArg = Vec2(50))) {
                                 // Toggle clicked cell + toggle neighbors
                                 selected3[y][x] = selected3[y][x] xor 1
                                 if (x > 0) selected3[y][x - 1] = selected3[y][x - 1] xor 1
@@ -938,7 +936,7 @@ object ShowDemoWindowWidgets {
                             val name = "(%.1f,%.1f)".format(alignment.x, alignment.y)
                             if (x > 0) sameLine()
                             pushStyleVar(StyleVar.SelectableTextAlign, alignment)
-                            selectable(name, selected4, 3 * y + x, Sf.None.i, Vec2(80))
+                            selectable(name, selected4, 3 * y + x, size = Vec2(80))
                             popStyleVar()
                         }
                 }
@@ -961,7 +959,7 @@ object ShowDemoWindowWidgets {
         ${'\t'}lock cmpxchg8b eax
         
         """.trimIndent().toByteArray(1024 * 16)
-        var flags = Itf.AllowTabInput.i
+        var flags: InputTextFlags = Itf.AllowTabInput
         val bufs = Array(6) { ByteArray(64) }
 
         object TextFilters {
@@ -975,9 +973,9 @@ object ShowDemoWindowWidgets {
 
         object Funcs1 {
             val myCallback: InputTextCallback = { data: InputTextCallbackData ->
-                when (data.eventFlag) {
-                    Itf.CallbackCompletion.i -> data.insertChars(data.cursorPos, "..")
-                    Itf.CallbackHistory.i ->
+                when {
+                    data.eventFlag eq Itf.CallbackCompletion -> data.insertChars(data.cursorPos, "..")
+                    data.eventFlag eq Itf.CallbackHistory ->
                         if (data.eventKey == Key.UpArrow) {
                             data.deleteChars(0, data.bufTextLen)
                             data.insertChars(0, "Pressed Up!")
@@ -987,7 +985,7 @@ object ShowDemoWindowWidgets {
                             data.insertChars(0, "Pressed Down!")
                             data.selectAll()
                         }
-                    Itf.CallbackEdit.i -> {
+                    data.eventFlag eq Itf.CallbackEdit -> {
                         // Toggle casing of first character
                         val c = data.buf[0].c
                         if (c in 'a'..'z' || c in 'A'..'Z')
@@ -1016,35 +1014,35 @@ object ShowDemoWindowWidgets {
                     /*  Note: we are using a fixed-sized buffer for simplicity here. See ImGuiInputTextFlags_CallbackResize
                         and the code in misc/cpp/imgui_stdlib.h for how to setup InputText() for dynamically resizing strings.  */
                     helpMarker("You can use the InputTextFlag.CallbackResize facility if you need to wire InputTextMultiline() to a dynamic string type. See misc/cpp/imgui_stl.h for an example. (This is not demonstrated in imgui_demo.cpp because we don't want to include <string> in here)") // TODO fix bug, some '?' appear at the end of the line
-                    checkboxFlags("ImGuiInputTextFlags_ReadOnly", ::flags, Itf.ReadOnly.i)
-                    checkboxFlags("ImGuiInputTextFlags_AllowTabInput", ::flags, Itf.AllowTabInput.i)
-                    checkboxFlags("ImGuiInputTextFlags_CtrlEnterForNewLine", ::flags, Itf.CtrlEnterForNewLine.i)
+                    checkboxFlags("ImGuiInputTextFlags_ReadOnly", ::flags, Itf.ReadOnly)
+                    checkboxFlags("ImGuiInputTextFlags_AllowTabInput", ::flags, Itf.AllowTabInput)
+                    checkboxFlags("ImGuiInputTextFlags_CtrlEnterForNewLine", ::flags, Itf.CtrlEnterForNewLine)
                     inputTextMultiline("##source", text, Vec2(-Float.MIN_VALUE, textLineHeight * 16), flags)
                 }
 
                 treeNode("Filtered Text Input") {
                     inputText("default", bufs[0])
-                    inputText("decimal", bufs[1], Itf.CharsDecimal.i)
+                    inputText("decimal", bufs[1], Itf.CharsDecimal)
                     inputText("hexadecimal", bufs[2], Itf.CharsHexadecimal or Itf.CharsUppercase)
-                    inputText("uppercase", bufs[3], Itf.CharsUppercase.i)
-                    inputText("no blank", bufs[4], Itf.CharsNoBlank.i)
-                    inputText("\"imgui\" letters", bufs[5], Itf.CallbackCharFilter.i, TextFilters.filterImGuiLetters)
+                    inputText("uppercase", bufs[3], Itf.CharsUppercase)
+                    inputText("no blank", bufs[4], Itf.CharsNoBlank)
+                    inputText("\"imgui\" letters", bufs[5], Itf.CallbackCharFilter, TextFilters.filterImGuiLetters)
                 }
                 treeNode("Password Input") {
-                    inputText("password", password, Itf.Password.i)
+                    inputText("password", password, Itf.Password)
                     sameLine(); helpMarker("Display all characters as '*'.\nDisable clipboard cut and copy.\nDisable logging.")
-                    inputTextWithHint("password (w/ hint)", "<password>", password, Itf.Password.i)
+                    inputTextWithHint("password (w/ hint)", "<password>", password, Itf.Password)
                     inputText("password (clear)", password)
                 }
 
                 treeNode("Completion, History, Edit Callbacks") {
-                    inputText("Completion", buf1, Itf.CallbackCompletion.i, Funcs1.myCallback)
+                    inputText("Completion", buf1, Itf.CallbackCompletion, Funcs1.myCallback)
                     sameLine(); helpMarker("Here we append \"..\" each time Tab is pressed. See 'Examples>Console' for a more meaningful demonstration of using this callback.")
 
-                    inputText("History", buf2, Itf.CallbackHistory.i, Funcs1.myCallback)
+                    inputText("History", buf2, Itf.CallbackHistory, Funcs1.myCallback)
                     sameLine(); helpMarker("Here we replace and select text each time Up/Down are pressed. See 'Examples>Console' for a more meaningful demonstration of using this callback.")
 
-                    inputText("Edit", buf3, Itf.CallbackEdit.i, Funcs1.myCallback, ::editCount)
+                    inputText("Edit", buf3, Itf.CallbackEdit, Funcs1.myCallback, ::editCount)
                     sameLine(); helpMarker("Here we toggle the casing of the first character on every edit + count edits.")
                     sameLine(); text("($editCount)")
                 }
@@ -1063,7 +1061,7 @@ object ShowDemoWindowWidgets {
                     // than usually reported by a typical string class.
                     if (myStr.isEmpty())
                         myStr = ByteArray(1)
-                    Funcs2.MyInputTextMultiline("##MyStr", myStr, Vec2(-Float.MIN_VALUE, textLineHeight * 16), 0)
+                    Funcs2.MyInputTextMultiline("##MyStr", myStr, Vec2(-Float.MIN_VALUE, textLineHeight * 16), emptyFlags())
                     text("Data: ${myStr.hashCode()}\nSize: ${myStr.strlen()}\nCapacity: ${myStr.size}")
                 }
             }
@@ -1071,7 +1069,7 @@ object ShowDemoWindowWidgets {
     }
 
     object Tabs {
-        var tabBarFlags1 = TabBarFlag.Reorderable.i
+        var tabBarFlags1: TabBarFlags = TabBarFlag.Reorderable
         val opened = BooleanArray(4) { true } // Persistent user state
         val activeTabs = ArrayList<Int>()
         var nextTabId = 0
@@ -1082,8 +1080,7 @@ object ShowDemoWindowWidgets {
             // Tabs
             treeNode("Tabs") {
                 treeNode("Basic") {
-                    val tabBarFlags = TabBarFlag.None.i
-                    tabBar("MyTabBar", tabBarFlags) {
+                    tabBar("MyTabBar") {
                         tabItem("Avocado") {
                             text("This is the Avocado tab!\nblah blah blah blah blah")
                         }
@@ -1099,16 +1096,16 @@ object ShowDemoWindowWidgets {
 
                 treeNode("Advanced & Close Button") {
                     // Expose a couple of the available flags. In most cases you may just call BeginTabBar() with no flags (0).
-                    checkboxFlags("ImGuiTabBarFlags_Reorderable", ::tabBarFlags1, TabBarFlag.Reorderable.i)
-                    checkboxFlags("ImGuiTabBarFlags_AutoSelectNewTabs", ::tabBarFlags1, TabBarFlag.AutoSelectNewTabs.i)
-                    checkboxFlags("ImGuiTabBarFlags_TabListPopupButton", ::tabBarFlags1, TabBarFlag.TabListPopupButton.i)
-                    checkboxFlags("ImGuiTabBarFlags_NoCloseWithMiddleMouseButton", ::tabBarFlags1, TabBarFlag.NoCloseWithMiddleMouseButton.i)
-                    if (tabBarFlags1 hasnt TabBarFlag.FittingPolicyMask_)
-                        tabBarFlags1 = tabBarFlags1 or TabBarFlag.FittingPolicyDefault_
-                    if (checkboxFlags("ImGuiTabBarFlags_FittingPolicyResizeDown", ::tabBarFlags1, TabBarFlag.FittingPolicyResizeDown.i))
-                        tabBarFlags1 = tabBarFlags1 wo (TabBarFlag.FittingPolicyMask_ xor TabBarFlag.FittingPolicyResizeDown)
-                    if (checkboxFlags("ImGuiTabBarFlags_FittingPolicyScroll", ::tabBarFlags1, TabBarFlag.FittingPolicyScroll.i))
-                        tabBarFlags1 = tabBarFlags1 wo (TabBarFlag.FittingPolicyMask_ xor TabBarFlag.FittingPolicyScroll)
+                    checkboxFlags("ImGuiTabBarFlags_Reorderable", ::tabBarFlags1, TabBarFlag.Reorderable)
+                    checkboxFlags("ImGuiTabBarFlags_AutoSelectNewTabs", ::tabBarFlags1, TabBarFlag.AutoSelectNewTabs)
+                    checkboxFlags("ImGuiTabBarFlags_TabListPopupButton", ::tabBarFlags1, TabBarFlag.TabListPopupButton)
+                    checkboxFlags("ImGuiTabBarFlags_NoCloseWithMiddleMouseButton", ::tabBarFlags1, TabBarFlag.NoCloseWithMiddleMouseButton)
+                    if (tabBarFlags1 hasnt TabBarFlag.FittingPolicyMask)
+                        tabBarFlags1 = tabBarFlags1 or TabBarFlag.FittingPolicyDefault
+                    if (checkboxFlags("ImGuiTabBarFlags_FittingPolicyResizeDown", ::tabBarFlags1, TabBarFlag.FittingPolicyResizeDown))
+                        tabBarFlags1 = tabBarFlags1 wo (TabBarFlag.FittingPolicyMask xor TabBarFlag.FittingPolicyResizeDown)
+                    if (checkboxFlags("ImGuiTabBarFlags_FittingPolicyScroll", ::tabBarFlags1, TabBarFlag.FittingPolicyScroll))
+                        tabBarFlags1 = tabBarFlags1 wo (TabBarFlag.FittingPolicyMask xor TabBarFlag.FittingPolicyScroll)
 
                     // Tab Bar
                     val names = listOf("Artichoke", "Beetroot", "Celery", "Daikon")
@@ -1122,7 +1119,7 @@ object ShowDemoWindowWidgets {
                     tabBar("MyTabBar", tabBarFlags1) {
                         for (n in opened.indices)
                             if (opened[n])
-                                tabItem(names[n], opened, n, TabItemFlag.None.i) {
+                                tabItem(names[n], opened, n) {
                                     text("This is the ${names[n]} tab!")
                                     if (n has 1)
                                         text("I am an odd tab.")
@@ -1143,11 +1140,11 @@ object ShowDemoWindowWidgets {
                     checkbox("Show Trailing TabItemButton()", ::showTrailingButton)
 
                     // Expose some other flags which are useful to showcase how they interact with Leading/Trailing tabs
-                    checkboxFlags("ImGuiTabBarFlags_TabListPopupButton", ::tabBarFlags2, TabBarFlag.TabListPopupButton.i)
-                    if (checkboxFlags("ImGuiTabBarFlags_FittingPolicyResizeDown", ::tabBarFlags2, TabBarFlag.FittingPolicyResizeDown.i))
-                        tabBarFlags2 = tabBarFlags2 wo (TabBarFlag.FittingPolicyMask_ xor TabBarFlag.FittingPolicyResizeDown)
-                    if (checkboxFlags("ImGuiTabBarFlags_FittingPolicyScroll", ::tabBarFlags2, TabBarFlag.FittingPolicyScroll.i))
-                        tabBarFlags2 = tabBarFlags2 wo (TabBarFlag.FittingPolicyMask_ xor TabBarFlag.FittingPolicyScroll)
+                    checkboxFlags("ImGuiTabBarFlags_TabListPopupButton", ::tabBarFlags2, TabBarFlag.TabListPopupButton)
+                    if (checkboxFlags("ImGuiTabBarFlags_FittingPolicyResizeDown", ::tabBarFlags2, TabBarFlag.FittingPolicyResizeDown))
+                        tabBarFlags2 = tabBarFlags2 wo (TabBarFlag.FittingPolicyMask xor TabBarFlag.FittingPolicyResizeDown)
+                    if (checkboxFlags("ImGuiTabBarFlags_FittingPolicyScroll", ::tabBarFlags2, TabBarFlag.FittingPolicyScroll))
+                        tabBarFlags2 = tabBarFlags2 wo (TabBarFlag.FittingPolicyMask xor TabBarFlag.FittingPolicyScroll)
 
                     tabBar("MyTabBar", tabBarFlags2) {
                         // Demo a Leading TabItemButton(): click the "?" button to open a menu
@@ -1170,7 +1167,7 @@ object ShowDemoWindowWidgets {
                             var open = true
                             val name = "%04d".format(activeTabs[n])
                             _b = open
-                            tabItem(name, ::_b, TabItemFlag.None.i) {
+                            tabItem(name, ::_b) {
                                 text("This is the $name tab!")
                             }
                             open = _b
@@ -1284,7 +1281,7 @@ object ShowDemoWindowWidgets {
                 checkbox("With Drag and Drop", ::dragAndDrop)
                 checkbox("With Options Menu", ::optionsMenu); sameLine(); helpMarker("Right-click on the individual color widget to show options.")
                 checkbox("With HDR", ::hdr); sameLine(); helpMarker("Currently all this does is to lift the 0..1 limits on dragging widgets.")
-                var miscFlags = if (hdr) Cef.HDR.i else Cef.None.i
+                var miscFlags = if (hdr) Cef.HDR else emptyFlags()
                 if (!dragAndDrop) miscFlags = miscFlags or Cef.NoDragDrop
                 if (alphaHalfPreview) miscFlags = miscFlags or Cef.AlphaPreviewHalf
                 else if (alphaPreview) miscFlags = miscFlags or Cef.AlphaPreview
@@ -1365,7 +1362,7 @@ object ShowDemoWindowWidgets {
                 }
                 text("Color button only:")
                 checkbox("ImGuiColorEditFlags_NoBorder", ::noBorder)
-                colorButton("MyColor##3c", color, miscFlags or if (noBorder) Cef.NoBorder else Cef.None, Vec2(80))
+                colorButton("MyColor##3c", color, miscFlags or if (noBorder) Cef.NoBorder else emptyFlags(), Vec2(80))
 
                 text("Color picker:")
                 checkbox("With Alpha", ::alpha)
@@ -1432,7 +1429,7 @@ object ShowDemoWindowWidgets {
     }
 
     object `DragSlider Flags` {
-        var flags = SliderFlag.None.i
+        var flags: SliderFlags = emptyFlags()
         var dragF = 0.5f
         var dragI = 50
         var sliderF = 0.5f
@@ -1440,13 +1437,13 @@ object ShowDemoWindowWidgets {
         operator fun invoke() {
             treeNode("Drag/Slider Flags") {
                 // Demonstrate using advanced flags for DragXXX and SliderXXX functions. Note that the flags are the same!
-                checkboxFlags("ImGuiSliderFlags_AlwaysClamp", ::flags, SliderFlag.AlwaysClamp.i)
+                checkboxFlags("ImGuiSliderFlags_AlwaysClamp", ::flags, SliderFlag.AlwaysClamp)
                 sameLine(); helpMarker("Always clamp value to min/max bounds (if any) when input manually with CTRL+Click.")
-                checkboxFlags("ImGuiSliderFlags_Logarithmic", ::flags, SliderFlag.Logarithmic.i)
+                checkboxFlags("ImGuiSliderFlags_Logarithmic", ::flags, SliderFlag.Logarithmic)
                 sameLine(); helpMarker("Enable logarithmic editing (more precision for small values).")
-                checkboxFlags("ImGuiSliderFlags_NoRoundToFormat", ::flags, SliderFlag.NoRoundToFormat.i)
+                checkboxFlags("ImGuiSliderFlags_NoRoundToFormat", ::flags, SliderFlag.NoRoundToFormat)
                 sameLine(); helpMarker("Disable rounding underlying value to match precision of the format string (e.g. %.3f values are rounded to those 3 digits).")
-                checkboxFlags("ImGuiSliderFlags_NoInput", ::flags, SliderFlag.NoInput.i)
+                checkboxFlags("ImGuiSliderFlags_NoInput", ::flags, SliderFlag.NoInput)
                 sameLine(); helpMarker("Disable CTRL+Click or Enter key allowing to input text directly into the widget.")
 
                 // Drags
@@ -1472,7 +1469,7 @@ object ShowDemoWindowWidgets {
         var endI = 1000
         operator fun invoke() {
             treeNode("Range Widgets") {
-                dragFloatRange2("range float", ::begin, ::end, 0.25f, 0f, 100f, "Min: %.1f %%", "Max: %.1f %%", SliderFlag.AlwaysClamp.i)
+                dragFloatRange2("range float", ::begin, ::end, 0.25f, 0f, 100f, "Min: %.1f %%", "Max: %.1f %%", SliderFlag.AlwaysClamp)
                 dragIntRange2("range int", ::beginI, ::endI, 5f, 0, 1000, "Min: %d units", "Max: %d units")
                 dragIntRange2("range int (no bounds)", ::beginI, ::endI, 5f, 0, 0, "Min: %d units", "Max: %d units")
             }
@@ -1588,9 +1585,9 @@ object ShowDemoWindowWidgets {
                 dragScalar("drag s64", DataType.Long, ::s64_v, dragSpeed, ::s64_zero.takeIf { dragClamp }, ::s64_fifty.takeIf { dragClamp })
                 dragScalar("drag u64", DataType.Ulong, ::u64_v, dragSpeed, ::u64_zero.takeIf { dragClamp }, ::u64_fifty.takeIf { dragClamp })
                 dragScalar("drag float", DataType.Float, ::f32_v, 0.005f, ::f32_zero, ::f32_one, "%f")
-                dragScalar("drag float log", DataType.Float, ::f32_v, 0.005f, ::f32_zero, ::f32_one, "%f", SliderFlag.Logarithmic.i)
+                dragScalar("drag float log", DataType.Float, ::f32_v, 0.005f, ::f32_zero, ::f32_one, "%f", SliderFlag.Logarithmic)
                 dragScalar("drag double", DataType.Double, ::f64_v, 0.0005f, ::f64_zero, null, "%.10f grams")
-                dragScalar("drag double log", DataType.Double, ::f64_v, 0.0005f, ::f64_zero, ::f64_one, "0 < %.10f < 1", SliderFlag.Logarithmic.i)
+                dragScalar("drag double log", DataType.Double, ::f64_v, 0.0005f, ::f64_zero, ::f64_one, "0 < %.10f < 1", SliderFlag.Logarithmic)
 
                 text("Sliders")
                 sliderScalar("slider s8 full", DataType.Byte, ::s8_v, ::s8_min, ::s8_max, "%d")
@@ -1611,10 +1608,10 @@ object ShowDemoWindowWidgets {
                 sliderScalar("slider u64 high", DataType.Ulong, ::u64_v, ::u64_hi_a, ::u64_hi_b, "%d ms")
                 sliderScalar("slider u64 full", DataType.Ulong, ::u64_v, ::u64_min, ::u64_max, "%d ms")
                 sliderScalar("slider float low", DataType.Float, ::f32_v, ::f32_zero, ::f32_one)
-                sliderScalar("slider float low log", DataType.Float, ::f32_v, ::f32_zero, ::f32_one, "%.10f", SliderFlag.Logarithmic.i)
+                sliderScalar("slider float low log", DataType.Float, ::f32_v, ::f32_zero, ::f32_one, "%.10f", SliderFlag.Logarithmic)
                 sliderScalar("slider float high", DataType.Float, ::f32_v, ::f32_lo_a, ::f32_hi_a, "%e")
                 sliderScalar("slider double low", DataType.Double, ::f64_v, ::f64_zero, ::f64_one, "%.10f grams")
-                sliderScalar("slider double low log", DataType.Double, ::f64_v, ::f64_zero, ::f64_one, "%.10f", SliderFlag.Logarithmic.i)
+                sliderScalar("slider double low log", DataType.Double, ::f64_v, ::f64_zero, ::f64_one, "%.10f", SliderFlag.Logarithmic)
                 sliderScalar("slider double high", DataType.Double, ::f64_v, ::f64_lo_a, ::f64_hi_a, "%e grams")
 
                 text("Sliders (reverse)")
@@ -1780,7 +1777,7 @@ object ShowDemoWindowWidgets {
                         button(name, Vec2(60))
 
                         // Our buttons are both drag sources and drag targets here!
-                        if (beginDragDropSource(DragDropFlag.None)) {
+                        if (beginDragDropSource()) {
                             // Set payload to carry the index of our item (could be anything)
                             setDragDropPayload("DND_DEMO_CELL", n)
 
@@ -1913,7 +1910,7 @@ object ShowDemoWindowWidgets {
                     endDisabled()
 
                 val buf = ByteArray(1)
-                inputText("unused", buf, Itf.ReadOnly.i)
+                inputText("unused", buf, Itf.ReadOnly)
                 sameLine()
                 helpMarker("This widget is only here to be able to tab-out of the widgets above and see e.g. Deactivated() status.")
             }

--- a/core/src/main/kotlin/imgui/demo/ShowDemoWindowWidgets.kt
+++ b/core/src/main/kotlin/imgui/demo/ShowDemoWindowWidgets.kt
@@ -200,10 +200,11 @@ object ShowDemoWindowWidgets {
     /* Text Input */
     object Funcs2 {
         val MyResizeCallback: InputTextCallback = { data ->
-            if (data.eventFlag eq Itf.CallbackResize) {
+            if (data.eventFlag == Itf.CallbackResize) {
                 val myString = data.userData as ByteArray
                 assert(myString.contentEquals(data.buf))
-                data.userData = ByteArray(data.bufSize)  // NB: On resizing calls, generally data->BufSize == data->BufTextLen + 1
+                // NB: On resizing calls, generally data->BufSize == data->BufTextLen + 1
+                data.userData = ByteArray(data.bufSize)
                 data.buf = myString
             }
             false
@@ -211,7 +212,7 @@ object ShowDemoWindowWidgets {
 
         // Note: Because ImGui:: is a namespace you would typically add your own function into the namespace.
         // For example, you code may declare a function 'ImGui::InputText(const char* label, MyString* my_str)'
-        val MyInputTextMultiline: (label: String, myStr: ByteArray, size: Vec2, flags: InputTextFlags) -> Boolean =
+        val MyInputTextMultiline: (label: String, myStr: ByteArray, size: Vec2, flags: InputTextSingleFlags) -> Boolean =
             { label, myStr, size, flags ->
                 assert(flags hasnt Itf.CallbackResize)
                 inputTextMultiline(label, String(myStr), size, flags or Itf.CallbackResize, MyResizeCallback, myStr)
@@ -727,7 +728,7 @@ object ShowDemoWindowWidgets {
     }
 
     object Combo {
-        var flags: ComboFlags = emptyFlags()
+        var flags: ComboFlags = emptyFlags
         var itemCurrentIdx = 0
         var itemCurrent2 = 0
         var itemCurrent3 = 0
@@ -959,7 +960,7 @@ object ShowDemoWindowWidgets {
         ${'\t'}lock cmpxchg8b eax
         
         """.trimIndent().toByteArray(1024 * 16)
-        var flags: InputTextFlags = Itf.AllowTabInput
+        var flags: InputTextSingleFlags = Itf.AllowTabInput
         val bufs = Array(6) { ByteArray(64) }
 
         object TextFilters {
@@ -973,9 +974,9 @@ object ShowDemoWindowWidgets {
 
         object Funcs1 {
             val myCallback: InputTextCallback = { data: InputTextCallbackData ->
-                when {
-                    data.eventFlag eq Itf.CallbackCompletion -> data.insertChars(data.cursorPos, "..")
-                    data.eventFlag eq Itf.CallbackHistory ->
+                when (data.eventFlag) {
+                    Itf.CallbackCompletion -> data.insertChars(data.cursorPos, "..")
+                    Itf.CallbackHistory ->
                         if (data.eventKey == Key.UpArrow) {
                             data.deleteChars(0, data.bufTextLen)
                             data.insertChars(0, "Pressed Up!")
@@ -985,7 +986,8 @@ object ShowDemoWindowWidgets {
                             data.insertChars(0, "Pressed Down!")
                             data.selectAll()
                         }
-                    data.eventFlag eq Itf.CallbackEdit -> {
+
+                    Itf.CallbackEdit -> {
                         // Toggle casing of first character
                         val c = data.buf[0].c
                         if (c in 'a'..'z' || c in 'A'..'Z')
@@ -1061,7 +1063,7 @@ object ShowDemoWindowWidgets {
                     // than usually reported by a typical string class.
                     if (myStr.isEmpty())
                         myStr = ByteArray(1)
-                    Funcs2.MyInputTextMultiline("##MyStr", myStr, Vec2(-Float.MIN_VALUE, textLineHeight * 16), emptyFlags())
+                    Funcs2.MyInputTextMultiline("##MyStr", myStr, Vec2(-Float.MIN_VALUE, textLineHeight * 16), emptyFlags)
                     text("Data: ${myStr.hashCode()}\nSize: ${myStr.strlen()}\nCapacity: ${myStr.size}")
                 }
             }
@@ -1281,7 +1283,7 @@ object ShowDemoWindowWidgets {
                 checkbox("With Drag and Drop", ::dragAndDrop)
                 checkbox("With Options Menu", ::optionsMenu); sameLine(); helpMarker("Right-click on the individual color widget to show options.")
                 checkbox("With HDR", ::hdr); sameLine(); helpMarker("Currently all this does is to lift the 0..1 limits on dragging widgets.")
-                var miscFlags = if (hdr) Cef.HDR else emptyFlags()
+                var miscFlags = if (hdr) Cef.HDR else emptyFlags
                 if (!dragAndDrop) miscFlags = miscFlags or Cef.NoDragDrop
                 if (alphaHalfPreview) miscFlags = miscFlags or Cef.AlphaPreviewHalf
                 else if (alphaPreview) miscFlags = miscFlags or Cef.AlphaPreview
@@ -1362,7 +1364,7 @@ object ShowDemoWindowWidgets {
                 }
                 text("Color button only:")
                 checkbox("ImGuiColorEditFlags_NoBorder", ::noBorder)
-                colorButton("MyColor##3c", color, miscFlags or if (noBorder) Cef.NoBorder else emptyFlags(), Vec2(80))
+                colorButton("MyColor##3c", color, miscFlags or if (noBorder) Cef.NoBorder else emptyFlags, Vec2(80))
 
                 text("Color picker:")
                 checkbox("With Alpha", ::alpha)
@@ -1429,7 +1431,7 @@ object ShowDemoWindowWidgets {
     }
 
     object `DragSlider Flags` {
-        var flags: SliderFlags = emptyFlags()
+        var flags: SliderFlags = emptyFlags
         var dragF = 0.5f
         var dragI = 50
         var sliderF = 0.5f

--- a/core/src/main/kotlin/imgui/demo/showExampleApp/AutoResize.kt
+++ b/core/src/main/kotlin/imgui/demo/showExampleApp/AutoResize.kt
@@ -14,7 +14,7 @@ object AutoResize {
     /** Demonstrate creating a window which gets auto-resized according to its content. */
     operator fun invoke(open: KMutableProperty0<Boolean>) {
 
-        if (!begin("Example: Auto-resizing window", open, Wf.AlwaysAutoResize.i)) {
+        if (!begin("Example: Auto-resizing window", open, Wf.AlwaysAutoResize)) {
             end()
             return
         }

--- a/core/src/main/kotlin/imgui/demo/showExampleApp/Console.kt
+++ b/core/src/main/kotlin/imgui/demo/showExampleApp/Console.kt
@@ -230,8 +230,8 @@ object Console {
         }
 
         fun inputTextCallback(data: InputTextCallbackData): Boolean {
-            when {
-                data.eventFlag eq Itf.CallbackCompletion -> {
+            when (data.eventFlag) {
+                Itf.CallbackCompletion -> {
                     val wordEnd = data.cursorPos
                     var wordStart = wordEnd
                     while (wordStart > 0) {
@@ -244,8 +244,8 @@ object Console {
                     val candidates = ArrayList<String>()
                     for (c in commands) if (c.startsWith(word)) candidates += c
                     when { // No match
-                        candidates.isEmpty() -> addLog("No match for \"%s\"!\n",
-                            word) // Single match. Delete the beginning of the word and replace it entirely so we've got nice casing.
+                        candidates.isEmpty() -> addLog("No match for \"%s\"!\n", word)
+                        // Single match. Delete the beginning of the word and replace it entirely so we've got nice casing.
                         candidates.size == 1 -> { // Single match. Delete the beginning of the word and replace it entirely so we've got nice casing.
                             data.deleteChars(wordStart, wordEnd)
                             data.insertChars(data.cursorPos, candidates[0])
@@ -277,7 +277,8 @@ object Console {
                         }
                     }
                 }
-                data.eventFlag eq Itf.CallbackHistory -> {
+
+                Itf.CallbackHistory -> {
                     val prevHistoryPos = historyPos
                     if (data.eventKey == Key.UpArrow) {
                         if (historyPos == -1) historyPos = history.size - 1

--- a/core/src/main/kotlin/imgui/demo/showExampleApp/Console.kt
+++ b/core/src/main/kotlin/imgui/demo/showExampleApp/Console.kt
@@ -41,7 +41,6 @@ import imgui.classes.TextFilter
 import imgui.dsl.popupContextItem
 import uno.kotlin.getValue
 import uno.kotlin.setValue
-import java.util.*
 import kotlin.reflect.KMutableProperty0
 import imgui.InputTextFlag as Itf
 import imgui.WindowFlag as Wf
@@ -125,7 +124,7 @@ object Console {
 
             // Reserve enough left-over height for 1 separator + 1 input text
             val footerHeightToReserve = style.itemSpacing.y + frameHeightWithSpacing
-            if(beginChild("ScrollingRegion", Vec2(0, -footerHeightToReserve), false, Wf.HorizontalScrollbar.i)) {
+            if (beginChild("ScrollingRegion", Vec2(0, -footerHeightToReserve), false, Wf.HorizontalScrollbar)) {
                 if (beginPopupContextWindow()) {
                     if (selectable("Clear")) clearLog()
                     endPopup()
@@ -231,8 +230,8 @@ object Console {
         }
 
         fun inputTextCallback(data: InputTextCallbackData): Boolean {
-            when (data.eventFlag) {
-                imgui.InputTextFlag.CallbackCompletion.i -> {
+            when {
+                data.eventFlag eq Itf.CallbackCompletion -> {
                     val wordEnd = data.cursorPos
                     var wordStart = wordEnd
                     while (wordStart > 0) {
@@ -278,7 +277,7 @@ object Console {
                         }
                     }
                 }
-                Itf.CallbackHistory.i -> {
+                data.eventFlag eq Itf.CallbackHistory -> {
                     val prevHistoryPos = historyPos
                     if (data.eventKey == Key.UpArrow) {
                         if (historyPos == -1) historyPos = history.size - 1

--- a/core/src/main/kotlin/imgui/demo/showExampleApp/ConstrainedResize.kt
+++ b/core/src/main/kotlin/imgui/demo/showExampleApp/ConstrainedResize.kt
@@ -90,8 +90,8 @@ object ConstrainedResize {
         // Submit window
         if (!windowPadding)
             pushStyleVar(StyleVar.WindowPadding, Vec2())
-        val windowFlags = if (autoResize) WindowFlag.AlwaysAutoResize else WindowFlag.None
-        val windowOpen = begin("Example: Constrained Resize", pOpen, windowFlags.i)
+        val windowFlags = if (autoResize) WindowFlag.AlwaysAutoResize else emptyFlags()
+        val windowOpen = begin("Example: Constrained Resize", pOpen, windowFlags)
         if (!windowPadding)
             popStyleVar()
         if (windowOpen) {

--- a/core/src/main/kotlin/imgui/demo/showExampleApp/ConstrainedResize.kt
+++ b/core/src/main/kotlin/imgui/demo/showExampleApp/ConstrainedResize.kt
@@ -90,7 +90,7 @@ object ConstrainedResize {
         // Submit window
         if (!windowPadding)
             pushStyleVar(StyleVar.WindowPadding, Vec2())
-        val windowFlags = if (autoResize) WindowFlag.AlwaysAutoResize else emptyFlags()
+        val windowFlags = if (autoResize) WindowFlag.AlwaysAutoResize else emptyFlags
         val windowOpen = begin("Example: Constrained Resize", pOpen, windowFlags)
         if (!windowPadding)
             popStyleVar()

--- a/core/src/main/kotlin/imgui/demo/showExampleApp/CustomRendering.kt
+++ b/core/src/main/kotlin/imgui/demo/showExampleApp/CustomRendering.kt
@@ -23,7 +23,6 @@ import imgui.ImGui.getColorU32
 import imgui.ImGui.getMouseDragDelta
 import imgui.ImGui.invisibleButton
 import imgui.ImGui.io
-import imgui.ImGui.isMouseReleased
 import imgui.ImGui.openPopupOnItemClick
 import imgui.ImGui.popItemWidth
 import imgui.ImGui.pushItemWidth
@@ -129,8 +128,8 @@ object CustomRendering {
                     drawList.apply {
                         addNgon(Vec2(x + sz * 0.5f, y + sz * 0.5f), sz * 0.5f, col, ngonSides, th); x += sz + spacing  // N-gon
                         addCircle(Vec2(x + sz * 0.5f, y + sz * 0.5f), sz * 0.5f, col, circleSegments, th); x += sz + spacing  // Circle
-                        addRect(Vec2(x, y), Vec2(x + sz, y + sz), col, 0f, DrawFlag.None.i, th); x += sz + spacing  // Square
-                        addRect(Vec2(x, y), Vec2(x + sz, y + sz), col, rounding, DrawFlag.None.i, th); x += sz + spacing  // Square with all rounded corners
+                        addRect(Vec2(x, y), Vec2(x + sz, y + sz), col, 0f, thickness = th); x += sz + spacing  // Square
+                        addRect(Vec2(x, y), Vec2(x + sz, y + sz), col, rounding, thickness = th); x += sz + spacing  // Square with all rounded corners
                         addRect(Vec2(x, y), Vec2(x + sz, y + sz), col, rounding, cornersTlBr, th); x += sz + spacing  // Square with two rounded corners
                         addTriangle(Vec2(x + sz * 0.5f, y), Vec2(x + sz, y + sz - 0.5f), Vec2(x, y + sz - 0.5f), col, th); x += sz + spacing      // Triangle
 //                        addTriangle(Vec2(x + sz * 0.2f, y), Vec2(x, y + sz - 0.5f), Vec2(x + sz * 0.4f, y + sz - 0.5f), col, th); x += sz * 0.4f + spacing // Thin triangle
@@ -225,7 +224,7 @@ object CustomRendering {
                 // Context menu (under default mouse threshold)
                 val dragDelta = getMouseDragDelta(MouseButton.Right)
                 if (optEnableContextMenu && dragDelta.x == 0f && dragDelta.y == 0f) // TODO glm
-                    openPopupOnItemClick("context", PopupFlag.MouseButtonRight.i)
+                    openPopupOnItemClick("context", PopupFlag.MouseButtonRight)
                 dsl.popup("context") {
                     if (addingLine) {
                         points.pop()

--- a/core/src/main/kotlin/imgui/demo/showExampleApp/Documents.kt
+++ b/core/src/main/kotlin/imgui/demo/showExampleApp/Documents.kt
@@ -197,7 +197,7 @@ object Documents {
 
         // Submit Tab Bar and Tabs
         run {
-            val tabBarFlags: TabBarFlags = optFittingFlags or if (optReorderable) TabBarFlag.Reorderable else emptyFlags()
+            val tabBarFlags: TabBarFlags = optFittingFlags or if (optReorderable) TabBarFlag.Reorderable else emptyFlags
             if (beginTabBar("##tabs", tabBarFlags)) {
                 if (optReorderable)
                     notifyOfDocumentsClosedElsewhere()
@@ -211,7 +211,7 @@ object Documents {
 
                     if (!doc.open) continue
 
-                    val tabFlags: TabItemFlags = if (doc.dirty) TabItemFlag.UnsavedDocument else emptyFlags()
+                    val tabFlags: TabItemOnlyFlags = if (doc.dirty) TabItemFlag.UnsavedDocument else emptyFlags
                     val visible = beginTabItem(doc.name, doc::open, tabFlags)
 
                     // Cancel attempt to close when unsaved add to save queue so we can display a popup.

--- a/core/src/main/kotlin/imgui/demo/showExampleApp/Documents.kt
+++ b/core/src/main/kotlin/imgui/demo/showExampleApp/Documents.kt
@@ -135,13 +135,13 @@ object Documents {
 
     // Options
     var optReorderable = true
-    var optFittingFlags: TabBarFlags = TabBarFlag.FittingPolicyDefault_.i
+    var optFittingFlags: TabBarFlags = TabBarFlag.FittingPolicyDefault
 
     val closeQueue = ArrayList<MyDocument>()
 
     operator fun invoke(pOpen: KMutableProperty0<Boolean>?) {
 
-        val windowContentsVisible = begin("Example: Documents", pOpen, WindowFlag.MenuBar.i)
+        val windowContentsVisible = begin("Example: Documents", pOpen, WindowFlag.MenuBar)
         if (!windowContentsVisible) {
             end()
             return
@@ -197,7 +197,7 @@ object Documents {
 
         // Submit Tab Bar and Tabs
         run {
-            val tabBarFlags: TabBarFlags = optFittingFlags or if (optReorderable) TabBarFlag.Reorderable else TabBarFlag.None
+            val tabBarFlags: TabBarFlags = optFittingFlags or if (optReorderable) TabBarFlag.Reorderable else emptyFlags()
             if (beginTabBar("##tabs", tabBarFlags)) {
                 if (optReorderable)
                     notifyOfDocumentsClosedElsewhere()
@@ -211,7 +211,7 @@ object Documents {
 
                     if (!doc.open) continue
 
-                    val tabFlags: TabItemFlags = if (doc.dirty) TabItemFlag.UnsavedDocument.i else TabItemFlag.None.i
+                    val tabFlags: TabItemFlags = if (doc.dirty) TabItemFlag.UnsavedDocument else emptyFlags()
                     val visible = beginTabItem(doc.name, doc::open, tabFlags)
 
                     // Cancel attempt to close when unsaved add to save queue so we can display a popup.
@@ -252,7 +252,7 @@ object Documents {
 
                 if (!isPopupOpen("Save?"))
                     openPopup("Save?")
-                if (beginPopupModal("Save?", null, WindowFlag.AlwaysAutoResize.i)) {
+                if (beginPopupModal("Save?", null, WindowFlag.AlwaysAutoResize)) {
                     text("Save change to the following items?")
                     val itemHeight = textLineHeightWithSpacing
                     if (beginChildFrame(getID("frame"), Vec2(-Float.MIN_VALUE, 6.25f * itemHeight))) {

--- a/core/src/main/kotlin/imgui/demo/showExampleApp/Fullscreen.kt
+++ b/core/src/main/kotlin/imgui/demo/showExampleApp/Fullscreen.kt
@@ -10,6 +10,7 @@ import imgui.ImGui.setNextWindowSize
 import imgui.api.demoDebugInformations.Companion.helpMarker
 import imgui.dsl.indent
 import imgui.dsl.window
+import imgui.or
 import kotlin.reflect.KMutableProperty0
 import imgui.WindowFlag as Wf
 

--- a/core/src/main/kotlin/imgui/demo/showExampleApp/Fullscreen.kt
+++ b/core/src/main/kotlin/imgui/demo/showExampleApp/Fullscreen.kt
@@ -1,10 +1,8 @@
 package imgui.demo.showExampleApp
 
-import glm_.vec2.Vec2
 import imgui.ImGui.button
 import imgui.ImGui.checkbox
 import imgui.ImGui.checkboxFlags
-import imgui.ImGui.io
 import imgui.ImGui.mainViewport
 import imgui.ImGui.sameLine
 import imgui.ImGui.setNextWindowPos
@@ -12,7 +10,6 @@ import imgui.ImGui.setNextWindowSize
 import imgui.api.demoDebugInformations.Companion.helpMarker
 import imgui.dsl.indent
 import imgui.dsl.window
-import imgui.or
 import kotlin.reflect.KMutableProperty0
 import imgui.WindowFlag as Wf
 
@@ -39,12 +36,12 @@ object Fullscreen {
             sameLine()
             helpMarker("Main Area = entire viewport,\nWork Area = entire viewport minus sections used by the main menu bars, task bars etc.\n\nEnable the main-menu bar in Examples menu to see the difference.")
 
-            checkboxFlags("ImGuiWindowFlags_NoBackground", ::flags, Wf.NoBackground.i)
-            checkboxFlags("ImGuiWindowFlags_NoDecoration", ::flags, Wf.NoDecoration.i)
+            checkboxFlags("ImGuiWindowFlags_NoBackground", ::flags, Wf.NoBackground)
+            checkboxFlags("ImGuiWindowFlags_NoDecoration", ::flags, Wf.NoDecoration)
             indent {
-                checkboxFlags("ImGuiWindowFlags_NoTitleBar", ::flags, Wf.NoTitleBar.i)
-                checkboxFlags("ImGuiWindowFlags_NoCollapse", ::flags, Wf.NoCollapse.i)
-                checkboxFlags("ImGuiWindowFlags_NoScrollbar", ::flags, Wf.NoScrollbar.i)
+                checkboxFlags("ImGuiWindowFlags_NoTitleBar", ::flags, Wf.NoTitleBar)
+                checkboxFlags("ImGuiWindowFlags_NoCollapse", ::flags, Wf.NoCollapse)
+                checkboxFlags("ImGuiWindowFlags_NoScrollbar", ::flags, Wf.NoScrollbar)
             }
 
             if (pOpen != null && button("Close this window"))

--- a/core/src/main/kotlin/imgui/demo/showExampleApp/Layout.kt
+++ b/core/src/main/kotlin/imgui/demo/showExampleApp/Layout.kt
@@ -17,7 +17,6 @@ import imgui.ImGui.separator
 import imgui.ImGui.setNextWindowSize
 import imgui.ImGui.text
 import imgui.ImGui.textWrapped
-import imgui.TabBarFlag
 import imgui.dsl.button
 import imgui.dsl.child
 import imgui.dsl.group
@@ -39,7 +38,7 @@ object Layout {
         var open by pOpen
 
         setNextWindowSize(Vec2(500, 440), Cond.FirstUseEver)
-        if (begin("Example: Simple layout", pOpen, Wf.MenuBar.i)) {
+        if (begin("Example: Simple layout", pOpen, Wf.MenuBar)) {
             menuBar {
                 menu("File") {
                     menuItem("Close", "Ctrl+W") { open = false }
@@ -62,7 +61,7 @@ object Layout {
                 beginChild("item view", Vec2(0, -frameHeightWithSpacing)) // Leave room for 1 line below us
                 text("MyObject: $selected")
                 separator()
-                if (beginTabBar("##Tabs", TabBarFlag.None.i)) {
+                if (beginTabBar("##Tabs")) {
                     if (beginTabItem("Description")) {
                         textWrapped("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ")
                         endTabItem()

--- a/core/src/main/kotlin/imgui/demo/showExampleApp/Log.kt
+++ b/core/src/main/kotlin/imgui/demo/showExampleApp/Log.kt
@@ -27,7 +27,6 @@ import imgui.api.g
 import imgui.classes.ListClipper
 import imgui.classes.TextFilter
 import java.util.*
-import kotlin.collections.ArrayList
 import kotlin.math.abs
 import kotlin.reflect.KMutableProperty0
 import imgui.WindowFlag as Wf
@@ -116,7 +115,7 @@ object Log {
             filter.draw("Filter", -100f)
 
             separator()
-            if(beginChild("scrolling", Vec2(0, 0), false, Wf.HorizontalScrollbar.i)) {
+            if (beginChild("scrolling", Vec2(0, 0), false, Wf.HorizontalScrollbar)) {
                 if (clear) clear()
                 if (copy) logToClipboard()
 

--- a/core/src/main/kotlin/imgui/demo/showExampleApp/StyleEditor.kt
+++ b/core/src/main/kotlin/imgui/demo/showExampleApp/StyleEditor.kt
@@ -85,7 +85,7 @@ object StyleEditor {
 
     var outputDest = 0
     var outputOnlyModified = true
-    var alphaFlags: ColorEditFlags = 0
+    var alphaFlags: ColorEditFlags = emptyFlags()
     val filter = TextFilter()
     var windowScale = 1f
 
@@ -135,7 +135,7 @@ object StyleEditor {
 
         separator()
 
-        if (beginTabBar("##tabs", TabBarFlag.None.i)) {
+        if (beginTabBar("##tabs")) {
 
             if (beginTabItem("Sizes")) {
                 text("Main")
@@ -211,18 +211,21 @@ object StyleEditor {
 
                 filter.draw("Filter colors", fontSize * 16)
 
-                radioButton("Opaque", alphaFlags == Cef.None.i) { alphaFlags = Cef.None.i }; sameLine()
-                radioButton("Alpha", alphaFlags == Cef.AlphaPreview.i) { alphaFlags = Cef.AlphaPreview.i }; sameLine()
-                radioButton("Both", alphaFlags == Cef.AlphaPreviewHalf.i) {
-                    alphaFlags = Cef.AlphaPreviewHalf.i
+                radioButton("Opaque", alphaFlags.isEmpty) { alphaFlags = emptyFlags() }; sameLine()
+                radioButton("Alpha", alphaFlags eq Cef.AlphaPreview) { alphaFlags = Cef.AlphaPreview }; sameLine()
+                radioButton("Both", alphaFlags eq Cef.AlphaPreviewHalf) {
+                    alphaFlags = Cef.AlphaPreviewHalf
                 }; sameLine()
                 helpMarker("""
                     In the color list:
                     Left-click on color square to open color picker,
-                    Right-click to open edit options menu.""".trimIndent())
+                    Right-click to open edit options menu.""".trimIndent()
+                )
 
-                child("#colors", Vec2(), true,
-                      Wf.AlwaysVerticalScrollbar or Wf.AlwaysHorizontalScrollbar or Wf._NavFlattened) {
+                child(
+                    "#colors", Vec2(), true,
+                    Wf.AlwaysVerticalScrollbar or Wf.AlwaysHorizontalScrollbar or Wf._NavFlattened
+                ) {
                     withItemWidth(-160) {
                         for (i in 0 until Col.COUNT) {
                             val name = Col.values()[i].name
@@ -259,11 +262,12 @@ object StyleEditor {
                 helpMarker("""
                     Those are old settings provided for convenience.
                     However, the _correct_ way of scaling your UI is currently to reload your font at the designed size, rebuild the font atlas, and call style.ScaleAllSizes() on a reference ImGuiStyle structure.
-                    Using those settings here will give you poor quality results.""".trimIndent())
+                    Using those settings here will give you poor quality results.""".trimIndent()
+                )
                 pushItemWidth(fontSize * 8)
-                if (dragFloat("window scale", ::windowScale, 0.005f, MIN_SCALE, MAX_SCALE, "%.2f", SliderFlag.AlwaysClamp.i)) // Scale only this window
+                if (dragFloat("window scale", ::windowScale, 0.005f, MIN_SCALE, MAX_SCALE, "%.2f", SliderFlag.AlwaysClamp)) // Scale only this window
                     setWindowFontScale(windowScale)
-                dragFloat("global scale", io::fontGlobalScale, 0.005f, MIN_SCALE, MAX_SCALE, "%.2f", SliderFlag.AlwaysClamp.i) // Scale everything
+                dragFloat("global scale", io::fontGlobalScale, 0.005f, MIN_SCALE, MAX_SCALE, "%.2f", SliderFlag.AlwaysClamp) // Scale everything
                 popItemWidth()
 
                 endTabItem()
@@ -284,7 +288,7 @@ object StyleEditor {
                 if (style.curveTessellationTol < 10f) style.curveTessellationTol = 0.1f
 
                 // When editing the "Circle Segment Max Error" value, draw a preview of its effect on auto-tessellated circles.
-                dragFloat("Circle Tessellation Max Error", style::circleTessellationMaxError, 0.005f, 0.1f, 5f, "%.2f", SliderFlag.AlwaysClamp.i)
+                dragFloat("Circle Tessellation Max Error", style::circleTessellationMaxError, 0.005f, 0.1f, 5f, "%.2f", SliderFlag.AlwaysClamp)
                 if (ImGui.isItemActive) {
                     setNextWindowPos(ImGui.cursorScreenPos)
                     tooltip {

--- a/core/src/main/kotlin/imgui/demo/showExampleApp/StyleEditor.kt
+++ b/core/src/main/kotlin/imgui/demo/showExampleApp/StyleEditor.kt
@@ -85,7 +85,7 @@ object StyleEditor {
 
     var outputDest = 0
     var outputOnlyModified = true
-    var alphaFlags: ColorEditFlags = emptyFlags()
+    var alphaFlags: ColorEditFlags = emptyFlags
     val filter = TextFilter()
     var windowScale = 1f
 
@@ -168,7 +168,7 @@ object StyleEditor {
                 run {
                     _i32 = style.windowMenuButtonPosition.i + 1
                     if (combo("WindowMenuButtonPosition", ::_i32,
-                              "None${NUL}Left${NUL}Right${NUL}")
+                            "None${NUL}Left${NUL}Right${NUL}")
                     ) style.windowMenuButtonPosition = Dir.values().first { it.i == _i32 - 1 }
                 }
                 run {
@@ -211,9 +211,9 @@ object StyleEditor {
 
                 filter.draw("Filter colors", fontSize * 16)
 
-                radioButton("Opaque", alphaFlags.isEmpty) { alphaFlags = emptyFlags() }; sameLine()
-                radioButton("Alpha", alphaFlags eq Cef.AlphaPreview) { alphaFlags = Cef.AlphaPreview }; sameLine()
-                radioButton("Both", alphaFlags eq Cef.AlphaPreviewHalf) {
+                radioButton("Opaque", alphaFlags.isEmpty) { alphaFlags = emptyFlags }; sameLine()
+                radioButton("Alpha", alphaFlags == Cef.AlphaPreview) { alphaFlags = Cef.AlphaPreview }; sameLine()
+                radioButton("Both", alphaFlags == Cef.AlphaPreviewHalf) {
                     alphaFlags = Cef.AlphaPreviewHalf
                 }; sameLine()
                 helpMarker("""
@@ -343,8 +343,8 @@ object StyleEditor {
     fun debugNodeFont(font: Font) {
         val name = font.configData.getOrNull(0)?.name ?: ""
         val fontDetailsOpened = treeNode(font,
-                                         "Font \\\"$name\\\"\\n%.2f px, %.2f px, ${font.glyphs.size} glyphs, ${font.configDataCount} file(s)",
-                                         font.fontSize)
+            "Font \\\"$name\\\"\\n%.2f px, %.2f px, ${font.glyphs.size} glyphs, ${font.configDataCount} file(s)",
+            font.fontSize)
         sameLine(); smallButton("Set as default") { io.fontDefault = font }
         if (!fontDetailsOpened)
             return
@@ -401,11 +401,11 @@ object StyleEditor {
                     val drawList = windowDrawList
                     for (n in 0 until 256) {
                         val cellP1 = Vec2(basePos.x + (n % 16) * (cellSize + cellSpacing),
-                                          basePos.y + (n / 16) * (cellSize + cellSpacing))
+                            basePos.y + (n / 16) * (cellSize + cellSpacing))
                         val cellP2 = Vec2(cellP1.x + cellSize, cellP1.y + cellSize)
                         val glyph = font.findGlyphNoFallback((base + n).c)
                         drawList.addRect(cellP1, cellP2, COL32(255, 255, 255,
-                                                               if (glyph != null) 100 else 50)) // We use ImFont::RenderChar as a shortcut because we don't have UTF-8 conversion functions
+                            if (glyph != null) 100 else 50)) // We use ImFont::RenderChar as a shortcut because we don't have UTF-8 conversion functions
                         // available here and thus cannot easily generate a zero-terminated UTF-8 encoded string.
                         if (glyph != null) {
                             font.renderChar(drawList, cellSize, cellP1, Col.Text.u32, (base + n).c)

--- a/core/src/main/kotlin/imgui/dsl.kt
+++ b/core/src/main/kotlin/imgui/dsl.kt
@@ -86,8 +86,8 @@ object dsl {
     // Tables
 
     inline fun table(
-        strId: String, columns: Int, flags: TableFlags = emptyFlags(),
-        outerSize: Vec2 = Vec2(), innerWidth: Float = 0f, block: () -> Unit
+            strId: String, columns: Int, flags: TableFlags = emptyFlags,
+            outerSize: Vec2 = Vec2(), innerWidth: Float = 0f, block: () -> Unit
     ) {
         if (beginTable(strId, columns, flags, outerSize, innerWidth)) { // ~open
             block()
@@ -97,7 +97,7 @@ object dsl {
 
     // Windows
 
-    inline fun window(name: String, open: KMutableProperty0<Boolean>? = null, flags: WindowFlags = emptyFlags(), block: () -> Unit) {
+    inline fun window(name: String, open: KMutableProperty0<Boolean>? = null, flags: WindowFlags = emptyFlags, block: () -> Unit) {
         if (begin(name, open, flags)) // ~open
             block()
         end()
@@ -105,7 +105,7 @@ object dsl {
 
     // Child Windows
 
-    inline fun child(strId: String, size: Vec2 = Vec2(), border: Boolean = false, extraFlags: WindowFlags = emptyFlags(), block: () -> Unit) {
+    inline fun child(strId: String, size: Vec2 = Vec2(), border: Boolean = false, extraFlags: WindowFlags = emptyFlags, block: () -> Unit) {
         if (beginChild(strId, size, border, extraFlags)) // ~open
             block()
         endChild()
@@ -299,7 +299,7 @@ object dsl {
     // Widgets: Combo Box
 
 
-    inline fun useCombo(label: String, previewValue: String?, flags: ComboFlags = emptyFlags(), block: () -> Unit) {
+    inline fun useCombo(label: String, previewValue: String?, flags: ComboFlags = emptyFlags, block: () -> Unit) {
         if (beginCombo(label, previewValue, flags)) {
             block()
             endCombo()
@@ -336,7 +336,7 @@ object dsl {
         }
     }
 
-    inline fun treeNodeEx(strID: String, flags: TreeNodeFlags = emptyFlags(), block: () -> Unit) {
+    inline fun treeNodeEx(strID: String, flags: TreeNodeFlags = emptyFlags, block: () -> Unit) {
         if (treeNodeEx(strID, flags)) {
             block()
             treePop()
@@ -369,12 +369,12 @@ object dsl {
     //        try { block() } finally { treePop() }
     //    }
 
-    inline fun collapsingHeader(label: String, flags: TreeNodeFlags = emptyFlags(), block: () -> Unit) {
+    inline fun collapsingHeader(label: String, flags: TreeNodeFlags = emptyFlags, block: () -> Unit) {
         if (collapsingHeader(label, flags))
             block()
     }
 
-    inline fun collapsingHeader(label: String, open: KMutableProperty0<Boolean>, flags: TreeNodeFlags = emptyFlags(), block: () -> Unit) {
+    inline fun collapsingHeader(label: String, open: KMutableProperty0<Boolean>, flags: TreeNodeFlags = emptyFlags, block: () -> Unit) {
         if (collapsingHeader(label, open, flags))
             block()
     }
@@ -382,7 +382,7 @@ object dsl {
 
     // Widgets: Selectables
 
-    inline fun selectable(label: String, selected: Boolean = false, flags: SelectableFlags = emptyFlags(), sizeArg: Vec2 = Vec2(), block: () -> Unit) {
+    inline fun selectable(label: String, selected: Boolean = false, flags: SelectableFlags = emptyFlags, sizeArg: Vec2 = Vec2(), block: () -> Unit) {
         if (selectable(label, selected, flags, sizeArg))
             block()
     }
@@ -428,7 +428,7 @@ object dsl {
 
     // Popups, Modals
 
-    inline fun popup(strId: String, flags: WindowFlags = emptyFlags(), block: () -> Unit) {
+    inline fun popup(strId: String, flags: WindowFlags = emptyFlags, block: () -> Unit) {
         if (beginPopup(strId, flags)) {
             block()
             endPopup()
@@ -456,7 +456,7 @@ object dsl {
         }
     }
 
-    inline fun popupModal(name: String, pOpen: KMutableProperty0<Boolean>? = null, extraFlags: WindowFlags = emptyFlags(), block: () -> Unit) {
+    inline fun popupModal(name: String, pOpen: KMutableProperty0<Boolean>? = null, extraFlags: WindowFlags = emptyFlags, block: () -> Unit) {
         if (beginPopupModal(name, pOpen, extraFlags)) {
             block()
             endPopup()
@@ -466,21 +466,21 @@ object dsl {
 
     // Tab Bars, Tabs
 
-    inline fun tabBar(strId: String, flags: TabBarFlags = emptyFlags(), block: () -> Unit) {
+    inline fun tabBar(strId: String, flags: TabBarFlags = emptyFlags, block: () -> Unit) {
         if (beginTabBar(strId, flags)) {
             block()
             endTabBar()
         }
     }
 
-    inline fun tabItem(label: String, pOpen: KMutableProperty0<Boolean>? = null, flags: TabItemFlags = emptyFlags(), block: () -> Unit) {
+    inline fun tabItem(label: String, pOpen: KMutableProperty0<Boolean>? = null, flags: TabItemOnlyFlags = emptyFlags, block: () -> Unit) {
         if (beginTabItem(label, pOpen, flags)) {
             block()
             endTabItem()
         }
     }
 
-    inline fun tabItem(label: String, pOpen: BooleanArray, ptr: Int, flags: TabItemFlags = emptyFlags(), block: () -> Unit) {
+    inline fun tabItem(label: String, pOpen: BooleanArray, ptr: Int, flags: TabItemOnlyFlags = emptyFlags, block: () -> Unit) {
         if (beginTabItem(label, pOpen, ptr, flags)) {
             block()
             endTabItem()
@@ -490,7 +490,7 @@ object dsl {
 
     // Drag and Drop
 
-    inline fun dragDropSource(flags: DragDropFlags = emptyFlags(), block: () -> Unit) {
+    inline fun dragDropSource(flags: DragDropFlags = emptyFlags, block: () -> Unit) {
         if (beginDragDropSource(flags)) {
             block()
             endDragDropSource()
@@ -516,7 +516,7 @@ object dsl {
 
     // Miscellaneous Utilities
 
-    inline fun childFrame(id: ID, size: Vec2, extraFlags: WindowFlags = emptyFlags(), block: () -> Unit) {
+    inline fun childFrame(id: ID, size: Vec2, extraFlags: WindowFlags = emptyFlags, block: () -> Unit) {
         beginChildFrame(id, size, extraFlags)
         block()
         endChildFrame()
@@ -524,7 +524,7 @@ object dsl {
 
     // Columns
 
-    inline fun columns(strId: String = "", columnsCount: Int, flags: OldColumnsFlags = emptyFlags(), block: () -> Unit) {
+    inline fun columns(strId: String = "", columnsCount: Int, flags: OldColumnsFlags = emptyFlags, block: () -> Unit) {
         beginColumns(strId, columnsCount, flags)
         block()
         endColumns()

--- a/core/src/main/kotlin/imgui/dsl.kt
+++ b/core/src/main/kotlin/imgui/dsl.kt
@@ -12,6 +12,7 @@ import imgui.ImGui.beginCombo
 import imgui.ImGui.beginDragDropSource
 import imgui.ImGui.beginDragDropTarget
 import imgui.ImGui.beginGroup
+import imgui.ImGui.beginListBox
 import imgui.ImGui.beginMainMenuBar
 import imgui.ImGui.beginMenu
 import imgui.ImGui.beginMenuBar
@@ -37,6 +38,7 @@ import imgui.ImGui.endCombo
 import imgui.ImGui.endDragDropSource
 import imgui.ImGui.endDragDropTarget
 import imgui.ImGui.endGroup
+import imgui.ImGui.endListBox
 import imgui.ImGui.endMainMenuBar
 import imgui.ImGui.endMenu
 import imgui.ImGui.endMenuBar
@@ -48,8 +50,6 @@ import imgui.ImGui.endTooltip
 import imgui.ImGui.imageButton
 import imgui.ImGui.indent
 import imgui.ImGui.invisibleButton
-import imgui.ImGui.endListBox
-import imgui.ImGui.beginListBox
 import imgui.ImGui.menuItem
 import imgui.ImGui.popAllowKeyboardFocus
 import imgui.ImGui.popButtonRepeat
@@ -77,7 +77,6 @@ import imgui.ImGui.treeNodeEx
 import imgui.ImGui.treePop
 import imgui.ImGui.unindent
 import imgui.font.Font
-import imgui.internal.sections.OldColumnsFlag
 import imgui.internal.sections.OldColumnsFlags
 import kotlin.reflect.KMutableProperty0
 
@@ -86,8 +85,10 @@ object dsl {
 
     // Tables
 
-    inline fun table(strId: String, columns: Int, flags: TableFlags = TableFlag.None.i,
-                     outerSize: Vec2 = Vec2(), innerWidth: Float = 0f, block: () -> Unit) {
+    inline fun table(
+        strId: String, columns: Int, flags: TableFlags = emptyFlags(),
+        outerSize: Vec2 = Vec2(), innerWidth: Float = 0f, block: () -> Unit
+    ) {
         if (beginTable(strId, columns, flags, outerSize, innerWidth)) { // ~open
             block()
             endTable()
@@ -96,7 +97,7 @@ object dsl {
 
     // Windows
 
-    inline fun window(name: String, open: KMutableProperty0<Boolean>? = null, flags: WindowFlags = 0, block: () -> Unit) {
+    inline fun window(name: String, open: KMutableProperty0<Boolean>? = null, flags: WindowFlags = emptyFlags(), block: () -> Unit) {
         if (begin(name, open, flags)) // ~open
             block()
         end()
@@ -104,7 +105,7 @@ object dsl {
 
     // Child Windows
 
-    inline fun child(strId: String, size: Vec2 = Vec2(), border: Boolean = false, extraFlags: WindowFlags = 0, block: () -> Unit) {
+    inline fun child(strId: String, size: Vec2 = Vec2(), border: Boolean = false, extraFlags: WindowFlags = emptyFlags(), block: () -> Unit) {
         if (beginChild(strId, size, border, extraFlags)) // ~open
             block()
         endChild()
@@ -279,7 +280,7 @@ object dsl {
             block()
     }
 
-    inline fun checkboxFlags(label: String, vPtr: KMutableProperty0<Int>, flagsValue: Int, block: () -> Unit) {
+    inline fun <F : Flag<F>> checkboxFlags(label: String, vPtr: KMutableProperty0<Flag<F>>, flagsValue: Flag<F>, block: () -> Unit) {
         if (checkboxFlags(label, vPtr, flagsValue))
             block()
     }
@@ -298,7 +299,7 @@ object dsl {
     // Widgets: Combo Box
 
 
-    inline fun useCombo(label: String, previewValue: String?, flags: ComboFlags = 0, block: () -> Unit) {
+    inline fun useCombo(label: String, previewValue: String?, flags: ComboFlags = emptyFlags(), block: () -> Unit) {
         if (beginCombo(label, previewValue, flags)) {
             block()
             endCombo()
@@ -335,7 +336,7 @@ object dsl {
         }
     }
 
-    inline fun treeNodeEx(strID: String, flags: TreeNodeFlags = 0, block: () -> Unit) {
+    inline fun treeNodeEx(strID: String, flags: TreeNodeFlags = emptyFlags(), block: () -> Unit) {
         if (treeNodeEx(strID, flags)) {
             block()
             treePop()
@@ -368,12 +369,12 @@ object dsl {
     //        try { block() } finally { treePop() }
     //    }
 
-    inline fun collapsingHeader(label: String, flags: TreeNodeFlags = 0, block: () -> Unit) {
+    inline fun collapsingHeader(label: String, flags: TreeNodeFlags = emptyFlags(), block: () -> Unit) {
         if (collapsingHeader(label, flags))
             block()
     }
 
-    inline fun collapsingHeader(label: String, open: KMutableProperty0<Boolean>, flags: TreeNodeFlags = 0, block: () -> Unit) {
+    inline fun collapsingHeader(label: String, open: KMutableProperty0<Boolean>, flags: TreeNodeFlags = emptyFlags(), block: () -> Unit) {
         if (collapsingHeader(label, open, flags))
             block()
     }
@@ -381,7 +382,7 @@ object dsl {
 
     // Widgets: Selectables
 
-    inline fun selectable(label: String, selected: Boolean = false, flags: Int = 0, sizeArg: Vec2 = Vec2(), block: () -> Unit) {
+    inline fun selectable(label: String, selected: Boolean = false, flags: SelectableFlags = emptyFlags(), sizeArg: Vec2 = Vec2(), block: () -> Unit) {
         if (selectable(label, selected, flags, sizeArg))
             block()
     }
@@ -427,35 +428,35 @@ object dsl {
 
     // Popups, Modals
 
-    inline fun popup(strId: String, flags: WindowFlags = 0, block: () -> Unit) {
+    inline fun popup(strId: String, flags: WindowFlags = emptyFlags(), block: () -> Unit) {
         if (beginPopup(strId, flags)) {
             block()
             endPopup()
         }
     }
 
-    inline fun popupContextItem(strId: String = "", popupFlags: PopupFlags = PopupFlag.MouseButtonRight.i, block: () -> Unit) {
+    inline fun popupContextItem(strId: String = "", popupFlags: PopupFlags = PopupFlag.MouseButtonRight, block: () -> Unit) {
         if (beginPopupContextItem(strId, popupFlags)) {
             block()
             endPopup()
         }
     }
 
-    inline fun popupContextWindow(strId: String = "", popupFlags: PopupFlags = PopupFlag.MouseButtonRight.i, block: () -> Unit) {
+    inline fun popupContextWindow(strId: String = "", popupFlags: PopupFlags = PopupFlag.MouseButtonRight, block: () -> Unit) {
         if (beginPopupContextWindow(strId, popupFlags)) {
             block()
             endPopup()
         }
     }
 
-    inline fun popupContextVoid(strId: String = "", popupFlags: PopupFlags = PopupFlag.MouseButtonRight.i, block: () -> Unit) {
+    inline fun popupContextVoid(strId: String = "", popupFlags: PopupFlags = PopupFlag.MouseButtonRight, block: () -> Unit) {
         if (beginPopupContextVoid(strId, popupFlags)) {
             block()
             endPopup()
         }
     }
 
-    inline fun popupModal(name: String, pOpen: KMutableProperty0<Boolean>? = null, extraFlags: WindowFlags = 0, block: () -> Unit) {
+    inline fun popupModal(name: String, pOpen: KMutableProperty0<Boolean>? = null, extraFlags: WindowFlags = emptyFlags(), block: () -> Unit) {
         if (beginPopupModal(name, pOpen, extraFlags)) {
             block()
             endPopup()
@@ -465,21 +466,21 @@ object dsl {
 
     // Tab Bars, Tabs
 
-    inline fun tabBar(strId: String, flags: TabBarFlags = 0, block: () -> Unit) {
+    inline fun tabBar(strId: String, flags: TabBarFlags = emptyFlags(), block: () -> Unit) {
         if (beginTabBar(strId, flags)) {
             block()
             endTabBar()
         }
     }
 
-    inline fun tabItem(label: String, pOpen: KMutableProperty0<Boolean>? = null, flags: TabItemFlags = 0, block: () -> Unit) {
+    inline fun tabItem(label: String, pOpen: KMutableProperty0<Boolean>? = null, flags: TabItemFlags = emptyFlags(), block: () -> Unit) {
         if (beginTabItem(label, pOpen, flags)) {
             block()
             endTabItem()
         }
     }
 
-    inline fun tabItem(label: String, pOpen: BooleanArray, ptr: Int, flags: TabItemFlags = 0, block: () -> Unit) {
+    inline fun tabItem(label: String, pOpen: BooleanArray, ptr: Int, flags: TabItemFlags = emptyFlags(), block: () -> Unit) {
         if (beginTabItem(label, pOpen, ptr, flags)) {
             block()
             endTabItem()
@@ -489,7 +490,7 @@ object dsl {
 
     // Drag and Drop
 
-    inline fun dragDropSource(flags: DragDropFlags = 0, block: () -> Unit) {
+    inline fun dragDropSource(flags: DragDropFlags = emptyFlags(), block: () -> Unit) {
         if (beginDragDropSource(flags)) {
             block()
             endDragDropSource()
@@ -515,7 +516,7 @@ object dsl {
 
     // Miscellaneous Utilities
 
-    inline fun childFrame(id: ID, size: Vec2, extraFlags: WindowFlags = 0, block: () -> Unit) {
+    inline fun childFrame(id: ID, size: Vec2, extraFlags: WindowFlags = emptyFlags(), block: () -> Unit) {
         beginChildFrame(id, size, extraFlags)
         block()
         endChildFrame()
@@ -523,8 +524,7 @@ object dsl {
 
     // Columns
 
-    inline fun columns(strId: String = "", columnsCount: Int,
-                       flags: OldColumnsFlags = OldColumnsFlag.None.i, block: () -> Unit) {
+    inline fun columns(strId: String = "", columnsCount: Int, flags: OldColumnsFlags = emptyFlags(), block: () -> Unit) {
         beginColumns(strId, columnsCount, flags)
         block()
         endColumns()

--- a/core/src/main/kotlin/imgui/flags & enumerations.kt
+++ b/core/src/main/kotlin/imgui/flags & enumerations.kt
@@ -33,6 +33,30 @@ value class FlagArray<F : Flag<F>> private constructor(private val array: IntArr
     // constructor from size
     constructor(size: Int) : this(IntArray(size))
 
+    // Provides Java-style constructors
+    companion object {
+        @JvmName("of")
+        @JvmStatic
+        fun <F : Flag<F>> of(flag: Flag<F>): FlagArray<F> = FlagArray(flag)
+        @JvmName("of")
+        @JvmStatic
+        fun <F : Flag<F>> of(vararg flags: Flag<F>): FlagArray<F> = FlagArray(flags)
+        @JvmName("of")
+        @JvmStatic
+        fun <F : Flag<F>> of(size: Int): FlagArray<F> = FlagArray(size)
+
+        @JvmName("get")
+        @JvmStatic
+        fun <F : Flag<F>> get(flagArray: FlagArray<F>, index: Int): Flag<F> = flagArray[index]
+        @JvmName("set")
+        @JvmStatic
+        fun <F : Flag<F>> set(flagArray: FlagArray<F>, index: Int, value: Flag<F>) {
+            flagArray[index] = value
+        }
+        @JvmName("iterator")
+        @JvmStatic
+        fun <F : Flag<F>> iterator(flagArray: FlagArray<F>): Iterator<Flag<F>> = flagArray.iterator()
+    }
     operator fun get(index: Int): Flag<F> = Flags(array[index])
     operator fun set(index: Int, value: Flag<F>) {
         array[index] = value.i

--- a/core/src/main/kotlin/imgui/flags & enumerations.kt
+++ b/core/src/main/kotlin/imgui/flags & enumerations.kt
@@ -1,9 +1,11 @@
 package imgui
 
+import com.livefront.sealedenum.GenSealedEnum
 import glm_.vec4.Vec4
 import imgui.DragDropFlag.*
 import imgui.ImGui.getColorU32
 import imgui.internal.isPowerOfTwo
+import kotlin.internal.NoInfer
 
 
 //-----------------------------------------------------------------------------
@@ -14,6 +16,12 @@ import imgui.internal.isPowerOfTwo
 private value class Flags<F : Flag<F>>(override val i: Int) : Flag<F> {
     constructor() : this(0)
     constructor(flag: Flag<F>) : this(flag.i)
+
+    @Suppress("RESERVED_MEMBER_INSIDE_VALUE_CLASS")
+    override fun equals(other: Any?): Boolean = other is Flag<*> && i == other.i
+
+    @Suppress("RESERVED_MEMBER_INSIDE_VALUE_CLASS")
+    override fun hashCode(): Int = i
 
     infix fun and(b: Flags<F>): Flags<F> = Flags(i and b.i)
     infix fun or(b: Flags<F>): Flags<F> = Flags(i or b.i)
@@ -82,33 +90,37 @@ inline fun <F : Flag<F>> FlagArray(size: Int, init: (Int) -> Flag<F>) = FlagArra
         this[i] = init(i)
 }
 
-fun <F : Flag<F>> emptyFlags(): Flag<F> = Flags()
+val emptyFlags: Flag<Nothing> = Flags()
+fun <F : Flag<F>> emptyFlags(): Flag<F> = emptyFlags
 fun <F : Flag<F>> flagArrayOf(flag: Flag<F>): FlagArray<F> = FlagArray(flag)
 fun <F : Flag<F>> flagArrayOf(vararg flags: Flag<F>): FlagArray<F> = FlagArray(flags)
 
-interface Flag<Self : Flag<Self>> {
+interface Flag<out Self : Flag<Self>> {
     val i: Int
 
     companion object {
         @JvmStatic
-        fun <F : Flag<F>> empty(): Flag<F> = emptyFlags()
+        fun <F : Flag<F>> empty(): Flag<F> = emptyFlags
     }
 
-    val isEmpty get() = this eq empty()
+    val isEmpty get() = this == emptyFlags
     val isNotEmpty get() = !isEmpty
     val isPowerOfTwo get() = i.isPowerOfTwo
+}
 
-    infix fun eq(b: Flag<Self>): Boolean = i == b.i
-    infix fun notEq(b: Flag<Self>): Boolean = !eq(b)
-    infix fun and(b: Flag<Self>): Flag<Self> = Flags(this) and Flags(b)
-    infix fun or(b: Flag<Self>): Flag<Self> = Flags(this) or Flags(b)
-    infix fun xor(b: Flag<Self>): Flag<Self> = Flags(this) xor Flags(b)
-    infix fun wo(b: Flag<Self>): Flag<Self> = Flags(this) wo Flags(b)
-    infix fun has(b: Flag<Self>): Boolean = and(b).isNotEmpty
-    infix fun hasnt(b: Flag<Self>): Boolean = and(b).isEmpty
-    operator fun minus(flag: Flag<Self>): Flag<Self> = wo(flag)
-    operator fun div(flag: Flag<Self>): Flag<Self> = or(flag)
-    operator fun contains(flag: Flag<Self>) = and(flag) eq flag
+infix fun <Self : Flag<Self>> Flag<Self>.and(b: Flag<Self>): Flag<Self> = Flags(this) and Flags(b)
+infix fun <Self : Flag<Self>> Flag<Self>.or(b: Flag<Self>): Flag<Self> = Flags(this) or Flags(b)
+infix fun <Self : Flag<Self>> Flag<Self>.xor(b: Flag<Self>): Flag<Self> = Flags(this) xor Flags(b)
+infix fun <Self : Flag<Self>> Flag<Self>.wo(b: Flag<Self>): Flag<Self> = Flags(this) wo Flags(b)
+infix fun <Self : Flag<Self>> Flag<Self>.has(b: Flag<@NoInfer Self>): Boolean = and(b).isNotEmpty
+infix fun <Self : Flag<Self>> Flag<Self>.hasnt(b: Flag<@NoInfer Self>): Boolean = and(b).isEmpty
+operator fun <Self : Flag<Self>> Flag<Self>.minus(flag: Flag<Self>): Flag<Self> = wo(flag)
+operator fun <Self : Flag<Self>> Flag<Self>.div(flag: Flag<Self>): Flag<Self> = or(flag)
+operator fun <Self : Flag<Self>> Flag<Self>.contains(flag: Flag<@NoInfer Self>) = and(flag) == flag
+
+abstract class FlagBase<out Self : Flag<Self>> : Flag<Self> {
+    override fun equals(other: Any?): Boolean = this === other || (other is Flag<*> && i == other.i)
+    override fun hashCode(): Int = i
 }
 
 /** Flags for ImGui::Begin()
@@ -116,241 +128,251 @@ interface Flag<Self : Flag<Self>> {
 typealias WindowFlags = Flag<WindowFlag>
 
 /** Flags: for Begin(), BeginChild()    */
-enum class WindowFlag(override val i: Int) : Flag<WindowFlag> {
+sealed class WindowFlag(override val i: Int) : FlagBase<WindowFlag>() {
     /** Disable title-bar   */
-    NoTitleBar(1 shl 0),
+    object NoTitleBar : WindowFlag(1 shl 0)
 
     /** Disable user resizing with the lower-right grip */
-    NoResize(1 shl 1),
+    object NoResize : WindowFlag(1 shl 1)
 
     /** Disable user moving the window  */
-    NoMove(1 shl 2),
+    object NoMove : WindowFlag(1 shl 2)
 
     /** Disable scrollbars (window can still scroll with mouse or programmatically)  */
-    NoScrollbar(1 shl 3),
+    object NoScrollbar : WindowFlag(1 shl 3)
 
     /** Disable user vertically scrolling with mouse wheel. On child window, mouse wheel will be forwarded to the parent
      *  unless noScrollbar is also set.  */
-    NoScrollWithMouse(1 shl 4),
+    object NoScrollWithMouse : WindowFlag(1 shl 4)
 
     /** Disable user collapsing window by double-clicking on it. Also referred to as Window Menu Button (e.g. within a docking node). */
-    NoCollapse(1 shl 5),
+    object NoCollapse : WindowFlag(1 shl 5)
 
     /** Resize every window to its content every frame  */
-    AlwaysAutoResize(1 shl 6),
+    object AlwaysAutoResize : WindowFlag(1 shl 6)
 
     /** Disable drawing background color (WindowBg, etc.) and outside border. Similar as using SetNextWindowBgAlpha(0.0f).(1 shl 7) */
-    NoBackground(1 shl 7),
+    object NoBackground : WindowFlag(1 shl 7)
 
     /** Never load/save settings in .ini file   */
-    NoSavedSettings(1 shl 8),
+    object NoSavedSettings : WindowFlag(1 shl 8)
 
     /** Disable catching mouse or keyboard inputs   */
-    NoMouseInputs(1 shl 9),
+    object NoMouseInputs : WindowFlag(1 shl 9)
 
     /** Has a menu-bar  */
-    MenuBar(1 shl 10),
+    object MenuBar : WindowFlag(1 shl 10)
 
     /** Allow horizontal scrollbar to appear (off by default). You may use SetNextWindowContentSize(ImVec2(width),0.0f));
      *  prior to calling Begin() to specify width. Read code in imgui_demo in the "Horizontal Scrolling" section.    */
-    HorizontalScrollbar(1 shl 11),
+    object HorizontalScrollbar : WindowFlag(1 shl 11)
 
     /** Disable taking focus when transitioning from hidden to visible state    */
-    NoFocusOnAppearing(1 shl 12),
+    object NoFocusOnAppearing : WindowFlag(1 shl 12)
 
     /** Disable bringing window to front when taking focus (e.g. clicking on it or programmatically giving it focus) */
-    NoBringToFrontOnFocus(1 shl 13),
+    object NoBringToFrontOnFocus : WindowFlag(1 shl 13)
 
     /** Always show vertical scrollbar (even if ContentSize.y < Size.y) */
-    AlwaysVerticalScrollbar(1 shl 14),
+    object AlwaysVerticalScrollbar : WindowFlag(1 shl 14)
 
     /** Always show horizontal scrollbar (even if ContentSize.x < Size.x)   */
-    AlwaysHorizontalScrollbar(1 shl 15),
+    object AlwaysHorizontalScrollbar : WindowFlag(1 shl 15)
 
     /** Ensure child windows without border uses style.WindowPadding (ignored by default for non-bordered child windows),
      *  because more convenient)  */
-    AlwaysUseWindowPadding(1 shl 16),
+    object AlwaysUseWindowPadding : WindowFlag(1 shl 16)
 
     /** No gamepad/keyboard navigation within the window    */
-    NoNavInputs(1 shl 18),
+    object NoNavInputs : WindowFlag(1 shl 18)
 
     /** No focusing toward this window with gamepad/keyboard navigation (e.g. skipped by CTRL+TAB)  */
-    NoNavFocus(1 shl 19),
+    object NoNavFocus : WindowFlag(1 shl 19)
 
     /** Display a dot next to the title. When used in a tab/docking context, tab is selected when clicking the X + closure is not assumed (will wait for user to stop submitting the tab). Otherwise closure is assumed when pressing the X, so if you keep submitting the tab may reappear at end of tab bar. */
-    UnsavedDocument(1 shl 20),
+    object UnsavedDocument : WindowFlag(1 shl 20)
 
     // [Internal]
 
     /** [BETA] On child window: allow gamepad/keyboard navigation to cross over parent border to this child or between sibling child windows. */
-    _NavFlattened(1 shl 23),
+    object _NavFlattened : WindowFlag(1 shl 23)
 
     /** Don't use! For internal use by BeginChild() */
-    _ChildWindow(1 shl 24),
+    object _ChildWindow : WindowFlag(1 shl 24)
 
     /** Don't use! For internal use by BeginTooltip()   */
-    _Tooltip(1 shl 25),
+    object _Tooltip : WindowFlag(1 shl 25)
 
     /** Don't use! For internal use by BeginPopup() */
-    _Popup(1 shl 26),
+    object _Popup : WindowFlag(1 shl 26)
 
     /** Don't use! For internal use by BeginPopupModal()    */
-    _Modal(1 shl 27),
+    object _Modal : WindowFlag(1 shl 27)
 
     /** Don't use! For internal use by BeginMenu()  */
-    _ChildMenu(1 shl 28);
+    object _ChildMenu : WindowFlag(1 shl 28)
 
+    @GenSealedEnum
     companion object {
-        val NoNav: WindowFlags = NoNavInputs or NoNavFocus
+        val NoNav: WindowFlags get() = NoNavInputs or NoNavFocus
 
-        val NoDecoration: WindowFlags = NoTitleBar or NoResize or NoScrollbar or NoCollapse
+        val NoDecoration: WindowFlags get() = NoTitleBar or NoResize or NoScrollbar or NoCollapse
 
-        val NoInputs: WindowFlags = NoMouseInputs or NoNavInputs or NoNavFocus
+        val NoInputs: WindowFlags get() = NoMouseInputs or NoNavInputs or NoNavFocus
     }
 }
 
 /** Flags for ImGui::InputText(), InputTextMultiline()
  *  (Those are per-item flags. There are shared flags in ImGuiIO: io.ConfigInputTextCursorBlink and io.ConfigInputTextEnterKeepActive) */
-typealias InputTextFlags = Flag<InputTextFlag>
+typealias InputTextFlags = Flag<InputTextFlag<*>>
+typealias InputTextSingleFlags = Flag<InputTextFlag.Single>
 
-enum class InputTextFlag(override val i: Int) : Flag<InputTextFlag> {
+sealed class InputTextFlag<out ITF : InputTextFlag<ITF>>(override val i: Int) : FlagBase<ITF>() {
+    sealed class Single(i: Int) : InputTextFlag<Single>(i)
+
+    sealed class Multiline(i: Int) : InputTextFlag<Multiline>(i)
+
     /** Allow 0123456789 . + - * /      */
-    CharsDecimal(1 shl 0),
+    object CharsDecimal : Single(1 shl 0)
 
     /** Allow 0123456789ABCDEFabcdef    */
-    CharsHexadecimal(1 shl 1),
+    object CharsHexadecimal : Single(1 shl 1)
 
     /** Turn a..z into A..Z */
-    CharsUppercase(1 shl 2),
+    object CharsUppercase : Single(1 shl 2)
 
     /** Filter out spaces), tabs    */
-    CharsNoBlank(1 shl 3),
+    object CharsNoBlank : Single(1 shl 3)
 
     /** Select entire text when first taking mouse focus    */
-    AutoSelectAll(1 shl 4),
+    object AutoSelectAll : Single(1 shl 4)
 
     /** Return 'true' when Enter is pressed (as opposed to every time the value was modified). Consider looking at the IsItemDeactivatedAfterEdit() function. */
-    EnterReturnsTrue(1 shl 5),
+    object EnterReturnsTrue : Single(1 shl 5)
 
     /** Callback on pressing TAB (for completion handling)    */
-    CallbackCompletion(1 shl 6),
+    object CallbackCompletion : Single(1 shl 6)
 
     /** Callback on pressing Up/Down arrows (for history handling)    */
-    CallbackHistory(1 shl 7),
+    object CallbackHistory : Single(1 shl 7)
 
     /** Callback on each iteration. User code may query cursor position), modify text buffer.    */
-    CallbackAlways(1 shl 8),
+    object CallbackAlways : Single(1 shl 8)
 
     /** Callback on character inputs to replace or discard them. Modify 'EventChar' to replace or discard,
      *  or return 1 in callback to discard.  */
-    CallbackCharFilter(1 shl 9),
+    object CallbackCharFilter : Single(1 shl 9)
 
     /** Pressing TAB input a '\t' character into the text field */
-    AllowTabInput(1 shl 10),
+    object AllowTabInput : Single(1 shl 10)
 
     /** In multi-line mode), unfocus with Enter), add new line with Ctrl+Enter (default is opposite: unfocus with
      *  Ctrl+Enter), add line with Enter).   */
-    CtrlEnterForNewLine(1 shl 11),
+    object CtrlEnterForNewLine : Single(1 shl 11)
 
     /** Disable following the cursor horizontally   */
-    NoHorizontalScroll(1 shl 12),
+    object NoHorizontalScroll : Single(1 shl 12)
 
     /** Overwrite mode */
-    AlwaysOverwrite(1 shl 13),
+    object AlwaysOverwrite : Single(1 shl 13)
 
     /** Read-only mode  */
-    ReadOnly(1 shl 14),
+    object ReadOnly : Single(1 shl 14)
 
     /** Password mode), display all characters as '*'   */
-    Password(1 shl 15),
+    object Password : Single(1 shl 15)
 
     /** Disable undo/redo. Note that input text owns the text data while active, if you want to provide your own
      *  undo/redo stack you need e.g. to call clearActiveID(). */
-    NoUndoRedo(1 shl 16),
+    object NoUndoRedo : Single(1 shl 16)
 
     /** Allow 0123456789.+-* /eE (Scientific notation input) */
-    CharsScientific(1 shl 17),
+    object CharsScientific : Single(1 shl 17)
 
     /** Callback on buffer capacity changes request (beyond 'buf_size' parameter value), allowing the string to grow.
      *  Notify when the string wants to be resized (for string types which hold a cache of their Size).
      *  You will be provided a new BufSize in the callback and NEED to honor it. (see misc/cpp/imgui_stl.h for an example of using this) */
-    CallbackResize(1 shl 18),
+    object CallbackResize : Single(1 shl 18)
 
     /** Callback on any edit (note that InputText() already returns true on edit, the callback is useful mainly to
      *  manipulate the underlying buffer while focus is active) */
-    CallbackEdit(1 shl 19),
+    object CallbackEdit : Single(1 shl 19)
 
     /** Escape key clears content if not empty, and deactivate otherwise (contrast to default behavior of Escape to revert) */
-    EscapeClearsAll(1 shl 20),
+    object EscapeClearsAll : Single(1 shl 20)
 
     // [Internal]
 
     /** For internal use by InputTextMultiline() */
-    _Multiline(1 shl 26),
+    object _Multiline : Multiline(1 shl 26)
 
     /** For internal use by functions using InputText() before reformatting data */
-    _NoMarkEdited(1 shl 27),
+    object _NoMarkEdited : Single(1 shl 27)
 
     /** For internal use by TempInputText(), will skip calling ItemAdd(). Require bounding-box to strictly match. */
-    _MergedItem(1 shl 28);
+    object _MergedItem : Single(1 shl 28)
+
+    @GenSealedEnum
+    companion object
 }
 
 
 typealias TreeNodeFlags = Flag<TreeNodeFlag>
 
 /** Flags: for TreeNode(), TreeNodeEx(), CollapsingHeader()   */
-enum class TreeNodeFlag(override val i: Int) : Flag<TreeNodeFlag> {
+sealed class TreeNodeFlag(override val i: Int) : FlagBase<TreeNodeFlag>() {
     /** Draw as selected    */
-    Selected(1 shl 0),
+    object Selected : TreeNodeFlag(1 shl 0)
 
     /** Draw frame with background (e.g. for CollapsingHeader)  */
-    Framed(1 shl 1),
+    object Framed : TreeNodeFlag(1 shl 1)
 
     /** Hit testing to allow subsequent widgets to overlap this one */
-    AllowItemOverlap(1 shl 2),
+    object AllowItemOverlap : TreeNodeFlag(1 shl 2)
 
     /** Don't do a TreePush() when open (e.g. for CollapsingHeader) ( no extra indent nor pushing on ID stack   */
-    NoTreePushOnOpen(1 shl 3),
+    object NoTreePushOnOpen : TreeNodeFlag(1 shl 3)
 
     /** Don't automatically and temporarily open node when Logging is active (by default logging will automatically open
      *  tree nodes) */
-    NoAutoOpenOnLog(1 shl 4),
+    object NoAutoOpenOnLog : TreeNodeFlag(1 shl 4)
 
     /** Default node to be open */
-    DefaultOpen(1 shl 5),
+    object DefaultOpen : TreeNodeFlag(1 shl 5)
 
     /** Need double-click to open node  */
-    OpenOnDoubleClick(1 shl 6),
+    object OpenOnDoubleClick : TreeNodeFlag(1 shl 6)
 
     /** Only open when clicking on the arrow part. If OpenOnDoubleClick is also set), single-click arrow or double-click
      *  all box to open.    */
-    OpenOnArrow(1 shl 7),
+    object OpenOnArrow : TreeNodeFlag(1 shl 7)
 
     /** No collapsing), no arrow (use as a convenience for leaf nodes). */
-    Leaf(1 shl 8),
+    object Leaf : TreeNodeFlag(1 shl 8)
 
     /** Display a bullet instead of arrow   */
-    Bullet(1 shl 9),
+    object Bullet : TreeNodeFlag(1 shl 9)
 
     /** Use FramePadding (even for an unframed text node) to vertically align text baseline to regular widget height.
      *  Equivalent to calling alignTextToFramePadding().    */
-    FramePadding(1 shl 10),
+    object FramePadding : TreeNodeFlag(1 shl 10)
 
     /** Extend hit box to the right-most edge, even if not framed. This is not the default in order to allow adding other items on the same line. In the future we may refactor the hit system to be front-to-back, allowing natural overlaps and then this can become the default. */
-    SpanAvailWidth(1 shl 11),
+    object SpanAvailWidth : TreeNodeFlag(1 shl 11)
 
     /** Extend hit box to the left-most and right-most edges (bypass the indented area). */
-    SpanFullWidth(1 shl 12),
+    object SpanFullWidth : TreeNodeFlag(1 shl 12)
 
     /** (WIP) Nav: left direction may move to this TreeNode() from any of its child (items submitted between TreeNode and TreePop)   */
-    NavLeftJumpsBackHere(1 shl 13),
+    object NavLeftJumpsBackHere : TreeNodeFlag(1 shl 13)
 
     // [Internal]
 
-    _ClipLabelForTrailingButton(1 shl 20);
+    object _ClipLabelForTrailingButton : TreeNodeFlag(1 shl 20)
 
+    @GenSealedEnum
     companion object {
-        val CollapsingHeader: TreeNodeFlags = Framed or NoTreePushOnOpen or NoAutoOpenOnLog
+        val CollapsingHeader: TreeNodeFlags get() = Framed or NoTreePushOnOpen or NoAutoOpenOnLog
     }
 }
 
@@ -364,127 +386,132 @@ typealias PopupFlags = Flag<PopupFlag>
  *    IMPORTANT: because the default parameter is 1 (==ImGuiPopupFlags_MouseButtonRight), if you rely on the default parameter
  *    and want to use another flag, you need to pass in the ImGuiPopupFlags_MouseButtonRight flag explicitly.
  *  - Multiple buttons currently cannot be combined/or-ed in those functions (we could allow it later). */
-enum class PopupFlag(override val i: Int) : Flag<PopupFlag> {
+sealed class PopupFlag(override val i: Int) : FlagBase<PopupFlag>() {
     /** For BeginPopupContext*(): open on Left Mouse release. */
-    MouseButtonLeft(0),
+    object MouseButtonLeft : PopupFlag(0)
 
     /** For BeginPopupContext*(): open on Right Mouse release. */
-    MouseButtonRight(1),
+    object MouseButtonRight : PopupFlag(1)
 
     /** For BeginPopupContext*(): open on Middle Mouse release. */
-    MouseButtonMiddle(2),
+    object MouseButtonMiddle : PopupFlag(2)
 
     /** For OpenPopup*(), BeginPopupContext*(): don't open if there's already a popup at the same level of the popup stack */
-    NoOpenOverExistingPopup(1 shl 5),
+    object NoOpenOverExistingPopup : PopupFlag(1 shl 5)
 
     /** For BeginPopupContextWindow(): don't return true when hovering items, only when hovering empty space */
-    NoOpenOverItems(1 shl 6),
+    object NoOpenOverItems : PopupFlag(1 shl 6)
 
     /** For IsPopupOpen(): ignore the ImGuiID parameter and test for any popup. */
-    AnyPopupId(1 shl 7),
+    object AnyPopupId : PopupFlag(1 shl 7)
 
     /** For IsPopupOpen(): search/test at any level of the popup stack (default test in the current level) */
-    AnyPopupLevel(1 shl 8);
+    object AnyPopupLevel : PopupFlag(1 shl 8)
 
+    @GenSealedEnum
     companion object {
-        val AnyPopup: PopupFlags = AnyPopupId or AnyPopupLevel
-        val Default: PopupFlags = MouseButtonRight
+        val AnyPopup: PopupFlags get() = AnyPopupId or AnyPopupLevel
+        val Default: PopupFlags get() = MouseButtonRight
 
         infix fun of(mouseButton: MouseButton): PopupFlags = when (mouseButton) {
             MouseButton.Left -> MouseButtonLeft
             MouseButton.Right -> MouseButtonRight
             MouseButton.Middle -> MouseButtonMiddle
-            else -> emptyFlags()
+            else -> emptyFlags
         }
     }
 }
 
 val PopupFlags.mouseButton: MouseButton
-    get() = when {
-        this eq PopupFlag.MouseButtonLeft -> MouseButton.Left
-        this eq PopupFlag.MouseButtonRight -> MouseButton.Right
-        this eq PopupFlag.MouseButtonMiddle -> MouseButton.Middle
+    get() = when(this) {
+        PopupFlag.MouseButtonLeft -> MouseButton.Left
+        PopupFlag.MouseButtonRight -> MouseButton.Right
+        PopupFlag.MouseButtonMiddle -> MouseButton.Middle
         else -> MouseButton.None
     }
 
 typealias SelectableFlags = Flag<SelectableFlag>
 
 /** Flags for ImGui::Selectable()   */
-enum class SelectableFlag(override val i: Int) : Flag<SelectableFlag> {
+sealed class SelectableFlag(override val i: Int) : FlagBase<SelectableFlag>() {
     /** Clicking this doesn't close parent popup window   */
-    DontClosePopups(1 shl 0),
+    object DontClosePopups : SelectableFlag(1 shl 0)
 
     /** Selectable frame can span all columns (text will still fit in current column)   */
-    SpanAllColumns(1 shl 1),
+    object SpanAllColumns : SelectableFlag(1 shl 1)
 
     /** Generate press events on double clicks too  */
-    AllowDoubleClick(1 shl 2),
+    object AllowDoubleClick : SelectableFlag(1 shl 2)
 
     /** Cannot be selected, display grayed out text */
-    Disabled(1 shl 3),
+    object Disabled : SelectableFlag(1 shl 3)
 
     /** (WIP) Hit testing to allow subsequent widgets to overlap this one */
-    AllowItemOverlap(1 shl 4),
+    object AllowItemOverlap : SelectableFlag(1 shl 4)
 
     // [Internal] NB: need to be in sync with last value of ImGuiSelectableFlags_
 
     /** private  */
-    _NoHoldingActiveID(1 shl 20),
+    object _NoHoldingActiveID : SelectableFlag(1 shl 20)
 
     /** (WIP) Auto-select when moved into. This is not exposed in public API as to handle multi-select and modifiers we will need user to explicitly control focus scope. May be replaced with a BeginSelection() API. */
-    _SelectOnNav(1 shl 21),
+    object _SelectOnNav : SelectableFlag(1 shl 21)
 
     /** Override button behavior to react on Click (default is Click+Release) */
-    _SelectOnClick(1 shl 22),
+    object _SelectOnClick : SelectableFlag(1 shl 22)
 
     /** Override button behavior to react on Release (default is Click+Release) */
-    _SelectOnRelease(1 shl 23),
+    object _SelectOnRelease : SelectableFlag(1 shl 23)
 
     /** Span all avail width even if we declared less for layout purpose. FIXME: We may be able to remove this (added in 6251d379, 2bcafc86 for menus)  */
-    _SpanAvailWidth(1 shl 24),
+    object _SpanAvailWidth : SelectableFlag(1 shl 24)
 
     /** Set Nav/Focus ID on mouse hover (used by MenuItem) */
-    _SetNavIdOnHover(1 shl 25),
+    object _SetNavIdOnHover : SelectableFlag(1 shl 25)
 
     /** Disable padding each side with ItemSpacing * 0.5f */
-    _NoPadWithHalfSpacing(1 shl 26),
+    object _NoPadWithHalfSpacing : SelectableFlag(1 shl 26)
 
     /** Don't set key/input owner on the initial click (note: mouse buttons are keys! often, the key in question will be ImGuiKey_MouseLeft!) */
-    _NoSetKeyOwner(1 shl 27);
+    object _NoSetKeyOwner : SelectableFlag(1 shl 27)
+
+    @GenSealedEnum
+    companion object
 }
 
 typealias ComboFlags = Flag<ComboFlag>
 
 /** Flags: for BeginCombo() */
-enum class ComboFlag(override val i: Int) : Flag<ComboFlag> {
+sealed class ComboFlag(override val i: Int) : FlagBase<ComboFlag>() {
     /** Align the popup toward the left by default */
-    PopupAlignLeft(1 shl 0),
+    object PopupAlignLeft : ComboFlag(1 shl 0)
 
     /** Max ~4 items visible */
-    HeightSmall(1 shl 1),
+    object HeightSmall : ComboFlag(1 shl 1)
 
     /** Max ~8 items visible (default) */
-    HeightRegular(1 shl 2),
+    object HeightRegular : ComboFlag(1 shl 2)
 
     /** Max ~20 items visible */
-    HeightLarge(1 shl 3),
+    object HeightLarge : ComboFlag(1 shl 3)
 
     /** As many fitting items as possible */
-    HeightLargest(1 shl 4),
+    object HeightLargest : ComboFlag(1 shl 4)
 
     /** Display on the preview box without the square arrow button  */
-    NoArrowButton(1 shl 5),
+    object NoArrowButton : ComboFlag(1 shl 5)
 
     /** Display only a square arrow button  */
-    NoPreview(1 shl 6),
+    object NoPreview : ComboFlag(1 shl 6)
 
     // private
 
     /** enable BeginComboPreview() */
-    _CustomPreview(1 shl 20);
+    object _CustomPreview : ComboFlag(1 shl 20)
 
+    @GenSealedEnum
     companion object {
-        val HeightMask: ComboFlags = HeightSmall or HeightRegular or HeightLarge or HeightLargest
+        val HeightMask: ComboFlags get() = HeightSmall or HeightRegular or HeightLarge or HeightLargest
     }
 }
 
@@ -492,83 +519,93 @@ enum class ComboFlag(override val i: Int) : Flag<ComboFlag> {
 typealias TabBarFlags = Flag<TabBarFlag>
 
 /** Flags for ImGui::BeginTabBar() */
-enum class TabBarFlag(override val i: Int) : Flag<TabBarFlag> {
+sealed class TabBarFlag(override val i: Int) : FlagBase<TabBarFlag>() {
     /** Allow manually dragging tabs to re-order them + New tabs are appended at the end of list */
-    Reorderable(1 shl 0),
+    object Reorderable : TabBarFlag(1 shl 0)
 
     /** Automatically select new tabs when they appear */
-    AutoSelectNewTabs(1 shl 1),
+    object AutoSelectNewTabs : TabBarFlag(1 shl 1)
 
     /** Disable buttons to open the tab list popup */
-    TabListPopupButton(1 shl 2),
+    object TabListPopupButton : TabBarFlag(1 shl 2)
 
     /** Disable behavior of closing tabs (that are submitted with p_open != NULL) with middle mouse button.
      *  You can still repro this behavior on user's side with if (IsItemHovered() && IsMouseClicked(2)) *p_open = false. */
-    NoCloseWithMiddleMouseButton(1 shl 3),
+    object NoCloseWithMiddleMouseButton : TabBarFlag(1 shl 3)
 
     /** Disable scrolling buttons (apply when fitting policy is ImGuiTabBarFlags_FittingPolicyScroll) */
-    NoTabListScrollingButtons(1 shl 4),
+    object NoTabListScrollingButtons : TabBarFlag(1 shl 4)
 
     /** Disable tooltips when hovering a tab */
-    NoTooltip(1 shl 5),
+    object NoTooltip : TabBarFlag(1 shl 5)
 
     /** Resize tabs when they don't fit */
-    FittingPolicyResizeDown(1 shl 6),
+    object FittingPolicyResizeDown : TabBarFlag(1 shl 6)
 
     /** Add scroll buttons when tabs don't fit */
-    FittingPolicyScroll(1 shl 7),
+    object FittingPolicyScroll : TabBarFlag(1 shl 7)
 
     // Private
 
     /** Part of a dock node [we don't use this in the master branch but it facilitate branch syncing to keep this around] */
-    _DockNode(1 shl 20), _IsFocused(1 shl 21),
+    object _DockNode : TabBarFlag(1 shl 20)
+
+    object _IsFocused : TabBarFlag(1 shl 21)
 
     /** FIXME: Settings are handled by the docking system, this only request the tab bar to mark settings dirty when reordering tabs, */
-    _SaveSettings(1 shl 22);
+    object _SaveSettings : TabBarFlag(1 shl 22)
 
+    @GenSealedEnum
     companion object {
-        val FittingPolicyMask: TabBarFlags = FittingPolicyResizeDown or FittingPolicyScroll
-        val FittingPolicyDefault: TabBarFlags = FittingPolicyResizeDown
+        val FittingPolicyMask: TabBarFlags get() = FittingPolicyResizeDown or FittingPolicyScroll
+        val FittingPolicyDefault: TabBarFlags get() = FittingPolicyResizeDown
     }
 }
 
-typealias TabItemFlags = Flag<TabItemFlag>
+// Represents flags that work for TabButton (which includes TabItem flags)
+typealias TabItemFlags = Flag<TabItemFlag<*>>
+// Represents flags for _only_ items
+typealias TabItemOnlyFlags = Flag<TabItemFlag.ItemOnly>
 
 /** Flags for ImGui::BeginTabItem() */
-enum class TabItemFlag(override val i: Int) : Flag<TabItemFlag> {
+sealed class TabItemFlag<out TIF : TabItemFlag<TIF>>(override val i: Int) : FlagBase<TIF>() {
+    sealed class Button(i: Int) : TabItemFlag<Button>(i)
+    sealed class ItemOnly(i: Int) : TabItemFlag<ItemOnly>(i)
+
     /** Display a dot next to the title + tab is selected when clicking the X + closure is not assumed (will wait for user to stop submitting the tab). Otherwise closure is assumed when pressing the X, so if you keep submitting the tab may reappear at end of tab bar. */
-    UnsavedDocument(1 shl 0),
+    object UnsavedDocument : ItemOnly(1 shl 0)
 
     /** Trigger flag to programmatically make the tab selected when calling BeginTabItem() */
-    SetSelected(1 shl 1),
+    object SetSelected : ItemOnly(1 shl 1)
 
     /** Disable behavior of closing tabs (that are submitted with p_open != NULL) with middle mouse button. You can still repro this behavior on user's side with if (IsItemHovered() && IsMouseClicked(2)) *p_open = false. */
-    NoCloseWithMiddleMouseButton(1 shl 2),
+    object NoCloseWithMiddleMouseButton : ItemOnly(1 shl 2)
 
     /** Don't call PushID(tab->ID)/PopID() on BeginTabItem()/EndTabItem() */
-    NoPushId(1 shl 3),
+    object NoPushId : ItemOnly(1 shl 3)
 
     /** Disable tooltip for the given tab */
-    NoTooltip(1 shl 4),
+    object NoTooltip : ItemOnly(1 shl 4)
 
     /** Disable reordering this tab or having another tab cross over this tab */
-    NoReorder(1 shl 5),
+    object NoReorder : ItemOnly(1 shl 5)
 
     /**  Enforce the tab position to the left of the tab bar (after the tab list popup button) */
-    Leading(1 shl 6),
+    object Leading : ItemOnly(1 shl 6)
 
     /**  Enforce the tab position to the right of the tab bar (before the scrolling buttons) */
-    Trailing(1 shl 7),
+    object Trailing : ItemOnly(1 shl 7)
 
     // [Internal]
     /** Track whether p_open was set or not (we'll need this info on the next frame to recompute ContentWidth during layout) */
-    _NoCloseButton(1 shl 20),
+    object _NoCloseButton : ItemOnly(1 shl 20)
 
     /** Used by TabItemButton, change the tab item behavior to mimic a button */
-    _Button(1 shl 21);
+    object _Button : Button(1 shl 21)
 
+    @GenSealedEnum
     companion object {
-        val _SectionMask: TabItemFlags = Leading or Trailing
+        val _SectionMask: TabItemOnlyFlags get() = Leading or Trailing
     }
 }
 
@@ -596,218 +633,228 @@ typealias TableFlags = Flag<TableFlag>
 //    - Using Stretch columns OFTEN DOES NOT MAKE SENSE if ScrollX is on, UNLESS you have specified a value for 'inner_width' in BeginTable().
 //      If you specify a value for 'inner_width' then effectively the scrolling space is known and Stretch or mixed Fixed/Stretch columns become meaningful again.
 // - Read on documentation at the top of imgui_tables.cpp for details.
-enum class TableFlag(override val i: Int) : Flag<TableFlag> {
+sealed class TableFlag(override val i: Int) : FlagBase<TableFlag>() {
     /** Enable resizing columns. */
-    Resizable(1 shl 0),
+    object Resizable : TableFlag(1 shl 0)
 
     /** Enable reordering columns in header row (need calling TableSetupColumn() + TableHeadersRow() to display headers) */
-    Reorderable(1 shl 1),
+    object Reorderable : TableFlag(1 shl 1)
 
     /** Enable hiding/disabling columns in context menu. */
-    Hideable(1 shl 2),
+    object Hideable : TableFlag(1 shl 2)
 
     /** Enable sorting. Call TableGetSortSpecs() to obtain sort specs. Also see ImGuiTableFlags_SortMulti and ImGuiTableFlags_SortTristate. */
-    Sortable(1 shl 3),
+    object Sortable : TableFlag(1 shl 3)
 
     /** Disable persisting columns order, width and sort settings in the .ini file. */
-    NoSavedSettings(1 shl 4),
+    object NoSavedSettings : TableFlag(1 shl 4)
 
     /** Right-click on columns body/contents will display table context menu. By default it is available in TableHeadersRow(). */
-    ContextMenuInBody(1 shl 5),
+    object ContextMenuInBody : TableFlag(1 shl 5)
 
     // Decorations
 
     /** Set each RowBg color with ImGuiCol_TableRowBg or ImGuiCol_TableRowBgAlt (equivalent of calling TableSetBgColor with ImGuiTableBgFlags_RowBg0 on each row manually) */
-    RowBg(1 shl 6),
+    object RowBg : TableFlag(1 shl 6)
 
     /** Draw horizontal borders between rows. */
-    BordersInnerH(1 shl 7),
+    object BordersInnerH : TableFlag(1 shl 7)
 
     /** Draw horizontal borders at the top and bottom. */
-    BordersOuterH(1 shl 8),
+    object BordersOuterH : TableFlag(1 shl 8)
 
     /** Draw vertical borders between columns. */
-    BordersInnerV(1 shl 9),
+    object BordersInnerV : TableFlag(1 shl 9)
 
     /** Draw vertical borders on the left and right sides. */
-    BordersOuterV(1 shl 10),
+    object BordersOuterV : TableFlag(1 shl 10)
 
     /** [ALPHA] Disable vertical borders in columns Body (borders will always appear in Headers). -> May move to style */
-    NoBordersInBody(1 shl 11),
+    object NoBordersInBody : TableFlag(1 shl 11)
 
     /** [ALPHA] Disable vertical borders in columns Body until hovered for resize (borders will always appear in Headers). -> May move to style */
-    NoBordersInBodyUntilResize(1 shl 12),
+    object NoBordersInBodyUntilResize : TableFlag(1 shl 12)
 
     // Sizing Policy (read above for defaults)
 
     /** Columns default to _WidthFixed or _WidthAuto (if resizable or not resizable), matching contents width. */
-    SizingFixedFit(1 shl 13),
+    object SizingFixedFit : TableFlag(1 shl 13)
 
     /** Columns default to _WidthFixed or _WidthAuto (if resizable or not resizable), matching the maximum contents width of all columns. Implicitly enable ImGuiTableFlags_NoKeepColumnsVisible. */
-    SizingFixedSame(2 shl 13),
+    object SizingFixedSame : TableFlag(2 shl 13)
 
     /** Columns default to _WidthStretch with default weights proportional to each columns contents widths. */
-    SizingStretchProp(3 shl 13),
+    object SizingStretchProp : TableFlag(3 shl 13)
 
     /** Columns default to _WidthStretch with default weights all equal, unless overridden by TableSetupColumn(). */
-    SizingStretchSame(4 shl 13),
+    object SizingStretchSame : TableFlag(4 shl 13)
 
     /** Make outer width auto-fit to columns, overriding outer_size.x value. Only available when ScrollX/ScrollY are disabled and Stretch columns are not used. */
-    NoHostExtendX(1 shl 16),
+    object NoHostExtendX : TableFlag(1 shl 16)
 
     /** Make outer height stop exactly at outer_size.y (prevent auto-extending table past the limit). Only available when ScrollX/ScrollY are disabled. Data below the limit will be clipped and not visible. */
-    NoHostExtendY(1 shl 17),
+    object NoHostExtendY : TableFlag(1 shl 17)
 
     /** Disable keeping column always minimally visible when ScrollX is off and table gets too small. Not recommended if columns are resizable. */
-    NoKeepColumnsVisible(1 shl 18),
+    object NoKeepColumnsVisible : TableFlag(1 shl 18)
 
     /** Disable distributing remainder width to stretched columns (width allocation on a 100-wide table with 3 columns: Without this flag: 33,33,34. With this flag: 33,33,33). With larger number of columns, resizing will appear to be less smooth. */
-    PreciseWidths(1 shl 19),
+    object PreciseWidths : TableFlag(1 shl 19)
 
     // Clipping
 
     /** Disable clipping rectangle for every individual columns (reduce draw command count, items will be able to overflow into other columns). Generally incompatible with TableSetupScrollFreeze(). */
-    NoClip(1 shl 20),
+    object NoClip : TableFlag(1 shl 20)
 
     // Padding
 
     /** Default if BordersOuterV is on. Enable outermost padding. Generally desirable if you have headers. */
-    PadOuterX(1 shl 21),
+    object PadOuterX : TableFlag(1 shl 21)
 
     /** Default if BordersOuterV is off. Disable outermost padding. */
-    NoPadOuterX(1 shl 22),
+    object NoPadOuterX : TableFlag(1 shl 22)
 
     /** Disable inner padding between columns (double inner padding if BordersOuterV is on, single inner padding if BordersOuterV is off). */
-    NoPadInnerX(1 shl 23),
+    object NoPadInnerX : TableFlag(1 shl 23)
 
     // Scrolling
 
     /** Enable horizontal scrolling. Require 'outer_size' parameter of BeginTable() to specify the container size. Changes default sizing policy. Because this creates a child window, ScrollY is currently generally recommended when using ScrollX. */
-    ScrollX(1 shl 24),
+    object ScrollX : TableFlag(1 shl 24)
 
     /** Enable vertical scrolling. Require 'outer_size' parameter of BeginTable() to specify the container size. */
-    ScrollY(1 shl 25),
+    object ScrollY : TableFlag(1 shl 25)
 
     // Sorting
 
     /** Hold shift when clicking headers to sort on multiple column. TableGetSortSpecs() may return specs where (SpecsCount > 1). */
-    SortMulti(1 shl 26),
+    object SortMulti : TableFlag(1 shl 26)
 
     /** Allow no sorting, disable default sorting. TableGetSortSpecs() may return specs where (SpecsCount == 0). */
-    SortTristate(1 shl 27);
+    object SortTristate : TableFlag(1 shl 27)
 
+    @GenSealedEnum
     companion object {
         /** Draw horizontal borders. */
-        val BordersH: TableFlags = BordersInnerH or BordersOuterH
+        val BordersH: TableFlags get() = BordersInnerH or BordersOuterH
 
         /** Draw vertical borders. */
-        val BordersV: TableFlags = BordersInnerV or BordersOuterV
+        val BordersV: TableFlags get() = BordersInnerV or BordersOuterV
 
         /** Draw inner borders. */
-        val BordersInner: TableFlags = BordersInnerV or BordersInnerH
+        val BordersInner: TableFlags get() = BordersInnerV or BordersInnerH
 
         /** Draw outer borders. */
-        val BordersOuter: TableFlags = BordersOuterV or BordersOuterH
+        val BordersOuter: TableFlags get() = BordersOuterV or BordersOuterH
 
         /** Draw all borders. */
-        val Borders: TableFlags = BordersInner or BordersOuter
+        val Borders: TableFlags get() = BordersInner or BordersOuter
 
         /** [Internal] Combinations and masks */
-        val _SizingMask: TableFlags = SizingFixedFit or SizingFixedSame or SizingStretchProp or SizingStretchSame
+        val _SizingMask: TableFlags get() = SizingFixedFit or SizingFixedSame or SizingStretchProp or SizingStretchSame
     }
 }
 
-typealias TableColumnFlags = Flag<TableColumnFlag>
+typealias TableColumnFlags = Flag<TableColumnFlag<*>>
+typealias TableColumnSetupFlags = Flag<TableColumnFlag.Setup>
 
 // Flags for ImGui::TableSetupColumn()
-enum class TableColumnFlag(override val i: Int) : Flag<TableColumnFlag> {
+sealed class TableColumnFlag<out TCF : TableColumnFlag<TCF>>(override val i: Int) : FlagBase<TCF>() {
+    sealed class Status(i: Int) : TableColumnFlag<Status>(i)
+
+    sealed class Setup(i: Int) : TableColumnFlag<Setup>(i)
+
     /** Overriding/master disable flag: hide column, won't show in context menu (unlike calling TableSetColumnEnabled() which manipulates the user accessible state) */
-    Disabled(1 shl 0),
+    object Disabled : Setup(1 shl 0)
 
     /** Default as a hidden/disabled column. */
-    DefaultHide(1 shl 1),
+    object DefaultHide : Setup(1 shl 1)
 
     /** Default as a sorting column. */
-    DefaultSort(1 shl 2),
+    object DefaultSort : Setup(1 shl 2)
 
     /** Column will stretch. Preferable with horizontal scrolling disabled (default if table sizing policy is _SizingStretchSame or _SizingStretchProp). */
-    WidthStretch(1 shl 3),
+    object WidthStretch : Setup(1 shl 3)
 
     /** Column will not stretch. Preferable with horizontal scrolling enabled (default if table sizing policy is _SizingFixedFit and table is resizable). */
-    WidthFixed(1 shl 4),
+    object WidthFixed : Setup(1 shl 4)
 
     /** Disable manual resizing. */
-    NoResize(1 shl 5),
+    object NoResize : Setup(1 shl 5)
 
     /** Disable manual reordering this column, this will also prevent other columns from crossing over this column. */
-    NoReorder(1 shl 6),
+    object NoReorder : Setup(1 shl 6)
 
     /** Disable ability to hide/disable this column. */
-    NoHide(1 shl 7),
+    object NoHide : Setup(1 shl 7)
 
     /** Disable clipping for this column (all NoClip columns will render in a same draw command). */
-    NoClip(1 shl 8),
+    object NoClip : Setup(1 shl 8)
 
     /** Disable ability to sort on this field (even if ImGuiTableFlags_Sortable is set on the table). */
-    NoSort(1 shl 9),
+    object NoSort : Setup(1 shl 9)
 
     /** Disable ability to sort in the ascending direction. */
-    NoSortAscending(1 shl 10),
+    object NoSortAscending : Setup(1 shl 10)
 
     /** Disable ability to sort in the descending direction. */
-    NoSortDescending(1 shl 11),
+    object NoSortDescending : Setup(1 shl 11)
 
     /** TableHeadersRow() will not submit label for this column. Convenient for some small columns. Name will still appear in context menu. */
-    NoHeaderLabel(1 shl 12),
+    object NoHeaderLabel : Setup(1 shl 12)
 
     /** Disable header text width contribution to automatic column width. */
-    NoHeaderWidth(1 shl 13),
+    object NoHeaderWidth : Setup(1 shl 13)
 
     /** Make the initial sort direction Ascending when first sorting on this column (default). */
-    PreferSortAscending(1 shl 14),
+    object PreferSortAscending : Setup(1 shl 14)
 
     /** Make the initial sort direction Descending when first sorting on this column. */
-    PreferSortDescending(1 shl 15),
+    object PreferSortDescending : Setup(1 shl 15)
 
     /** Use current Indent value when entering cell (default for column 0). */
-    IndentEnable(1 shl 16),
+    object IndentEnable : Setup(1 shl 16)
 
     /** Ignore current Indent value when entering cell (default for columns > 0). Indentation changes _within_ the cell will still be honored. */
-    IndentDisable(1 shl 17),
+    object IndentDisable : Setup(1 shl 17)
 
     // Output status flags, read-only via TableGetColumnFlags()
 
     /** Status: is enabled == not hidden by user/api (referred to as "Hide" in _DefaultHide and _NoHide) flags. */
-    IsEnabled(1 shl 24),
+    object IsEnabled : Status(1 shl 24)
 
     /** Status: is visible == is enabled AND not clipped by scrolling. */
-    IsVisible(1 shl 25),
+    object IsVisible : Status(1 shl 25)
 
     /** Status: is currently part of the sort specs */
-    IsSorted(1 shl 26),
+    object IsSorted : Status(1 shl 26)
 
     /** Status: is hovered by mouse */
-    IsHovered(1 shl 27),
+    object IsHovered : Status(1 shl 27)
 
     /** [Internal] Disable user resizing this column directly (it may however we resized indirectly from its left edge) */
-    NoDirectResize_(1 shl 30);
+    object NoDirectResize_ : Setup(1 shl 30)
 
+    @GenSealedEnum
     companion object {
         /** [Internal] Combinations and masks */
-        val WidthMask: TableColumnFlags = WidthStretch or WidthFixed
+        val WidthMask: TableColumnSetupFlags get() = WidthStretch or WidthFixed
 
-        val IndentMask: TableColumnFlags = IndentEnable or IndentDisable
+        val IndentMask: TableColumnSetupFlags get() = IndentEnable or IndentDisable
 
-        val StatusMask: TableColumnFlags = IsEnabled or IsVisible or IsSorted or IsHovered
+        val StatusMask: TableColumnFlags get() = IsEnabled or IsVisible or IsSorted or IsHovered
     }
 }
 
 typealias TableRowFlags = Flag<TableRowFlag>
 
 // Flags for ImGui::TableNextRow()
-enum class TableRowFlag(override val i: Int) : Flag<TableRowFlag> {
+sealed class TableRowFlag(override val i: Int) : FlagBase<TableRowFlag>() {
     /** Identify header row (set default background color + width of its contents accounted differently for auto column width) */
-    Headers(1 shl 0);
+    object Headers : TableRowFlag(1 shl 0)
+
+    @GenSealedEnum
+    companion object
 }
 
 // Enum for ImGui::TableSetBgColor()
@@ -837,122 +884,136 @@ enum class TableBgTarget(val i: Int) {
 typealias FocusedFlags = Flag<FocusedFlag>
 
 /** Flags for ImGui::IsWindowFocused() */
-enum class FocusedFlag : Flag<FocusedFlag> {
+sealed class FocusedFlag : FlagBase<FocusedFlag>() {
     /** Return true if any children of the window is focused */
-    ChildWindows,
+    object ChildWindows : FocusedFlag()
 
     /** Test from root window (top most parent of the current hierarchy) */
-    RootWindow,
+    object RootWindow : FocusedFlag()
 
     /** Return true if any window is focused.
      *  Important: If you are trying to tell how to dispatch your low-level inputs, do NOT use this. Use 'io.WantCaptureMouse' instead! Please read the FAQ! */
-    AnyWindow,
+    object AnyWindow : FocusedFlag()
 
     /** Do not consider popup hierarchy (do not treat popup emitter as parent of popup) (when used with _ChildWindows or _RootWindow) */
-    NoPopupHierarchy,
+    object NoPopupHierarchy : FocusedFlag()
 
     //ImGuiFocusedFlags_DockHierarchy               = 1 << 4,   // Consider docking hierarchy (treat dockspace host as parent of docked window) (when used with _ChildWindows or _RootWindow)
-    ;
 
     override val i: Int = 1 shl ordinal
 
+    @GenSealedEnum
     companion object {
-        val RootAndChildWindows: FocusedFlags = RootWindow or ChildWindows
+        val RootAndChildWindows: FocusedFlags get() = RootWindow or ChildWindows
     }
 }
 
-typealias HoveredFlags = Flag<HoveredFlag>
+typealias HoveredFlags = Flag<HoveredFlag<*>>
+typealias ItemHoveredFlags = Flag<HoveredFlag.Item>
+typealias WindowHoveredFlags = Flag<HoveredFlag.Window>
 
 /** Flags: for IsItemHovered(), IsWindowHovered() etc.
  *  Note: if you are trying to check whether your mouse should be dispatched to Dear ImGui or to your app, you should use 'io.WantCaptureMouse' instead! Please read the FAQ!
  *  Note: windows with the ImGuiWindowFlags_NoInputs flag are ignored by IsWindowHovered() calls.*/
-enum class HoveredFlag(override val i: Int) : Flag<HoveredFlag> {
+
+@Suppress("INCONSISTENT_TYPE_PARAMETER_VALUES")
+sealed interface HoveredFlag<out HF : HoveredFlag<HF>> : Flag<HF> {
+    sealed interface Window : HoveredFlag<Window>
+    sealed class WindowBase(override val i: Int) : Window, FlagBase<Window>()
+
+    sealed interface Item : HoveredFlag<Item>
+    sealed class ItemBase(override val i: Int) : Item, FlagBase<Item>()
+
+    sealed class General(override val i: Int) : Window, Item, FlagBase<General>()
+
     /** isWindowHovered() only: Return true if any children of the window is hovered */
-    ChildWindows(1 shl 0),
+    object ChildWindows : WindowBase(1 shl 0)
 
     /** isWindowHovered() only: Test from root window (top most parent of the current hierarchy) */
-    RootWindow(1 shl 1),
+    object RootWindow : WindowBase(1 shl 1)
 
     /** IsWindowHovered() only: Return true if any window is hovered    */
-    AnyWindow(1 shl 2),
+    object AnyWindow : WindowBase(1 shl 2)
 
     /** IsWindowHovered() only: Do not consider popup hierarchy (do not treat popup emitter as parent of popup) (when used with _ChildWindows or _RootWindow) */
-    NoPopupHierarchy(1 shl 3),
+    object NoPopupHierarchy : WindowBase(1 shl 3)
     //ImGuiHoveredFlags_DockHierarchy               = 1 << 4,   // IsWindowHovered() only: Consider docking hierarchy (treat dockspace host as parent of docked window) (when used with _ChildWindows or _RootWindow)
 
     /** Return true even if a popup window is normally blocking access to this item/window  */
-    AllowWhenBlockedByPopup(1 shl 5),
+    object AllowWhenBlockedByPopup : General(1 shl 5)
     //AllowWhenBlockedByModal     (1 shl 6),   // Return true even if a modal popup window is normally blocking access to this item/window. FIXME-TODO: Unavailable yet.
 
     /** Return true even if an active item is blocking access to this item/window. Useful for Drag and Drop patterns.   */
-    AllowWhenBlockedByActiveItem(1 shl 7),
+    object AllowWhenBlockedByActiveItem : General(1 shl 7)
 
     /** IsItemHovered() only: Return true even if the position is obstructed or overlapped by another window,   */
-    AllowWhenOverlapped(1 shl 8),
+    object AllowWhenOverlapped : ItemBase(1 shl 8)
 
     /** IsItemHovered() only: Return true even if the item is disabled */
-    AllowWhenDisabled(1 shl 9),
+    object AllowWhenDisabled : ItemBase(1 shl 9)
 
     /** Disable using gamepad/keyboard navigation state when active, always query mouse. */
-    NoNavOverride(1 shl 10),
+    object NoNavOverride : General(1 shl 10)
 
     // Hovering delays (for tooltips)
     /** Return true after io.HoverDelayNormal elapsed (~0.30 sec) */
-    DelayNormal(1 shl 11),
+    object DelayNormal : General(1 shl 11)
 
     /** Return true after io.HoverDelayShort elapsed (~0.10 sec) */
-    DelayShort(1 shl 12),
+    object DelayShort : General(1 shl 12)
 
     /** Disable shared delay system where moving from one item to the next keeps the previous timer for a short time (standard for tooltips with long delays) */
-    NoSharedDelay(1 shl 13);
+    object NoSharedDelay : General(1 shl 13)
 
+    @GenSealedEnum
     companion object {
-        val RootAndChildWindows: HoveredFlags = RootWindow or ChildWindows
-        val RectOnly = AllowWhenBlockedByPopup or AllowWhenBlockedByActiveItem or AllowWhenOverlapped
+        val RootAndChildWindows: WindowHoveredFlags get() = RootWindow or ChildWindows
+        val RectOnly get() = AllowWhenBlockedByPopup or AllowWhenBlockedByActiveItem or AllowWhenOverlapped
     }
 }
 
 typealias DragDropFlags = Flag<DragDropFlag>
 
 /** Flags for beginDragDropSource(), acceptDragDropPayload() */
-enum class DragDropFlag(override val i: Int) : Flag<DragDropFlag> {
+sealed class DragDropFlag(override val i: Int) : FlagBase<DragDropFlag>() {
     /** Disable preview tooltip. By default, a successful call to BeginDragDropSource opens a tooltip so you can display a preview or description of the source contents. This flag disables this behavior. */
-    SourceNoPreviewTooltip(1 shl 0),
+    object SourceNoPreviewTooltip : DragDropFlag(1 shl 0)
 
     /** By default, when dragging we clear data so that IsItemHovered() will return false,
      *  to avoid subsequent user code submitting tooltips.
      *  This flag disables this behavior so you can still call IsItemHovered() on the source item. */
-    SourceNoDisableHover(1 shl 1),
+    object SourceNoDisableHover : DragDropFlag(1 shl 1)
 
     /** Disable the behavior that allows to open tree nodes and collapsing header by holding over them while dragging
      *  a source item. */
-    SourceNoHoldToOpenOthers(1 shl 2),
+    object SourceNoHoldToOpenOthers : DragDropFlag(1 shl 2)
 
     /** Allow items such as text()), Image() that have no unique identifier to be used as drag source),
      *  by manufacturing a temporary identifier based on their window-relative position.
      *  This is extremely unusual within the dear imgui ecosystem and so we made it explicit. */
-    SourceAllowNullID(1 shl 3),
+    object SourceAllowNullID : DragDropFlag(1 shl 3)
 
     /** External source (from outside of dear imgui), won't attempt to read current item/window info. Will always return true.
      *  Only one Extern source can be active simultaneously.    */
-    SourceExtern(1 shl 4),
+    object SourceExtern : DragDropFlag(1 shl 4)
 
     /** Automatically expire the payload if the source cease to be submitted (otherwise payloads are persisting while being dragged) */
-    SourceAutoExpirePayload(1 shl 5),
+    object SourceAutoExpirePayload : DragDropFlag(1 shl 5)
     // AcceptDragDropPayload() flags
     /** AcceptDragDropPayload() will returns true even before the mouse button is released.
      *  You can then call isDelivery() to test if the payload needs to be delivered. */
-    AcceptBeforeDelivery(1 shl 10),
+    object AcceptBeforeDelivery : DragDropFlag(1 shl 10)
 
     /** Do not draw the default highlight rectangle when hovering over target. */
-    AcceptNoDrawDefaultRect(1 shl 11),
+    object AcceptNoDrawDefaultRect : DragDropFlag(1 shl 11)
 
     /** Request hiding the BeginDragDropSource tooltip from the BeginDragDropTarget site. */
-    AcceptNoPreviewTooltip(1 shl 12);
+    object AcceptNoPreviewTooltip : DragDropFlag(1 shl 12)
 
+    @GenSealedEnum
     companion object {
         /** For peeking ahead and inspecting the payload before delivery. */
-        val AcceptPeekOnly: DragDropFlags = AcceptBeforeDelivery or AcceptNoDrawDefaultRect
+        val AcceptPeekOnly: DragDropFlags get() = AcceptBeforeDelivery or AcceptNoDrawDefaultRect
     }
 }
 
@@ -1026,89 +1087,213 @@ typealias KeyChord = Flag<Key>
 // Read details about the 1.87 and 1.89 transition : https://github.com/ocornut/imgui/issues/4921
 
 /** A key identifier (ImGui-side enum) */
-enum class Key(i: Int? = null) : Flag<Key> {
+sealed class Key(private val int: Int? = null) : FlagBase<Key>() {
+
     // Keyboard
-    None, Tab, LeftArrow, RightArrow, UpArrow, DownArrow, PageUp, PageDown, Home, End, Insert, Delete, Backspace, Space, Enter, Escape,
-    LeftCtrl, LeftShift, LeftAlt, LeftSuper,
-    RightCtrl, RightShift, RightAlt, RightSuper,
-    Menu,
-    `0`, `1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`, `9`,
-    A, B, C, D, E, F, G, H, I, J,
-    K, L, M, N, O, P, Q, R, S, T,
-    U, V, W, X, Y, Z,
-    F1, F2, F3, F4, F5, F6,
-    F7, F8, F9, F10, F11, F12,
+    object None : Key()
+
+    object Tab : Key()
+    object LeftArrow : Key()
+    object RightArrow : Key()
+    object UpArrow : Key()
+    object DownArrow : Key()
+    object PageUp : Key()
+    object PageDown : Key()
+    object Home : Key()
+    object End : Key()
+    object Insert : Key()
+    object Delete : Key()
+    object Backspace : Key()
+    object Space : Key()
+    object Enter : Key()
+    object Escape : Key()
+    object LeftCtrl : Key()
+    object LeftShift : Key()
+    object LeftAlt : Key()
+    object LeftSuper : Key()
+    object RightCtrl : Key()
+    object RightShift : Key()
+    object RightAlt : Key()
+    object RightSuper : Key()
+    object Menu : Key()
+    object `0` : Key()
+    object `1` : Key()
+    object `2` : Key()
+    object `3` : Key()
+    object `4` : Key()
+    object `5` : Key()
+    object `6` : Key()
+    object `7` : Key()
+    object `8` : Key()
+    object `9` : Key()
+    object A : Key()
+    object B : Key()
+    object C : Key()
+    object D : Key()
+    object E : Key()
+    object F : Key()
+    object G : Key()
+    object H : Key()
+    object I : Key()
+    object J : Key()
+    object K : Key()
+    object L : Key()
+    object M : Key()
+    object N : Key()
+    object O : Key()
+    object P : Key()
+    object Q : Key()
+    object R : Key()
+    object S : Key()
+    object T : Key()
+    object U : Key()
+    object V : Key()
+    object W : Key()
+    object X : Key()
+    object Y : Key()
+    object Z : Key()
+    object F1 : Key()
+    object F2 : Key()
+    object F3 : Key()
+    object F4 : Key()
+    object F5 : Key()
+    object F6 : Key()
+    object F7 : Key()
+    object F8 : Key()
+    object F9 : Key()
+    object F10 : Key()
+    object F11 : Key()
+    object F12 : Key()
 
     /** ' */
-    Apostrophe,
+    object Apostrophe : Key()
 
     /** , */
-    Comma,
+    object Comma : Key()
 
     /** - */
-    Minus,
+    object Minus : Key()
 
     /** . */
-    Period,
+    object Period : Key()
 
     /** / */
-    Slash,
+    object Slash : Key()
 
     /** ; */
-    Semicolon,
+    object Semicolon : Key()
 
     /** = */
-    Equal,
+    object Equal : Key()
 
     /** [ */
-    LeftBracket,
+    object LeftBracket : Key()
 
     /** \ (this text inhibit multiline comment caused by backslash) */
-    Backslash,
+    object Backslash : Key()
 
     /** ] */
-    RightBracket,
+    object RightBracket : Key()
 
     /** ` */
-    GraveAccent,
-    CapsLock, ScrollLock, NumLock, PrintScreen, Pause,
-    Keypad0, Keypad1, Keypad2, Keypad3, Keypad4,
-    Keypad5, Keypad6, Keypad7, Keypad8, Keypad9,
-    KeypadDecimal, KeypadDivide, KeypadMultiply, KeypadSubtract, KeypadAdd, KeypadEnter, KeypadEqual,
+    object GraveAccent : Key()
+
+    object CapsLock : Key()
+    object ScrollLock : Key()
+    object NumLock : Key()
+    object PrintScreen : Key()
+    object Pause : Key()
+    object Keypad0 : Key()
+    object Keypad1 : Key()
+    object Keypad2 : Key()
+    object Keypad3 : Key()
+    object Keypad4 : Key()
+    object Keypad5 : Key()
+    object Keypad6 : Key()
+    object Keypad7 : Key()
+    object Keypad8 : Key()
+    object Keypad9 : Key()
+    object KeypadDecimal : Key()
+    object KeypadDivide : Key()
+    object KeypadMultiply : Key()
+    object KeypadSubtract : Key()
+    object KeypadAdd : Key()
+    object KeypadEnter : Key()
+    object KeypadEqual : Key()
 
     // Gamepad (some of those are analog values, 0.0f to 1.0f)                         // NAVIGATION action
-    GamepadStart,          // Menu (Xbox)          + (Switch)      Start/Options (PS)  // --
-    GamepadBack,           // View (Xbox)          - (Switch)      Share (PS)          // --
-    GamepadFaceLeft,       // X (Xbox)             Y (Switch)      Square (PS)         // -> ImGuiNavInput_Menu
-    GamepadFaceRight,      // B (Xbox)             A (Switch)      Circle (PS)         // -> ImGuiNavInput_Cancel
-    GamepadFaceUp,         // Y (Xbox)             X (Switch)      Triangle (PS)       // -> ImGuiNavInput_Input
-    GamepadFaceDown,       // A (Xbox)             B (Switch)      Cross (PS)          // -> ImGuiNavInput_Activate
-    GamepadDpadLeft,       // D-pad Left                                               // -> ImGuiNavInput_DpadLeft
-    GamepadDpadRight,      // D-pad Right                                              // -> ImGuiNavInput_DpadRight
-    GamepadDpadUp,         // D-pad Up                                                 // -> ImGuiNavInput_DpadUp
-    GamepadDpadDown,       // D-pad Down                                               // -> ImGuiNavInput_DpadDown
-    GamepadL1,             // L Bumper (Xbox)      L (Switch)      L1 (PS)             // -> ImGuiNavInput_FocusPrev + ImGuiNavInput_TweakSlow
-    GamepadR1,             // R Bumper (Xbox)      R (Switch)      R1 (PS)             // -> ImGuiNavInput_FocusNext + ImGuiNavInput_TweakFast
-    GamepadL2,             // L Trigger (Xbox)     ZL (Switch)     L2 (PS) [Analog]
-    GamepadR2,             // R Trigger (Xbox)     ZR (Switch)     R2 (PS) [Analog]
-    GamepadL3,             // L Thumbstick (Xbox)  L3 (Switch)     L3 (PS)
-    GamepadR3,             // R Thumbstick (Xbox)  R3 (Switch)     R3 (PS)
-    GamepadLStickLeft,     // [Analog]                                                 // -> ImGuiNavInput_LStickLeft
-    GamepadLStickRight,    // [Analog]                                                 // -> ImGuiNavInput_LStickRight
-    GamepadLStickUp,       // [Analog]                                                 // -> ImGuiNavInput_LStickUp
-    GamepadLStickDown,     // [Analog]                                                 // -> ImGuiNavInput_LStickDown
-    GamepadRStickLeft,     // [Analog]
-    GamepadRStickRight,    // [Analog]
-    GamepadRStickUp,       // [Analog]
-    GamepadRStickDown,     // [Analog]
+    object GamepadStart : Key()          // Menu (Xbox)          + (Switch)      Start/Options (PS)  // --
+
+    object GamepadBack : Key()           // View (Xbox)          - (Switch)      Share (PS)          // --
+    object GamepadFaceLeft :
+        Key()       // X (Xbox)             Y (Switch)      Square (PS)         // -> ImGuiNavInput_Menu
+
+    object GamepadFaceRight :
+        Key()      // B (Xbox)             A (Switch)      Circle (PS)         // -> ImGuiNavInput_Cancel
+
+    object GamepadFaceUp :
+        Key()         // Y (Xbox)             X (Switch)      Triangle (PS)       // -> ImGuiNavInput_Input
+
+    object GamepadFaceDown :
+        Key()       // A (Xbox)             B (Switch)      Cross (PS)          // -> ImGuiNavInput_Activate
+
+    object GamepadDpadLeft :
+        Key()       // D-pad Left                                               // -> ImGuiNavInput_DpadLeft
+
+    object GamepadDpadRight :
+        Key()      // D-pad Right                                              // -> ImGuiNavInput_DpadRight
+
+    object GamepadDpadUp :
+        Key()         // D-pad Up                                                 // -> ImGuiNavInput_DpadUp
+
+    object GamepadDpadDown :
+        Key()       // D-pad Down                                               // -> ImGuiNavInput_DpadDown
+
+    object GamepadL1 :
+        Key()             // L Bumper (Xbox)      L (Switch)      L1 (PS)             // -> ImGuiNavInput_FocusPrev + ImGuiNavInput_TweakSlow
+
+    object GamepadR1 :
+        Key()             // R Bumper (Xbox)      R (Switch)      R1 (PS)             // -> ImGuiNavInput_FocusNext + ImGuiNavInput_TweakFast
+
+    object GamepadL2 : Key()             // L Trigger (Xbox)     ZL (Switch)     L2 (PS) [Analog]
+    object GamepadR2 : Key()             // R Trigger (Xbox)     ZR (Switch)     R2 (PS) [Analog]
+    object GamepadL3 : Key()             // L Thumbstick (Xbox)  L3 (Switch)     L3 (PS)
+    object GamepadR3 : Key()             // R Thumbstick (Xbox)  R3 (Switch)     R3 (PS)
+    object GamepadLStickLeft :
+        Key()     // [Analog]                                                 // -> ImGuiNavInput_LStickLeft
+
+    object GamepadLStickRight :
+        Key()    // [Analog]                                                 // -> ImGuiNavInput_LStickRight
+
+    object GamepadLStickUp :
+        Key()       // [Analog]                                                 // -> ImGuiNavInput_LStickUp
+
+    object GamepadLStickDown :
+        Key()     // [Analog]                                                 // -> ImGuiNavInput_LStickDown
+
+    object GamepadRStickLeft : Key()     // [Analog]
+    object GamepadRStickRight : Key()    // [Analog]
+    object GamepadRStickUp : Key()       // [Analog]
+    object GamepadRStickDown : Key()     // [Analog]
 
     // Aliases: Mouse Buttons (auto-submitted from AddMouseButtonEvent() calls)
     // - This is mirroring the data also written to io.MouseDown[], io.MouseWheel, in a format allowing them to be accessed via standard key API.
-    MouseLeft, MouseRight, MouseMiddle, MouseX1, MouseX2, MouseWheelX, MouseWheelY,
+    object MouseLeft : Key()
+
+    object MouseRight : Key()
+    object MouseMiddle : Key()
+    object MouseX1 : Key()
+    object MouseX2 : Key()
+    object MouseWheelX : Key()
+    object MouseWheelY : Key()
 
     // [Internal] Reserved for mod storage
-    ReservedForModCtrl, ReservedForModShift, ReservedForModAlt, ReservedForModSuper,
-    Count,
+    object ReservedForModCtrl : Key()
+
+    object ReservedForModShift : Key()
+    object ReservedForModAlt : Key()
+    object ReservedForModSuper : Key()
+    object Count : Key()
 
     // Keyboard Modifiers (explicitly submitted by backend via AddKeyEvent() calls)
     // - This is mirroring the data also written to io.KeyCtrl, io.KeyShift, io.KeyAlt, io.KeySuper, in a format allowing
@@ -1118,50 +1303,51 @@ enum class Key(i: Int? = null) : Flag<Key> {
     // - In theory the value of keyboard modifiers should be roughly equivalent to a logical or of the equivalent left/right keys.
     //   In practice: it's complicated; mods are often provided from different sources. Keyboard layout, IME, sticky keys and
     //   backends tend to interfere and break that equivalence. The safer decision is to relay that ambiguity down to the end-user...
-    Mod_None(0),
+    object Mod_None : Key(0)
 
     /** Alias for Ctrl (non-macOS) _or_ Super (macOS). */
-    Mod_Shortcut(1 shl 11),
+    object Mod_Shortcut : Key(1 shl 11)
 
     /** Ctrl */
-    Mod_Ctrl(1 shl 12),
+    object Mod_Ctrl : Key(1 shl 12)
 
     /** Shift */
-    Mod_Shift(1 shl 13),
+    object Mod_Shift : Key(1 shl 13)
 
     /** Option/Menu */
-    Mod_Alt(1 shl 14),
+    object Mod_Alt : Key(1 shl 14)
 
     /** Cmd/Super/Windows */
-    Mod_Super(1 shl 15);
+    object Mod_Super : Key(1 shl 15)
 
-    override val i: Int = i ?: if (ordinal == 0) 0 else 511 + ordinal
+    override val i: Int = int ?: if (ordinal == 0) 0 else 511 + ordinal
 
     val index: Int
         get() = ordinal - 1
 
+    @GenSealedEnum
     companion object {
-        val COUNT = values().size
-        val BEGIN = None
-        val END = Count
-        val Named = values().drop(1).take(Count.ordinal - 1)
-        val Data = Named
-        val Keyboard = values().drop(1).take(GamepadStart.ordinal - 1)
-        val Gamepad = values().drop(GamepadStart.ordinal).take(GamepadRStickDown.ordinal - GamepadStart.ordinal + 1)
-        val Mouse = values().drop(MouseLeft.ordinal).take(MouseWheelY.ordinal - MouseLeft.ordinal + 1)
-        val Aliases = Mouse
-        val Mod_Mask = Mod_Shortcut or Mod_Ctrl or Mod_Shift or Mod_Alt or Mod_Super
-        infix fun of(chord: KeyChord) = values().first(chord::eq)
+        val COUNT get() = values.size
+        val BEGIN: Key get() = None
+        val END: Key get() = Count
+        val Named get() = values.drop(1).take(Count.ordinal - 1)
+        val Data get() = Named
+        val Keyboard get() = values.drop(1).take(GamepadStart.ordinal - 1)
+        val Gamepad get() = values.drop(GamepadStart.ordinal).take(GamepadRStickDown.ordinal - GamepadStart.ordinal + 1)
+        val Mouse get() = values.drop(MouseLeft.ordinal).take(MouseWheelY.ordinal - MouseLeft.ordinal + 1)
+        val Aliases get() = Mouse
+        val Mod_Mask get() = Mod_Shortcut or Mod_Ctrl or Mod_Shift or Mod_Alt or Mod_Super
+        infix fun of(chord: KeyChord) = values.first { chord == it }
 
         // [Internal] Named shortcuts for Navigation
-        internal val _NavKeyboardTweakSlow = Mod_Ctrl
-        internal val _NavKeyboardTweakFast = Mod_Shift
-        internal val _NavGamepadTweakSlow = GamepadL1
-        internal val _NavGamepadTweakFast = GamepadR1
-        internal val _NavGamepadActivate = GamepadFaceDown
-        internal val _NavGamepadCancel = GamepadFaceRight
-        internal val _NavGamepadMenu = GamepadFaceLeft
-        internal val _NavGamepadInput = GamepadFaceUp
+        internal val _NavKeyboardTweakSlow get() = Mod_Ctrl
+        internal val _NavKeyboardTweakFast get() = Mod_Shift
+        internal val _NavGamepadTweakSlow get() = GamepadL1
+        internal val _NavGamepadTweakFast get() = GamepadR1
+        internal val _NavGamepadActivate get() = GamepadFaceDown
+        internal val _NavGamepadCancel get() = GamepadFaceRight
+        internal val _NavGamepadMenu get() = GamepadFaceLeft
+        internal val _NavGamepadInput get() = GamepadFaceUp
     }
 }
 
@@ -1277,43 +1463,46 @@ typealias ConfigFlags = Flag<ConfigFlag>
 /** Configuration flags stored in io.configFlags
  *
  *  Flags: for io.ConfigFlags   */
-enum class ConfigFlag(override val i: Int) : Flag<ConfigFlag> {
+sealed class ConfigFlag(override val i: Int) : FlagBase<ConfigFlag>() {
     /** Master keyboard navigation enable flag. NewFrame() will automatically fill io.NavInputs[] based on io.AddKeyEvent() calls. */
-    NavEnableKeyboard(1 shl 0),
+    object NavEnableKeyboard : ConfigFlag(1 shl 0)
 
     /** Master gamepad navigation enable flag. This is mostly to instruct your imgui backend to fill io.NavInputs[].
      *  Backend also needs to set ImGuiBackendFlags_HasGamepad. */
-    NavEnableGamepad(1 shl 1),
+    object NavEnableGamepad : ConfigFlag(1 shl 1)
 
     /** Instruct navigation to move the mouse cursor. May be useful on TV/console systems where moving a virtual mouse is awkward.
      *  Will update io.MousePos and set io.wantSetMousePos=true. If enabled you MUST honor io.wantSetMousePos requests in your backend,
      *  otherwise ImGui will react as if the mouse is jumping around back and forth. */
-    NavEnableSetMousePos(1 shl 2),
+    object NavEnableSetMousePos : ConfigFlag(1 shl 2)
 
     /** Instruct navigation to not set the io.WantCaptureKeyboard flag when io.NavActive is set. */
-    NavNoCaptureKeyboard(1 shl 3),
+    object NavNoCaptureKeyboard : ConfigFlag(1 shl 3)
 
     /** Instruct imgui to clear mouse position/buttons in NewFrame(). This allows ignoring the mouse information set by the backend. */
-    NoMouse(1 shl 4),
+    object NoMouse : ConfigFlag(1 shl 4)
 
     /** Request backend to not alter mouse cursor configuration.
      *  Use if the backend cursor changes are interfering with yours and you don't want to use setMouseCursor() to change mouse cursor.
      *  You may want to honor requests from imgui by reading ::mouseCursor yourself instead. */
-    NoMouseCursorChange(1 shl 5),
+    object NoMouseCursorChange : ConfigFlag(1 shl 5)
 
     /** JVM custom, request backend to not read the mouse status allowing you to provide your own custom input */
-    NoMouseUpdate(1 shl 12),
+    object NoMouseUpdate : ConfigFlag(1 shl 12)
 
     /** JVM custom */
-    NoKeyboardUpdate(1 shl 13),
+    object NoKeyboardUpdate : ConfigFlag(1 shl 13)
 
     // User storage (to allow your backend/engine to communicate to code that may be shared between multiple projects. Those flags are NOT used by core Dear ImGui)
 
     /** Application is SRGB-aware. */
-    IsSRGB(1 shl 20),
+    object IsSRGB : ConfigFlag(1 shl 20)
 
     /** Application is using a touch screen instead of a mouse. */
-    IsTouchScreen(1 shl 21)
+    object IsTouchScreen : ConfigFlag(1 shl 21)
+
+    @GenSealedEnum
+    companion object
 }
 
 
@@ -1322,21 +1511,23 @@ typealias BackendFlags = Flag<BackendFlag>
 /** Backend capabilities flags stored in io.BackendFlag. Set by imgui_impl_xxx or custom backend.
  *
  *  Flags: for io.BackendFlags  */
-enum class BackendFlag : Flag<BackendFlag> {
+sealed class BackendFlag : FlagBase<BackendFlag>() {
+    override val i: Int = 1 shl ordinal
 
     /** Backend Platform supports gamepad and currently has one connected. */
-    HasGamepad,
+    object HasGamepad : BackendFlag()
 
     /** Backend Platform supports honoring GetMouseCursor() value to change the OS cursor shape. */
-    HasMouseCursors,
+    object HasMouseCursors : BackendFlag()
 
     /** Backend Platform supports io.WantSetMousePos requests to reposition the OS mouse position (only used if ImGuiConfigFlags_NavEnableSetMousePos is set). */
-    HasSetMousePos,
+    object HasSetMousePos : BackendFlag()
 
     /** Backend Platform supports ImDrawCmd::VtxOffset. This enables output of large meshes (64K+ vertices) while still using 16-bit indices. */
-    RendererHasVtxOffset;
+    object RendererHasVtxOffset : BackendFlag()
 
-    override val i: Int = 1 shl ordinal
+    @GenSealedEnum
+    companion object
 }
 
 /** Enumeration for PushStyleColor() / PopStyleColor()  */
@@ -1543,90 +1734,91 @@ typealias ColorEditFlags = Flag<ColorEditFlag>
 /** Flags for ColorEdit3() / ColorEdit4() / ColorPicker3() / ColorPicker4() / ColorButton()
  *
  *  Flags: for ColorEdit4(), ColorPicker4() etc.    */
-enum class ColorEditFlag(override val i: Int) : Flag<ColorEditFlag> {
+sealed class ColorEditFlag(override val i: Int) : FlagBase<ColorEditFlag>() {
     /** ColorEdit, ColorPicker, ColorButton: ignore Alpha component (will only read 3 components from the input pointer). */
-    NoAlpha(1 shl 1),
+    object NoAlpha : ColorEditFlag(1 shl 1)
 
     /** ColorEdit: disable picker when clicking on color square.  */
-    NoPicker(1 shl 2),
+    object NoPicker : ColorEditFlag(1 shl 2)
 
     /** ColorEdit: disable toggling options menu when right-clicking on inputs/small preview.   */
-    NoOptions(1 shl 3),
+    object NoOptions : ColorEditFlag(1 shl 3)
 
     /** ColorEdit, ColorPicker: disable color square preview next to the inputs. (e.g. to show only the inputs)   */
-    NoSmallPreview(1 shl 4),
+    object NoSmallPreview : ColorEditFlag(1 shl 4)
 
     /** ColorEdit, ColorPicker: disable inputs sliders/text widgets (e.g. to show only the small preview color square).   */
-    NoInputs(1 shl 5),
+    object NoInputs : ColorEditFlag(1 shl 5)
 
     /** ColorEdit, ColorPicker, ColorButton: disable tooltip when hovering the preview. */
-    NoTooltip(1 shl 6),
+    object NoTooltip : ColorEditFlag(1 shl 6)
 
     /** ColorEdit, ColorPicker: disable display of inline text label (the label is still forwarded to the tooltip and picker).  */
-    NoLabel(1 shl 7),
+    object NoLabel : ColorEditFlag(1 shl 7)
 
     /** ColorPicker: disable bigger color preview on right side of the picker, use small color square preview instead.    */
-    NoSidePreview(1 shl 8),
+    object NoSidePreview : ColorEditFlag(1 shl 8)
 
     /** ColorEdit: disable drag and drop target. ColorButton: disable drag and drop source. */
-    NoDragDrop(1 shl 9),
+    object NoDragDrop : ColorEditFlag(1 shl 9)
 
     /** ColorButton: disable border (which is enforced by default) */
-    NoBorder(1 shl 10),
+    object NoBorder : ColorEditFlag(1 shl 10)
 
     // User Options (right-click on widget to change some of them).
 
     /** ColorEdit, ColorPicker: show vertical alpha bar/gradient in picker. */
-    AlphaBar(1 shl 16),
+    object AlphaBar : ColorEditFlag(1 shl 16)
 
     /** ColorEdit, ColorPicker, ColorButton: display preview as a transparent color over a checkerboard, instead of opaque. */
-    AlphaPreview(1 shl 17),
+    object AlphaPreview : ColorEditFlag(1 shl 17)
 
     /** ColorEdit, ColorPicker, ColorButton: display half opaque / half checkerboard, instead of opaque.    */
-    AlphaPreviewHalf(1 shl 18),
+    object AlphaPreviewHalf : ColorEditFlag(1 shl 18)
 
     /** (WIP) ColorEdit: Currently only disable 0.0f..1.0f limits in RGBA edition (note: you probably want to use
      *  ColorEditFlags.Float flag as well). */
-    HDR(1 shl 19),
+    object HDR : ColorEditFlag(1 shl 19)
 
     /** [Display] ColorEdit: override _display_ type among RGB/HSV/Hex. ColorPicker: select any combination using one or more of RGB/HSV/Hex.    */
-    DisplayRGB(1 shl 20),
+    object DisplayRGB : ColorEditFlag(1 shl 20)
 
     /** [Display] ColorEdit: override _display_ type among RGB/HSV/Hex. ColorPicker: select any combination using one or more of RGB/HSV/Hex.    */
-    DisplayHSV(1 shl 21),
+    object DisplayHSV : ColorEditFlag(1 shl 21)
 
     /** [Display] ColorEdit: override _display_ type among RGB/HSV/Hex. ColorPicker: select any combination using one or more of RGB/HSV/Hex.    */
-    DisplayHEX(1 shl 22),
+    object DisplayHEX : ColorEditFlag(1 shl 22)
 
     /** [DataType] ColorEdit, ColorPicker, ColorButton: _display_ values formatted as 0..255.   */
-    Uint8(1 shl 23),
+    object Uint8 : ColorEditFlag(1 shl 23)
 
     /** [DataType] ColorEdit, ColorPicker, ColorButton: _display_ values formatted as 0.0f..1.0f floats instead of 0..255 integers.
      *  No round-trip of value via integers.    */
-    Float(1 shl 24),
+    object Float : ColorEditFlag(1 shl 24)
 
     /** [Picker]     // ColorPicker: bar for Hue, rectangle for Sat/Value. */
-    PickerHueBar(1 shl 25),
+    object PickerHueBar : ColorEditFlag(1 shl 25)
 
     /** [Picker]     // ColorPicker: wheel for Hue, triangle for Sat/Value. */
-    PickerHueWheel(1 shl 26),
+    object PickerHueWheel : ColorEditFlag(1 shl 26)
 
     /** [Input]      // ColorEdit, ColorPicker: input and output data in RGB format. */
-    InputRGB(1 shl 27),
+    object InputRGB : ColorEditFlag(1 shl 27)
 
     /** [Input]      // ColorEdit, ColorPicker: input and output data in HSV format. */
-    InputHSV(1 shl 28);
+    object InputHSV : ColorEditFlag(1 shl 28)
 
+    @GenSealedEnum
     companion object {
         /** Defaults Options. You can set application defaults using SetColorEditOptions(). The intent is that you probably don't want to
          *  override them in most of your calls. Let the user choose via the option menu and/or call SetColorEditOptions() once during startup. */
-        val DefaultOptions: ColorEditFlags = Uint8 or DisplayRGB or InputRGB or PickerHueBar
+        val DefaultOptions: ColorEditFlags get() = Uint8 or DisplayRGB or InputRGB or PickerHueBar
 
         // [Internal] Masks
-        val _DisplayMask: ColorEditFlags = DisplayRGB or DisplayHSV or DisplayHEX
-        val _DataTypeMask: ColorEditFlags = Uint8 or Float
-        val _PickerMask: ColorEditFlags = PickerHueWheel or PickerHueBar
-        val _InputMask: ColorEditFlags = InputRGB or InputHSV
+        val _DisplayMask: ColorEditFlags get() = DisplayRGB or DisplayHSV or DisplayHEX
+        val _DataTypeMask: ColorEditFlags get() = Uint8 or Float
+        val _PickerMask: ColorEditFlags get() = PickerHueWheel or PickerHueBar
+        val _InputMask: ColorEditFlags get() = InputRGB or InputHSV
     }
 }
 
@@ -1636,23 +1828,26 @@ enum class ColorEditFlag(override val i: Int) : Flag<ColorEditFlag> {
  *  (Those are per-item flags. There are shared flags in ImGuiIO: io.ConfigDragClickToInputText) */
 typealias SliderFlags = Flag<SliderFlag>
 
-enum class SliderFlag(override val i: Int) : Flag<SliderFlag> {
+sealed class SliderFlag(override val i: Int) : FlagBase<SliderFlag>() {
+
     /** Clamp value to min/max bounds when input manually with CTRL+Click. By default CTRL+Click allows going out of bounds. */
-    AlwaysClamp(1 shl 4),
+    object AlwaysClamp : SliderFlag(1 shl 4)
 
     /** Make the widget logarithmic (linear otherwise). Consider using ImGuiDragFlags_NoRoundToFormat with this if using a format-string with small amount of digits. */
-    Logarithmic(1 shl 5),
+    object Logarithmic : SliderFlag(1 shl 5)
 
     /** Disable rounding underlying value to match precision of the display format string (e.g. %.3f values are rounded to those 3 digits) */
-    NoRoundToFormat(1 shl 6),
+    object NoRoundToFormat : SliderFlag(1 shl 6)
 
     /** Disable CTRL+Click or Enter key allowing to input text directly into the widget */
-    NoInput(1 shl 7),
+    object NoInput : SliderFlag(1 shl 7)
 
     /** [Private] Should this widget be orientated vertically? */
-    _Vertical(1 shl 20),
+    object _Vertical : SliderFlag(1 shl 20)
+    object _ReadOnly : SliderFlag(1 shl 21)
 
-    _ReadOnly(1 shl 21);
+    @GenSealedEnum
+    companion object
 }
 
 /** Identify a mouse button. */
@@ -1720,21 +1915,25 @@ typealias CondFlags = Flag<Cond>
  *  All the functions above treat 0 as a shortcut to Cond.Always.
  *
  *  Enum: A condition for many Set*() functions */
-enum class Cond : Flag<Cond> {
-    /** No condition (always set the variable), same as Always */
-    None,
-
-    /** No condition (always set the variable), same as None */
-    Always,
-
-    /** Set the variable once per runtime session (only the first call will succeed)    */
-    Once,
-
-    /** Set the variable if the object/window has no persistently saved data (no entry in .ini file)    */
-    FirstUseEver,
-
-    /** Set the variable if the object/window is appearing after being hidden/inactive (or the first time) */
-    Appearing;
+sealed class Cond : FlagBase<Cond>() {
 
     override val i: Int = if (ordinal == 0) 0 else 1 shl (ordinal - 1)
+
+    /** No condition (always set the variable), same as Always */
+    object None : Cond()
+
+    /** No condition (always set the variable), same as None */
+    object Always : Cond()
+
+    /** Set the variable once per runtime session (only the first call will succeed)    */
+    object Once : Cond()
+
+    /** Set the variable if the object/window has no persistently saved data (no entry in .ini file)    */
+    object FirstUseEver : Cond()
+
+    /** Set the variable if the object/window is appearing after being hidden/inactive (or the first time) */
+    object Appearing : Cond()
+
+    @GenSealedEnum
+    companion object
 }

--- a/core/src/main/kotlin/imgui/font/FontAtlas.kt
+++ b/core/src/main/kotlin/imgui/font/FontAtlas.kt
@@ -1,5 +1,6 @@
 package imgui.font
 
+import com.livefront.sealedenum.GenSealedEnum
 import gli_.has
 import glm_.*
 import glm_.vec2.Vec2
@@ -370,21 +371,24 @@ class FontAtlas {
     //-------------------------------------------
 
     /** Flags: for ImFontAtlas build */
-    enum class Flag : imgui.Flag<Flag> {
+    sealed class Flag : FlagBase<Flag>() {
         /** Don't round the height to next power of two */
-        NoPowerOfTwoHeight,
+        object NoPowerOfTwoHeight : Flag()
 
         /** Don't build software mouse cursors into the atlas (save a little texture memory) */
-        NoMouseCursors,
+        object NoMouseCursors : Flag()
 
         /** Don't build thick line textures into the atlas (save a little texture memory, allow support for point/nearest filtering). The AntiAliasedLinesUseTex features uses them, otherwise they will be rendered using polygons (more expensive for CPU/GPU). */
-        NoBakedLines;
+        object NoBakedLines : Flag()
 
-        override val i = 1 shl ordinal
+        override val i: Int = 1 shl ordinal
+
+        @GenSealedEnum
+        companion object
     }
 
     /** Build flags (see ImFontAtlasFlags_) */
-    var flags: FontAtlasFlags = emptyFlags()
+    var flags: FontAtlasFlags = emptyFlags
 
     /** User data to refer to the texture once it has been uploaded to user's graphic systems. It is passed back to you
     during rendering via the DrawCmd structure.   */
@@ -827,7 +831,7 @@ class FontAtlas {
                 val q = AlignedQuad()
                 getPackedQuad(srcTmp.packedChars, texSize.x, texSize.y, glyphIdx, q = q)
                 dstFont.addGlyph(cfg, codepoint, q.x0 + fontOff.x, q.y0 + fontOff.y,
-                                 q.x1 + fontOff.x, q.y1 + fontOff.y, q.s0, q.t0, q.s1, q.t1, pc.xAdvance)
+                    q.x1 + fontOff.x, q.y1 + fontOff.y, q.s0, q.t0, q.s1, q.t1, pc.xAdvance)
             }
         }
 //        bufPackedchars.free()
@@ -926,7 +930,7 @@ class FontAtlas {
             val uv1 = Vec2()
             calcCustomRectUV(r, uv0, uv1)
             font.addGlyph(null, r.glyphID, r.glyphOffset.x, r.glyphOffset.y, r.glyphOffset.x + r.width, r.glyphOffset.y + r.height,
-                          uv0.x, uv0.y, uv1.x, uv1.y, r.glyphAdvanceX)
+                uv0.x, uv0.y, uv1.x, uv1.y, r.glyphAdvanceX)
         }
         // Build all fonts lookup tables
         fonts.filter { it.dirtyLookupTables }.forEach { it.buildLookupTable() }

--- a/core/src/main/kotlin/imgui/font/FontAtlas.kt
+++ b/core/src/main/kotlin/imgui/font/FontAtlas.kt
@@ -20,6 +20,7 @@ import unsigned.toUInt
 import java.nio.ByteBuffer
 import kotlin.math.sqrt
 
+typealias FontAtlasFlags = Flag<FontAtlas.Flag>
 /** Load and rasterize multiple TTF/OTF fonts into a same texture. The font atlas will build a single texture holding:
  *      - One or more fonts.
  *      - Custom graphics data needed to render the shapes needed by Dear ImGui.
@@ -369,9 +370,7 @@ class FontAtlas {
     //-------------------------------------------
 
     /** Flags: for ImFontAtlas build */
-    enum class Flag {
-        None,
-
+    enum class Flag : imgui.Flag<Flag> {
         /** Don't round the height to next power of two */
         NoPowerOfTwoHeight,
 
@@ -381,14 +380,11 @@ class FontAtlas {
         /** Don't build thick line textures into the atlas (save a little texture memory, allow support for point/nearest filtering). The AntiAliasedLinesUseTex features uses them, otherwise they will be rendered using polygons (more expensive for CPU/GPU). */
         NoBakedLines;
 
-        val i = if (ordinal == 0) 0 else 1 shl (ordinal - 1)
+        override val i = 1 shl ordinal
     }
 
-    infix fun Int.has(flag: Flag) = and(flag.i) != 0
-    infix fun Int.hasnt(flag: Flag) = and(flag.i) == 0
-
     /** Build flags (see ImFontAtlasFlags_) */
-    var flags = Flag.None.i
+    var flags: FontAtlasFlags = emptyFlags()
 
     /** User data to refer to the texture once it has been uploaded to user's graphic systems. It is passed back to you
     during rendering via the DrawCmd structure.   */
@@ -1028,7 +1024,7 @@ class FontAtlas {
 
         fun buildRenderLinesTexData(atlas: FontAtlas) {
 
-            if (atlas.flags has Flag.NoBakedLines.i)
+            if (atlas.flags has Flag.NoBakedLines)
                 return
 
             // This generates a triangular shape in the texture, with the various line widths stacked on top of each other to allow interpolation between them

--- a/core/src/main/kotlin/imgui/internal/api/basicAccessors.kt
+++ b/core/src/main/kotlin/imgui/internal/api/basicAccessors.kt
@@ -5,8 +5,8 @@ import imgui.ID
 import imgui.ImGui.debugHookIdInfo
 import imgui.ImGui.rectAbsToRel
 import imgui.ImGui.setNavWindow
+import imgui.MouseButton
 import imgui.api.g
-import imgui.div
 import imgui.internal.classes.Window
 import imgui.internal.hashStr
 import imgui.internal.sections.*
@@ -47,7 +47,7 @@ internal interface basicAccessors {
             g.activeIdTimer = 0f
             g.activeIdHasBeenPressedBefore = false
             g.activeIdHasBeenEditedBefore = false
-            g.activeIdMouseButton = -1
+            g.activeIdMouseButton = MouseButton.None
             if (id != 0) {
                 g.lastActiveId = id
                 g.lastActiveIdTimer = 0f

--- a/core/src/main/kotlin/imgui/internal/api/basicAccessors.kt
+++ b/core/src/main/kotlin/imgui/internal/api/basicAccessors.kt
@@ -7,6 +7,7 @@ import imgui.ImGui.rectAbsToRel
 import imgui.ImGui.setNavWindow
 import imgui.MouseButton
 import imgui.api.g
+import imgui.div
 import imgui.internal.classes.Window
 import imgui.internal.hashStr
 import imgui.internal.sections.*

--- a/core/src/main/kotlin/imgui/internal/api/basicHelpersForWidgetCode.kt
+++ b/core/src/main/kotlin/imgui/internal/api/basicHelpersForWidgetCode.kt
@@ -82,7 +82,7 @@ internal interface basicHelpersForWidgetCode {
     /** Declare item bounding box for clipping and interaction.
      *  Note that the size can be different than the one provided to ItemSize(). Typically, widgets that spread over available surface
      *  declare their minimum size requirement to ItemSize() and provide a larger region to ItemAdd() which is used drawing/interaction. */
-    fun itemAdd(bb: Rect, id: ID, navBbArg: Rect? = null, extraFlags: ItemFlags = 0): Boolean {
+    fun itemAdd(bb: Rect, id: ID, navBbArg: Rect? = null, extraFlags: ItemFlags = emptyFlags()): Boolean {
 
         val window = g.currentWindow!!
 
@@ -92,7 +92,7 @@ internal interface basicHelpersForWidgetCode {
         g.lastItemData.rect put bb
         g.lastItemData.navRect put (navBbArg ?: bb)
         g.lastItemData.inFlags = g.currentItemFlags or extraFlags
-        g.lastItemData.statusFlags = ItemStatusFlag.None.i
+        g.lastItemData.statusFlags = emptyFlags()
 
         // Directional navigation processing
         if (id != 0) {
@@ -120,7 +120,7 @@ internal interface basicHelpersForWidgetCode {
             // READ THE FAQ: https://dearimgui.org/faq
             assert(id != window.id) { "Cannot have an empty ID at the root of a window. If you need an empty label, use ## and read the FAQ about how the ID Stack works!" }
         }
-        g.nextItemData.flags = NextItemDataFlag.None.i
+        g.nextItemData.flags = emptyFlags()
 
         if (IMGUI_ENABLE_TEST_ENGINE && id != 0)
             IMGUI_TEST_ENGINE_ITEM_ADD(navBbArg ?: bb, id)
@@ -167,7 +167,7 @@ internal interface basicHelpersForWidgetCode {
 
         // Done with rectangle culling so we can perform heavier checks now.
         val itemFlags = if (g.lastItemData.id == id) g.lastItemData.inFlags else g.currentItemFlags
-        if (itemFlags hasnt ItemFlag.NoWindowHoverableCheck && !window.isContentHoverable(HoveredFlag.None)) {
+        if (itemFlags hasnt ItemFlag.NoWindowHoverableCheck && !window.isContentHoverable) {
             g.hoveredIdDisabled = true
             return false
         }

--- a/core/src/main/kotlin/imgui/internal/api/basicHelpersForWidgetCode.kt
+++ b/core/src/main/kotlin/imgui/internal/api/basicHelpersForWidgetCode.kt
@@ -82,7 +82,7 @@ internal interface basicHelpersForWidgetCode {
     /** Declare item bounding box for clipping and interaction.
      *  Note that the size can be different than the one provided to ItemSize(). Typically, widgets that spread over available surface
      *  declare their minimum size requirement to ItemSize() and provide a larger region to ItemAdd() which is used drawing/interaction. */
-    fun itemAdd(bb: Rect, id: ID, navBbArg: Rect? = null, extraFlags: ItemFlags = emptyFlags()): Boolean {
+    fun itemAdd(bb: Rect, id: ID, navBbArg: Rect? = null, extraFlags: ItemFlags = emptyFlags): Boolean {
 
         val window = g.currentWindow!!
 
@@ -92,7 +92,7 @@ internal interface basicHelpersForWidgetCode {
         g.lastItemData.rect put bb
         g.lastItemData.navRect put (navBbArg ?: bb)
         g.lastItemData.inFlags = g.currentItemFlags or extraFlags
-        g.lastItemData.statusFlags = emptyFlags()
+        g.lastItemData.statusFlags = emptyFlags
 
         // Directional navigation processing
         if (id != 0) {
@@ -120,7 +120,7 @@ internal interface basicHelpersForWidgetCode {
             // READ THE FAQ: https://dearimgui.org/faq
             assert(id != window.id) { "Cannot have an empty ID at the root of a window. If you need an empty label, use ## and read the FAQ about how the ID Stack works!" }
         }
-        g.nextItemData.flags = emptyFlags()
+        g.nextItemData.flags = emptyFlags
 
         if (IMGUI_ENABLE_TEST_ENGINE && id != 0)
             IMGUI_TEST_ENGINE_ITEM_ADD(navBbArg ?: bb, id)

--- a/core/src/main/kotlin/imgui/internal/api/color.kt
+++ b/core/src/main/kotlin/imgui/internal/api/color.kt
@@ -3,8 +3,7 @@ package imgui.internal.api
 import glm_.glm
 import glm_.vec2.Vec2
 import glm_.vec4.Vec4
-import imgui.*
-import imgui.ColorEditFlag as Cef
+import imgui.ColorEditFlags
 import imgui.ImGui.beginPopup
 import imgui.ImGui.beginTooltipEx
 import imgui.ImGui.button
@@ -30,8 +29,10 @@ import imgui.ImGui.style
 import imgui.ImGui.text
 import imgui.ImGui.textEx
 import imgui.api.g
+import imgui.flagArrayOf
 import imgui.internal.F32_TO_INT8_SAT
 import imgui.internal.sections.TooltipFlag
+import imgui.ColorEditFlag as Cef
 
 /** Color */
 internal interface color {
@@ -39,7 +40,7 @@ internal interface color {
     /** Note: only access 3 floats if ColorEditFlag.NoAlpha flag is set.   */
     fun colorTooltip(text: String, col: FloatArray, flags: ColorEditFlags) {
 
-        beginTooltipEx(TooltipFlag.OverridePreviousTooltip.i, WindowFlag.None.i)
+        beginTooltipEx(TooltipFlag.OverridePreviousTooltip)
         val textEnd = if (text.isEmpty()) findRenderedTextEnd(text) else 0
         if (textEnd > 0) {
             textEx(text, textEnd)
@@ -135,7 +136,8 @@ internal interface color {
                 if (pickerType == 0) pickerFlags = pickerFlags or Cef.PickerHueBar
                 if (pickerType == 1) pickerFlags = pickerFlags or Cef.PickerHueWheel
                 val backupPos = Vec2(cursorScreenPos)
-                if (selectable("##selectable", false, 0, pickerSize)) // By default, Selectable() is closing popup
+                // By default, Selectable() is closing popup
+                if (selectable("##selectable", false, sizeArg = pickerSize))
                     g.colorEditOptions = (g.colorEditOptions wo Cef._PickerMask) or (pickerFlags and Cef._PickerMask)
                 cursorScreenPos = backupPos
                 val previewingRefCol = Vec4()
@@ -148,8 +150,8 @@ internal interface color {
         }
         if (allowOptAlphaBar) {
             if (allowOptPicker) separator()
-            val pI = intArrayOf(g.colorEditOptions)
-            checkboxFlags("Alpha Bar", pI, Cef.AlphaBar.i)
+            val pI = flagArrayOf(g.colorEditOptions)
+            checkboxFlags("Alpha Bar", pI, Cef.AlphaBar)
             g.colorEditOptions = pI[0]
         }
         endPopup()

--- a/core/src/main/kotlin/imgui/internal/api/color.kt
+++ b/core/src/main/kotlin/imgui/internal/api/color.kt
@@ -3,7 +3,7 @@ package imgui.internal.api
 import glm_.glm
 import glm_.vec2.Vec2
 import glm_.vec4.Vec4
-import imgui.ColorEditFlags
+import imgui.*
 import imgui.ImGui.beginPopup
 import imgui.ImGui.beginTooltipEx
 import imgui.ImGui.button
@@ -29,7 +29,6 @@ import imgui.ImGui.style
 import imgui.ImGui.text
 import imgui.ImGui.textEx
 import imgui.api.g
-import imgui.flagArrayOf
 import imgui.internal.F32_TO_INT8_SAT
 import imgui.internal.sections.TooltipFlag
 import imgui.ColorEditFlag as Cef

--- a/core/src/main/kotlin/imgui/internal/api/combos.kt
+++ b/core/src/main/kotlin/imgui/internal/api/combos.kt
@@ -9,10 +9,11 @@ import imgui.ImGui.popupAllowedExtentRect
 import imgui.ImGui.pushClipRect
 import imgui.api.g
 import imgui.api.widgetsComboBox
-import imgui.hasnt
 import imgui.internal.classes.Rect
-import imgui.internal.isPowerOfTwo
-import imgui.internal.sections.*
+import imgui.internal.sections.ItemStatusFlag
+import imgui.internal.sections.LayoutType
+import imgui.internal.sections.NextWindowDataFlag
+import imgui.internal.sections.PopupPositionPolicy
 
 
 // Combos
@@ -22,7 +23,7 @@ internal interface combos {
 
         var flags = flags_
 
-        if (!ImGui.isPopupOpen(popupId, PopupFlag.None.i)) {
+        if (!ImGui.isPopupOpen(popupId)) {
             g.nextWindowData.clearFlags()
             return false
         }
@@ -32,9 +33,9 @@ internal interface combos {
         if (g.nextWindowData.flags has NextWindowDataFlag.HasSizeConstraint)
             g.nextWindowData.sizeConstraintRect.min.x = g.nextWindowData.sizeConstraintRect.min.x max w
         else {
-            if (flags hasnt ComboFlag.HeightMask_)
+            if (flags hasnt ComboFlag.HeightMask)
                 flags = flags or ComboFlag.HeightRegular
-            assert((flags and ComboFlag.HeightMask_).isPowerOfTwo) { "Only one" }
+            assert((flags and ComboFlag.HeightMask).isPowerOfTwo) { "Only one" }
             val popupMaxHeightInItems = when {
                 flags has ComboFlag.HeightRegular -> 8
                 flags has ComboFlag.HeightSmall -> 4

--- a/core/src/main/kotlin/imgui/internal/api/debugLog.kt
+++ b/core/src/main/kotlin/imgui/internal/api/debugLog.kt
@@ -1,6 +1,7 @@
 package imgui.internal.api
 
 import imgui.api.g
+import imgui.has
 import imgui.internal.classes.DebugLogFlag
 import imgui.internal.sections.IMGUI_DEBUG_PRINTF
 

--- a/core/src/main/kotlin/imgui/internal/api/debugLog.kt
+++ b/core/src/main/kotlin/imgui/internal/api/debugLog.kt
@@ -1,7 +1,6 @@
 package imgui.internal.api
 
 import imgui.api.g
-import imgui.has
 import imgui.internal.classes.DebugLogFlag
 import imgui.internal.sections.IMGUI_DEBUG_PRINTF
 

--- a/core/src/main/kotlin/imgui/internal/api/debugTools.kt
+++ b/core/src/main/kotlin/imgui/internal/api/debugTools.kt
@@ -554,11 +554,11 @@ internal interface debugTools {
     companion object {
         fun debugNodeTableGetSizingPolicyDesc(sizingPolicy: TableFlags): String {
             val flag = sizingPolicy and TableFlag._SizingMask
-            return when {
-                flag eq TableFlag.SizingFixedFit -> "FixedFit"
-                flag eq TableFlag.SizingFixedSame -> "FixedSame"
-                flag eq TableFlag.SizingStretchProp -> "StretchProp"
-                flag eq TableFlag.SizingStretchSame -> "StretchSame"
+            return when (flag) {
+                TableFlag.SizingFixedFit -> "FixedFit"
+                TableFlag.SizingFixedSame -> "FixedSame"
+                TableFlag.SizingStretchProp -> "StretchProp"
+                TableFlag.SizingStretchSame -> "StretchSame"
                 else -> "N/A"
             }
         }
@@ -685,7 +685,7 @@ internal interface debugTools {
         }
 
         val isActive = window.wasActive
-        val treeNodeFlags = if (window === g.navWindow) TreeNodeFlag.Selected else emptyFlags()
+        val treeNodeFlags = if (window === g.navWindow) TreeNodeFlag.Selected else emptyFlags
         if (!isActive)
             pushStyleColor(Col.Text, getStyleColorVec4(Col.TextDisabled))
         val open = treeNodeEx(label, treeNodeFlags, "$label '${window.name}'${if (isActive) "" else " *Inactive*"}")

--- a/core/src/main/kotlin/imgui/internal/api/debugTools.kt
+++ b/core/src/main/kotlin/imgui/internal/api/debugTools.kt
@@ -362,7 +362,7 @@ internal interface debugTools {
                     if (/*fgDrawList != null &&*/ isItemHovered()) {
                         val backupFlags = fgDrawList.flags
                         fgDrawList.flags = fgDrawList.flags wo DrawListFlag.AntiAliasedLines // Disable AA on triangle outlines is more readable for very large and thin triangles.
-                        fgDrawList.addPolyline(triangle.asList(), COL32(255, 255, 0, 255), DrawFlag.Closed.i, 1f)
+                        fgDrawList.addPolyline(triangle.asList(), COL32(255, 255, 0, 255), DrawFlag.Closed, 1f)
                         fgDrawList.flags = backupFlags
                     }
                 }
@@ -395,7 +395,7 @@ internal interface debugTools {
                 idxN++
             }
             if (showMesh)
-                outDrawList.addPolyline(triangle.asList(), COL32(255, 255, 0, 255), DrawFlag.Closed.i, 1f) // In yellow: mesh triangles
+                outDrawList.addPolyline(triangle.asList(), COL32(255, 255, 0, 255), DrawFlag.Closed, 1f) // In yellow: mesh triangles
         }
         // Draw bounding boxes
         if (showAabb) {
@@ -552,14 +552,16 @@ internal interface debugTools {
     }
 
     companion object {
-        fun debugNodeTableGetSizingPolicyDesc(sizingPolicy: TableFlags): String =
-            when (sizingPolicy and TableFlag._SizingMask) {
-                TableFlag.SizingFixedFit.i -> "FixedFit"
-                TableFlag.SizingFixedSame.i -> "FixedSame"
-                TableFlag.SizingStretchProp.i -> "StretchProp"
-                TableFlag.SizingStretchSame.i -> "StretchSame"
+        fun debugNodeTableGetSizingPolicyDesc(sizingPolicy: TableFlags): String {
+            val flag = sizingPolicy and TableFlag._SizingMask
+            return when {
+                flag eq TableFlag.SizingFixedFit -> "FixedFit"
+                flag eq TableFlag.SizingFixedSame -> "FixedSame"
+                flag eq TableFlag.SizingStretchProp -> "StretchProp"
+                flag eq TableFlag.SizingStretchSame -> "StretchSame"
                 else -> "N/A"
             }
+        }
 
         /** Avoid naming collision with imgui_demo.cpp's HelpMarker() for unity builds. */
         fun metricsHelpMarker(desc: String) {
@@ -683,10 +685,10 @@ internal interface debugTools {
         }
 
         val isActive = window.wasActive
-        val treeNodeFlags = if (window === g.navWindow) TreeNodeFlag.Selected else TreeNodeFlag.None
+        val treeNodeFlags = if (window === g.navWindow) TreeNodeFlag.Selected else emptyFlags()
         if (!isActive)
             pushStyleColor(Col.Text, getStyleColorVec4(Col.TextDisabled))
-        val open = treeNodeEx(label, treeNodeFlags.i, "$label '${window.name}'${if (isActive) "" else " *Inactive*"}")
+        val open = treeNodeEx(label, treeNodeFlags, "$label '${window.name}'${if (isActive) "" else " *Inactive*"}")
         if (!isActive)
             popStyleColor()
         if (isItemHovered() && isActive)
@@ -836,7 +838,7 @@ internal interface debugTools {
             drawList.addRect(keyMin, keyMax, COL32(24, 24, 24, 255), keyRounding)
             val faceMin = Vec2(keyMin.x + keyFacePos.x, keyMin.y + keyFacePos.y)
             val faceMax = Vec2(faceMin.x + keyFaceSize.x, faceMin.y + keyFaceSize.y)
-            drawList.addRect(faceMin, faceMax, COL32(193, 193, 193, 255), keyFaceRounding, DrawFlag.None.i, 2f)
+            drawList.addRect(faceMin, faceMax, COL32(193, 193, 193, 255), keyFaceRounding, thickness = 2f)
             drawList.addRectFilled(faceMin, faceMax, COL32(252, 252, 252, 255), keyFaceRounding)
             val labelMin = Vec2(keyMin.x + keyLabelPos.x, keyMin.y + keyLabelPos.y)
             drawList.addText(labelMin, COL32(64, 64, 64, 255), keyData.label)

--- a/core/src/main/kotlin/imgui/internal/api/disabling.kt
+++ b/core/src/main/kotlin/imgui/internal/api/disabling.kt
@@ -1,9 +1,6 @@
 package imgui.internal.api
 
 import imgui.api.g
-import imgui.div
-import imgui.has
-import imgui.hasnt
 import imgui.internal.sections.ItemFlag
 
 // Disabling [BETA API]

--- a/core/src/main/kotlin/imgui/internal/api/disabling.kt
+++ b/core/src/main/kotlin/imgui/internal/api/disabling.kt
@@ -1,6 +1,9 @@
 package imgui.internal.api
 
 import imgui.api.g
+import imgui.div
+import imgui.has
+import imgui.hasnt
 import imgui.internal.sections.ItemFlag
 
 // Disabling [BETA API]

--- a/core/src/main/kotlin/imgui/internal/api/dragAndDrop.kt
+++ b/core/src/main/kotlin/imgui/internal/api/dragAndDrop.kt
@@ -39,7 +39,7 @@ internal interface dragAndDrop {
     fun clearDragDrop() = with(g) {
         dragDropActive = false
         dragDropPayload.clear()
-        dragDropAcceptFlags = emptyFlags()
+        dragDropAcceptFlags = emptyFlags
         dragDropAcceptIdPrev = 0
         dragDropAcceptIdCurr = 0
         dragDropAcceptIdCurrRectSurface = Float.MAX_VALUE

--- a/core/src/main/kotlin/imgui/internal/api/dragAndDrop.kt
+++ b/core/src/main/kotlin/imgui/internal/api/dragAndDrop.kt
@@ -2,11 +2,11 @@ package imgui.internal.api
 
 import glm_.vec2.Vec2
 import imgui.Col
-import imgui.DragDropFlag
 import imgui.ID
 import imgui.ImGui
 import imgui.ImGui.isMouseHoveringRect
 import imgui.api.g
+import imgui.emptyFlags
 import imgui.internal.classes.Rect
 import kool.lib.fill
 import java.nio.ByteBuffer
@@ -39,7 +39,7 @@ internal interface dragAndDrop {
     fun clearDragDrop() = with(g) {
         dragDropActive = false
         dragDropPayload.clear()
-        dragDropAcceptFlags = DragDropFlag.None.i
+        dragDropAcceptFlags = emptyFlags()
         dragDropAcceptIdPrev = 0
         dragDropAcceptIdCurr = 0
         dragDropAcceptIdCurrRectSurface = Float.MAX_VALUE
@@ -54,5 +54,5 @@ internal interface dragAndDrop {
 
     /** FIXME-DRAGDROP: Settle on a proper default visuals for drop target. */
     fun renderDragDropTargetRect(bb: Rect) =
-        ImGui.windowDrawList.addRect(bb.min - Vec2(3.5f), bb.max + Vec2( 3.5f), Col.DragDropTarget.u32, 0f, 0, 2f)
+        ImGui.windowDrawList.addRect(bb.min - Vec2(3.5f), bb.max + Vec2(3.5f), Col.DragDropTarget.u32, 0f, thickness = 2f)
 }

--- a/core/src/main/kotlin/imgui/internal/api/gamepadKeyboardNavigation.kt
+++ b/core/src/main/kotlin/imgui/internal/api/gamepadKeyboardNavigation.kt
@@ -182,7 +182,7 @@ internal interface gamepadKeyboardNavigation {
         // Activate
         if (g.navMoveFlags has NavMoveFlag.Activate) {
             g.navNextActivateId = result.id
-            g.navNextActivateFlags = emptyFlags()
+            g.navNextActivateFlags = emptyFlags
         }
 
         // Enable nav highlight
@@ -204,7 +204,7 @@ internal interface gamepadKeyboardNavigation {
      *  on the next frame when the item is encountered again.  */
     fun activateItem(id: ID) {
         g.navNextActivateId = id
-        g.navNextActivateFlags = emptyFlags()
+        g.navNextActivateFlags = emptyFlags
     }
 
     // FIXME-NAV: The existence of SetNavID vs SetFocusID vs FocusWindow() needs to be clarified/reworked.

--- a/core/src/main/kotlin/imgui/internal/api/gamepadKeyboardNavigation.kt
+++ b/core/src/main/kotlin/imgui/internal/api/gamepadKeyboardNavigation.kt
@@ -182,7 +182,7 @@ internal interface gamepadKeyboardNavigation {
         // Activate
         if (g.navMoveFlags has NavMoveFlag.Activate) {
             g.navNextActivateId = result.id
-            g.navNextActivateFlags = ActivateFlag.None.i
+            g.navNextActivateFlags = emptyFlags()
         }
 
         // Enable nav highlight
@@ -194,7 +194,7 @@ internal interface gamepadKeyboardNavigation {
     /** Navigation wrap-around logic is delayed to the end of the frame because this operation is only valid after entire
      *  popup is assembled and in case of appended popups it is not clear which EndPopup() call is final. */
     fun navMoveRequestTryWrapping(window: Window, wrapFlags: NavMoveFlags) {
-        assert(wrapFlags != 0) { "Call with _WrapX, _WrapY, _LoopX, _LoopY" }
+        assert(wrapFlags.isNotEmpty) { "Call with _WrapX, _WrapY, _LoopX, _LoopY" }
         // In theory we should test for NavMoveRequestButNoResultYet() but there's no point doing it, NavEndFrame() will do the same test
         if (g.navWindow === window && g.navMoveScoringItems && g.navLayer == NavLayer.Main)
             g.navMoveFlags = g.navMoveFlags or wrapFlags
@@ -204,7 +204,7 @@ internal interface gamepadKeyboardNavigation {
      *  on the next frame when the item is encountered again.  */
     fun activateItem(id: ID) {
         g.navNextActivateId = id
-        g.navNextActivateFlags = ActivateFlag.None.i
+        g.navNextActivateFlags = emptyFlags()
     }
 
     // FIXME-NAV: The existence of SetNavID vs SetFocusID vs FocusWindow() needs to be clarified/reworked.

--- a/core/src/main/kotlin/imgui/internal/api/inputText.kt
+++ b/core/src/main/kotlin/imgui/internal/api/inputText.kt
@@ -618,8 +618,8 @@ internal interface inputText {
                 if (flags has (Itf.CallbackCompletion or Itf.CallbackHistory or Itf.CallbackAlways)) {
                     callback!!
                     // The reason we specify the usage semantic (Completion/History) is that Completion needs to disable keyboard TABBING at the moment.
-                    var eventFlag: InputTextFlags = emptyFlags()
-                    var eventKey = Key.None
+                    var eventFlag: InputTextFlags = emptyFlags
+                    var eventKey: Key = Key.None
                     when {
                         flags has Itf.CallbackCompletion && Key.Tab.isPressed -> {
                             eventFlag = Itf.CallbackCompletion
@@ -669,7 +669,7 @@ internal interface inputText {
                         callbackData = if (isReadOnly) buf else state.textA // Pointer may have been invalidated by a resize callback
                         assert(cbData.buf === callbackData) { "Invalid to modify those fields" }
                         assert(cbData.bufSize == state.bufCapacityA)
-                        assert(cbData.flags eq flags)
+                        assert(cbData.flags == flags)
                         val bufDirty = cbData.bufDirty
                         if (cbData.cursorPos != utf8CursorPos || bufDirty) {
                             state.stb.cursor = textCountCharsFromUtf8(cbData.buf, cbData.cursorPos)

--- a/core/src/main/kotlin/imgui/internal/api/inputs.kt
+++ b/core/src/main/kotlin/imgui/internal/api/inputs.kt
@@ -133,8 +133,8 @@ internal interface inputs {
     fun getTypematicRepeatRate(flags: InputFlags): Pair<Float, Float> {
         val flag = flags and InputFlag.RepeatRateMask
         return when {
-            flag eq InputFlag.RepeatRateNavMove -> g.io.keyRepeatDelay * 0.72f to g.io.keyRepeatRate * 0.80f
-            flag eq InputFlag.RepeatRateNavTweak -> g.io.keyRepeatDelay * 0.72f to g.io.keyRepeatRate * 0.30f
+            flag == InputFlag.RepeatRateNavMove -> g.io.keyRepeatDelay * 0.72f to g.io.keyRepeatRate * 0.80f
+            flag == InputFlag.RepeatRateNavTweak -> g.io.keyRepeatDelay * 0.72f to g.io.keyRepeatRate * 0.30f
             else -> g.io.keyRepeatDelay * 1.00f to g.io.keyRepeatRate * 1.00f
         }
     }
@@ -184,7 +184,7 @@ internal interface inputs {
     // - SetKeyOwner(..., None)              : clears owner
     // - SetKeyOwner(..., Any, !Lock)        : illegal (assert)
     // - SetKeyOwner(..., Any or None, Lock) : set lock
-    fun Key.setOwner(ownerId: ID, flags: InputFlags = emptyFlags()) {
+    fun Key.setOwner(ownerId: ID, flags: InputFlags = emptyFlags) {
 
         assert(isNamedOrMod && (ownerId != KeyOwner_Any || flags has (InputFlag.LockThisFrame or InputFlag.LockUntilRelease))) { "Can only use _Any with _LockXXX flags(to eat a key away without an ID to retrieve it)" }
         assert((flags wo InputFlag.SupportedBySetKeyOwner).isEmpty) { "Passing flags not supported by this function !" }
@@ -204,7 +204,7 @@ internal interface inputs {
     // Extensive uses of that (e.g. many calls for a single item) may want to manually perform the tests once and then call SetKeyOwner() multiple times.
     // More advanced usage scenarios may want to call SetKeyOwner() manually based on different condition.
     // Worth noting is that only one item can be hovered and only one item can be active, therefore this usage pattern doesn't need to bother with routing and priority.
-    fun Key.setItemKeyOwner(flags_: InputFlags = emptyFlags()) { // Set key owner to last item if it is hovered or active. Equivalent to 'if (IsItemHovered() || IsItemActive()) { SetKeyOwner(key, GetItemID());'.
+    fun Key.setItemKeyOwner(flags_: InputFlags = emptyFlags) { // Set key owner to last item if it is hovered or active. Equivalent to 'if (IsItemHovered() || IsItemActive()) { SetKeyOwner(key, GetItemID());'.
         var flags = flags_
         val id = g.lastItemData.id
         if (id == 0 || (g.hoveredId != id && g.activeId != id))
@@ -273,7 +273,7 @@ internal interface inputs {
 
     // Important: unless legacy IsKeyPressed(ImGuiKey, bool repeat=true) which DEFAULT to repeat, this requires EXPLICIT repeat.
     /** ~IsKeyPressed */
-    fun Key.isPressed(ownerId: ID, flags: InputFlags = emptyFlags()): Boolean { // Important: when transitioning from old to new IsKeyPressed(): old API has "bool repeat = true", so would default to repeat. New API requiress explicit ImGuiInputFlags_Repeat.
+    fun Key.isPressed(ownerId: ID, flags: InputFlags = emptyFlags): Boolean { // Important: when transitioning from old to new IsKeyPressed(): old API has "bool repeat = true", so would default to repeat. New API requiress explicit ImGuiInputFlags_Repeat.
         val keyData = data
         if (!keyData.down) // In theory this should already be encoded as (DownDuration < 0.0f), but testing this facilitates eating mechanism (until we finish work on key ownership)
             return false
@@ -307,7 +307,7 @@ internal interface inputs {
     }
 
     /** ~IsMouseClicked */
-    fun MouseButton.isClicked(ownerId: ID, flags: InputFlags = emptyFlags()): Boolean {
+    fun MouseButton.isClicked(ownerId: ID, flags: InputFlags = emptyFlags): Boolean {
 
         //        IM_ASSERT(button >= 0 && button < IM_ARRAYSIZE(g.IO.MouseDown));
         if (!g.io.mouseDown[i]) // In theory this should already be encoded as (DownDuration < 0.0f), but testing this facilitates eating mechanism (until we finish work on key ownership)

--- a/core/src/main/kotlin/imgui/internal/api/inputs.kt
+++ b/core/src/main/kotlin/imgui/internal/api/inputs.kt
@@ -5,16 +5,13 @@ import glm_.f
 import glm_.i
 import glm_.vec2.Vec2
 import imgui.*
-import imgui.ImGui.convertSingleModFlagToKey
 import imgui.ImGui.getPressedAmount
 import imgui.ImGui.io
 import imgui.ImGui.isDown
-import imgui.ImGui.isPressed
 import imgui.ImGui.navMoveRequestCancel
 import imgui.api.g
 import imgui.classes.KeyData
 import imgui.internal.classes.*
-import imgui.internal.isPowerOfTwo
 import imgui.internal.sections.*
 
 /** Inputs
@@ -64,14 +61,9 @@ internal interface inputs {
 
     /** ~GetKeyData */
     val Key.data: KeyData
-        get() {
-            var key = this
+        get() =
             // Special storage location for mods
-            if (i has Key.Mod_Mask_)
-                key = key.convertSingleModFlagToKey()
-
-            return g.io.keysData[key.index]
-        }
+            g.io.keysData[convertSingleModFlagToKey().index]
 
     // ImGuiMod_Shortcut is translated to either Ctrl or Super.
     fun getKeyChordName(keyChord_: KeyChord): String {
@@ -80,19 +72,13 @@ internal interface inputs {
         out += if (keyChord has Key.Mod_Shift) "Shift+" else ""
         out += if (keyChord has Key.Mod_Alt) "Alt+" else ""
         out += if (keyChord has Key.Mod_Super) (if (g.io.configMacOSXBehaviors) "Cmd+" else "Super+") else ""
-        return out + (Key of (keyChord wo Key.Mod_Mask_)).name
+        return out + (Key of (keyChord wo Key.Mod_Mask)).name
     }
 
 
     fun mouseButtonToKey(button: Int): Key {
         assert(button in 0 until MouseButton.COUNT)
-        return Key of (Key.MouseLeft.i + button)
-    }
-
-    /** ~MouseButtonToKey */
-    fun MouseButton.toKey(): Key {
-        val res = Key.values().first { it.i == Key.MouseLeft.i + i }
-        return res
+        return (MouseButton of button).key
     }
 
     /** Return if a mouse click/drag went past the given threshold. Valid to call during the MouseReleased frame.
@@ -114,7 +100,7 @@ internal interface inputs {
 
     fun getNavTweakPressedAmount(axis: Axis): Float {
 
-        val (repeatDelay, repeatRate) = getTypematicRepeatRate(InputFlag.RepeatRateNavTweak.i)
+        val (repeatDelay, repeatRate) = getTypematicRepeatRate(InputFlag.RepeatRateNavTweak)
 
         val keyLess: Key
         val keyMore: Key
@@ -144,10 +130,13 @@ internal interface inputs {
     }
 
     /** @return repeatDelay, repeatRate */
-    fun getTypematicRepeatRate(flags: InputFlags): Pair<Float, Float> = when (flags and InputFlag.RepeatRateMask_) {
-        InputFlag.RepeatRateNavMove.i -> g.io.keyRepeatDelay * 0.72f to g.io.keyRepeatRate * 0.80f
-        InputFlag.RepeatRateNavTweak.i -> g.io.keyRepeatDelay * 0.72f to g.io.keyRepeatRate * 0.30f
-        else -> g.io.keyRepeatDelay * 1.00f to g.io.keyRepeatRate * 1.00f
+    fun getTypematicRepeatRate(flags: InputFlags): Pair<Float, Float> {
+        val flag = flags and InputFlag.RepeatRateMask
+        return when {
+            flag eq InputFlag.RepeatRateNavMove -> g.io.keyRepeatDelay * 0.72f to g.io.keyRepeatRate * 0.80f
+            flag eq InputFlag.RepeatRateNavTweak -> g.io.keyRepeatDelay * 0.72f to g.io.keyRepeatRate * 0.30f
+            else -> g.io.keyRepeatDelay * 1.00f to g.io.keyRepeatRate * 1.00f
+        }
     }
 
     /** FIXME: It might be undesirable that this will likely disable KeyOwner-aware shortcuts systems. Consider a more fine-tuned version for the two users of this function. */
@@ -195,10 +184,10 @@ internal interface inputs {
     // - SetKeyOwner(..., None)              : clears owner
     // - SetKeyOwner(..., Any, !Lock)        : illegal (assert)
     // - SetKeyOwner(..., Any or None, Lock) : set lock
-    fun Key.setOwner(ownerId: ID, flags: InputFlags = 0) {
+    fun Key.setOwner(ownerId: ID, flags: InputFlags = emptyFlags()) {
 
         assert(isNamedOrMod && (ownerId != KeyOwner_Any || flags has (InputFlag.LockThisFrame or InputFlag.LockUntilRelease))) { "Can only use _Any with _LockXXX flags(to eat a key away without an ID to retrieve it)" }
-        assert((flags wo InputFlag.SupportedBySetKeyOwner) == 0) { "Passing flags not supported by this function !" }
+        assert((flags wo InputFlag.SupportedBySetKeyOwner).isEmpty) { "Passing flags not supported by this function !" }
 
         val ownerData = ownerData
         ownerData.ownerCurr = ownerId; ownerData.ownerNext = ownerId
@@ -215,16 +204,16 @@ internal interface inputs {
     // Extensive uses of that (e.g. many calls for a single item) may want to manually perform the tests once and then call SetKeyOwner() multiple times.
     // More advanced usage scenarios may want to call SetKeyOwner() manually based on different condition.
     // Worth noting is that only one item can be hovered and only one item can be active, therefore this usage pattern doesn't need to bother with routing and priority.
-    fun Key.setItemKeyOwner(flags_: InputFlags = 0) { // Set key owner to last item if it is hovered or active. Equivalent to 'if (IsItemHovered() || IsItemActive()) { SetKeyOwner(key, GetItemID());'.
+    fun Key.setItemKeyOwner(flags_: InputFlags = emptyFlags()) { // Set key owner to last item if it is hovered or active. Equivalent to 'if (IsItemHovered() || IsItemActive()) { SetKeyOwner(key, GetItemID());'.
         var flags = flags_
         val id = g.lastItemData.id
         if (id == 0 || (g.hoveredId != id && g.activeId != id))
             return
-        if (flags hasnt InputFlag.CondMask_)
-            flags /= InputFlag.CondDefault_
+        if (flags hasnt InputFlag.CondMask)
+            flags /= InputFlag.CondDefault
         if ((g.hoveredId == id && flags has InputFlag.CondHovered) || (g.activeId == id && flags has InputFlag.CondActive)) {
-            assert((flags wo InputFlag.SupportedBySetItemKeyOwner) == 0) { "Passing flags not supported by this function !" }
-            setOwner(id, flags wo InputFlag.CondMask_)
+            assert((flags wo InputFlag.SupportedBySetItemKeyOwner).isEmpty) { "Passing flags not supported by this function !" }
+            setOwner(id, flags wo InputFlag.CondMask)
         }
     }
 
@@ -262,7 +251,7 @@ internal interface inputs {
     val Key.ownerData: KeyOwnerData
         get() {
             var key = this
-            if (key has Key.Mod_Mask_)
+            if (key has Key.Mod_Mask)
                 key = key.convertSingleModFlagToKey()
             return g.keysOwnerData[key.ordinal]
         }
@@ -284,14 +273,14 @@ internal interface inputs {
 
     // Important: unless legacy IsKeyPressed(ImGuiKey, bool repeat=true) which DEFAULT to repeat, this requires EXPLICIT repeat.
     /** ~IsKeyPressed */
-    fun Key.isPressed(ownerId: ID, flags: InputFlags = 0): Boolean { // Important: when transitioning from old to new IsKeyPressed(): old API has "bool repeat = true", so would default to repeat. New API requiress explicit ImGuiInputFlags_Repeat.
+    fun Key.isPressed(ownerId: ID, flags: InputFlags = emptyFlags()): Boolean { // Important: when transitioning from old to new IsKeyPressed(): old API has "bool repeat = true", so would default to repeat. New API requiress explicit ImGuiInputFlags_Repeat.
         val keyData = data
         if (!keyData.down) // In theory this should already be encoded as (DownDuration < 0.0f), but testing this facilitates eating mechanism (until we finish work on key ownership)
             return false
         val t = keyData.downDuration
         if (t < 0f)
             return false
-        assert((flags wo InputFlag.SupportedByIsKeyPressed) == 0) { "Passing flags not supported by this function !" }
+        assert((flags wo InputFlag.SupportedByIsKeyPressed).isEmpty) { "Passing flags not supported by this function !" }
 
         var pressed = t == 0f
         if (!pressed && flags hasnt InputFlag.Repeat) {
@@ -314,11 +303,11 @@ internal interface inputs {
     /** ~IsMouseDown */
     infix fun MouseButton.isDown(ownerId: ID): Boolean {
         //        assert(button >= 0 && button < IM_ARRAYSIZE(g.IO.MouseDown));
-        return g.io.mouseDown[i] && toKey() testOwner ownerId // Should be same as IsKeyDown(MouseButtonToKey(button), owner_id), but this allows legacy code hijacking the io.Mousedown[] array.
+        return g.io.mouseDown[i] && key testOwner ownerId // Should be same as IsKeyDown(MouseButtonToKey(button), owner_id), but this allows legacy code hijacking the io.Mousedown[] array.
     }
 
     /** ~IsMouseClicked */
-    fun MouseButton.isClicked(ownerId: ID, flags: InputFlags = 0): Boolean {
+    fun MouseButton.isClicked(ownerId: ID, flags: InputFlags = emptyFlags()): Boolean {
 
         //        IM_ASSERT(button >= 0 && button < IM_ARRAYSIZE(g.IO.MouseDown));
         if (!g.io.mouseDown[i]) // In theory this should already be encoded as (DownDuration < 0.0f), but testing this facilitates eating mechanism (until we finish work on key ownership)
@@ -326,20 +315,20 @@ internal interface inputs {
         val t = g.io.mouseDownDuration[i]
         if (t < 0f)
             return false
-        assert((flags wo InputFlag.SupportedByIsKeyPressed) == 0) { "Passing flags not supported by this function !" }
+        assert((flags wo InputFlag.SupportedByIsKeyPressed).isEmpty) { "Passing flags not supported by this function !" }
 
         val repeat = flags has InputFlag.Repeat
         val pressed = t == 0f || (repeat && t > g.io.keyRepeatDelay && calcTypematicRepeatAmount(t - g.io.deltaTime, t, g.io.keyRepeatDelay, g.io.keyRepeatRate) > 0)
         if (!pressed)
             return false
 
-        return toKey().testOwner(ownerId)
+        return key.testOwner(ownerId)
     }
 
     /** ~IsMouseReleased */
     infix fun MouseButton.isReleased(ownerId: ID): Boolean {
         //        IM_ASSERT(button >= 0 && button < IM_ARRAYSIZE(g.IO.MouseDown));
-        return g.io.mouseReleased[i] && toKey() testOwner ownerId // Should be same as IsKeyReleased(MouseButtonToKey(button), owner_id)
+        return g.io.mouseReleased[i] && key testOwner ownerId // Should be same as IsKeyReleased(MouseButtonToKey(button), owner_id)
     }
 
 

--- a/core/src/main/kotlin/imgui/internal/api/internalColumnsAPI.kt
+++ b/core/src/main/kotlin/imgui/internal/api/internalColumnsAPI.kt
@@ -144,7 +144,7 @@ internal interface internalColumnsAPI {
                 val columnId = columns.id + n
                 val columnHitHw = imgui.api.columns.COLUMNS_HIT_RECT_HALF_WIDTH
                 val columnHitRect = Rect(Vec2(x - columnHitHw, y1), Vec2(x + columnHitHw, y2))
-                if (!itemAdd(columnHitRect, columnId, null, ItemFlag.NoNav.i))
+                if (!itemAdd(columnHitRect, columnId, null, ItemFlag.NoNav))
                     continue
 
                 var hovered = false

--- a/core/src/main/kotlin/imgui/internal/api/menus.kt
+++ b/core/src/main/kotlin/imgui/internal/api/menus.kt
@@ -220,7 +220,7 @@ internal interface menus {
         if (wantClose && isPopupOpen(id))
             closePopupToLevel(g.beginPopupStack.size, true)
 
-        IMGUI_TEST_ENGINE_ITEM_INFO(id, label, g.lastItemData.statusFlags or ItemStatusFlag.Openable or if (menuIsOpen) ItemStatusFlag.Opened else emptyFlags())
+        IMGUI_TEST_ENGINE_ITEM_INFO(id, label, g.lastItemData.statusFlags or ItemStatusFlag.Openable or if (menuIsOpen) ItemStatusFlag.Opened else emptyFlags)
         popID()
 
         if (wantOpen && !menuIsOpen && g.openPopupStack.size > g.beginPopupStack.size)
@@ -310,7 +310,7 @@ internal interface menus {
                     window.drawList.renderCheckMark(pos + Vec2(offsets.offsetMark + stretchW + g.fontSize * 0.4f, g.fontSize * 0.134f * 0.5f), Col.Text.u32, g.fontSize * 0.866f)
             }
         }
-        IMGUI_TEST_ENGINE_ITEM_INFO(g.lastItemData.id, label, g.lastItemData.statusFlags or ItemStatusFlag.Checkable or if (selected) ItemStatusFlag.Checked else emptyFlags())
+        IMGUI_TEST_ENGINE_ITEM_INFO(g.lastItemData.id, label, g.lastItemData.statusFlags or ItemStatusFlag.Checkable or if (selected) ItemStatusFlag.Checked else emptyFlags)
         if (!enabled)
             endDisabled()
         popID()

--- a/core/src/main/kotlin/imgui/internal/api/menus.kt
+++ b/core/src/main/kotlin/imgui/internal/api/menus.kt
@@ -4,18 +4,18 @@ import glm_.glm
 import glm_.max
 import glm_.vec2.Vec2
 import imgui.*
-import imgui.ImGui.calcTextSize
-import imgui.ImGui.contentRegionAvail
-import imgui.ImGui.popID
-import imgui.ImGui.popStyleColor
-import imgui.ImGui.popStyleVar
 import imgui.ImGui.beginDisabled
 import imgui.ImGui.beginPopupEx
+import imgui.ImGui.calcTextSize
 import imgui.ImGui.closePopupToLevel
+import imgui.ImGui.contentRegionAvail
 import imgui.ImGui.endDisabled
 import imgui.ImGui.isPopupOpen
 import imgui.ImGui.openPopup
+import imgui.ImGui.popID
 import imgui.ImGui.popItemFlag
+import imgui.ImGui.popStyleColor
+import imgui.ImGui.popStyleVar
 import imgui.ImGui.pushID
 import imgui.ImGui.pushItemFlag
 import imgui.ImGui.pushStyleColor
@@ -110,7 +110,7 @@ internal interface menus {
         // This is only done for items for the menu set and not the full parent window.
         val menusetIsOpen = widgets.isRootOfOpenMenuSet
         if (menusetIsOpen)
-            pushItemFlag(ItemFlag.NoWindowHoverableCheck.i, true)
+            pushItemFlag(ItemFlag.NoWindowHoverableCheck, true)
 
         // The reference position stored in popup_pos will be used by Begin() to find a suitable position for the child menu,
         // However the final position is going to be different! It is chosen by FindBestWindowPosForPopup().
@@ -220,7 +220,7 @@ internal interface menus {
         if (wantClose && isPopupOpen(id))
             closePopupToLevel(g.beginPopupStack.size, true)
 
-        IMGUI_TEST_ENGINE_ITEM_INFO(id, label, g.lastItemData.statusFlags or ItemStatusFlag.Openable or if (menuIsOpen) ItemStatusFlag.Opened else ItemStatusFlag.None)
+        IMGUI_TEST_ENGINE_ITEM_INFO(id, label, g.lastItemData.statusFlags or ItemStatusFlag.Openable or if (menuIsOpen) ItemStatusFlag.Opened else emptyFlags())
         popID()
 
         if (wantOpen && !menuIsOpen && g.openPopupStack.size > g.beginPopupStack.size)
@@ -263,7 +263,7 @@ internal interface menus {
         // See BeginMenuEx() for comments about this.
         val menusetIsOpen = widgets.isRootOfOpenMenuSet
         if (menusetIsOpen)
-            pushItemFlag(ItemFlag.NoWindowHoverableCheck.i, true)
+            pushItemFlag(ItemFlag.NoWindowHoverableCheck, true)
 
         // We've been using the equivalent of ImGuiSelectableFlags_SetNavIdOnHover on all Selectable() since early Nav system days (commit 43ee5d73),
         // but I am unsure whether this should be kept at all. For now moved it to be an opt-in feature used by menus only.
@@ -310,7 +310,7 @@ internal interface menus {
                     window.drawList.renderCheckMark(pos + Vec2(offsets.offsetMark + stretchW + g.fontSize * 0.4f, g.fontSize * 0.134f * 0.5f), Col.Text.u32, g.fontSize * 0.866f)
             }
         }
-        IMGUI_TEST_ENGINE_ITEM_INFO(g.lastItemData.id, label, g.lastItemData.statusFlags or ItemStatusFlag.Checkable or if (selected) ItemStatusFlag.Checked else ItemStatusFlag.None)
+        IMGUI_TEST_ENGINE_ITEM_INFO(g.lastItemData.id, label, g.lastItemData.statusFlags or ItemStatusFlag.Checkable or if (selected) ItemStatusFlag.Checked else emptyFlags())
         if (!enabled)
             endDisabled()
         popID()

--- a/core/src/main/kotlin/imgui/internal/api/newFrame.kt
+++ b/core/src/main/kotlin/imgui/internal/api/newFrame.kt
@@ -60,7 +60,7 @@ internal interface newFrame {
                 }
                 is InputEvent.MouseButton -> {
                     // Trickling Rule: Stop processing queued events if we got multiple action on the same button
-                    val button = MouseButton of e.button
+                    val button = e.button
                     //                    assert(button >= 0 && button < ImGuiMouseButton_COUNT)
                     if (trickleFastInputs && ((mouseButtonChanged has (1 shl button.i)) || mouseWheeled))
                         break
@@ -273,7 +273,7 @@ internal interface newFrame {
             // Handle the edge case of a popup being closed while clicking in its empty space.
             // If we try to focus it, FocusWindow() > ClosePopupsOverWindow() will accidentally close any parent popups because they are not linked together any more.
             val rootWindow = g.hoveredWindow?.rootWindow
-            val isClosedPopup = rootWindow != null && rootWindow.flags has WindowFlag._Popup && !isPopupOpen(rootWindow.popupId, PopupFlag.AnyPopupLevel.i)
+            val isClosedPopup = rootWindow != null && rootWindow.flags has WindowFlag._Popup && !isPopupOpen(rootWindow.popupId, PopupFlag.AnyPopupLevel)
 
             if (rootWindow != null && !isClosedPopup) {
                 g.hoveredWindow!!.startMouseMoving() //-V595

--- a/core/src/main/kotlin/imgui/internal/api/parameterStacks.kt
+++ b/core/src/main/kotlin/imgui/internal/api/parameterStacks.kt
@@ -1,8 +1,9 @@
 package imgui.internal.api
 
-import glm_.wo
 import imgui.api.g
 import imgui.internal.sections.ItemFlags
+import imgui.or
+import imgui.wo
 
 // Parameter stacks (shared)
 internal interface parameterStacks {
@@ -11,7 +12,7 @@ internal interface parameterStacks {
      *  @param option = ItemFlag   */
     fun pushItemFlag(option: ItemFlags, enabled: Boolean) {
         var itemFlags = g.currentItemFlags
-        assert(itemFlags eq g.itemFlagsStack.last())
+        assert(itemFlags == g.itemFlagsStack.last())
         itemFlags = when {
             enabled -> itemFlags or option
             else -> itemFlags wo option

--- a/core/src/main/kotlin/imgui/internal/api/parameterStacks.kt
+++ b/core/src/main/kotlin/imgui/internal/api/parameterStacks.kt
@@ -11,7 +11,7 @@ internal interface parameterStacks {
      *  @param option = ItemFlag   */
     fun pushItemFlag(option: ItemFlags, enabled: Boolean) {
         var itemFlags = g.currentItemFlags
-        assert(itemFlags == g.itemFlagsStack.last())
+        assert(itemFlags eq g.itemFlagsStack.last())
         itemFlags = when {
             enabled -> itemFlags or option
             else -> itemFlags wo option

--- a/core/src/main/kotlin/imgui/internal/api/popupsModalsTooltips.kt
+++ b/core/src/main/kotlin/imgui/internal/api/popupsModalsTooltips.kt
@@ -21,7 +21,6 @@ import imgui.ImGui.setNextWindowPos
 import imgui.ImGui.setNextWindowSize
 import imgui.ImGui.style
 import imgui.api.g
-import imgui.has
 import imgui.internal.classes.PopupData
 import imgui.internal.classes.Rect
 import imgui.internal.classes.Window
@@ -41,7 +40,7 @@ internal interface popupsModalsTooltips {
 
         val parentWindow = g.currentWindow!!
         var flags = flags_ or Wf.NoTitleBar or Wf.NoResize or Wf.NoSavedSettings or Wf._ChildWindow
-        flags = flags or (parentWindow.flags and Wf.NoMove.i)  // Inherit the NoMove flag
+        flags = flags or (parentWindow.flags and Wf.NoMove)  // Inherit the NoMove flag
 
         // Size
         val contentAvail = contentRegionAvail
@@ -90,13 +89,13 @@ internal interface popupsModalsTooltips {
      *  level).
      *  One open popup per level of the popup hierarchy (NB: when assigning we reset the Window member of ImGuiPopupRef
      *  to NULL)    */
-    fun openPopupEx(id: ID, popupFlags: PopupFlags = PopupFlag.None.i) {
+    fun openPopupEx(id: ID, popupFlags: PopupFlags = emptyFlags()) {
 
         val parentWindow = g.currentWindow!!
         val currentStackSize = g.beginPopupStack.size
 
         if (popupFlags has PopupFlag.NoOpenOverExistingPopup)
-            if (isPopupOpen(0, PopupFlag.AnyPopupId.i))
+            if (isPopupOpen(0, PopupFlag.AnyPopupId))
                 return
 
         // Tagged as new ref as Window will be set back to NULL if we write this into OpenPopupStack.
@@ -205,7 +204,7 @@ internal interface popupsModalsTooltips {
     /** Supported flags: ImGuiPopupFlags_AnyPopupId, ImGuiPopupFlags_AnyPopupLevel
      *
      *  Test for id at the current BeginPopup() level of the popup stack (this doesn't scan the whole popup stack!) */
-    fun isPopupOpen(id: ID, popupFlags: PopupFlags = PopupFlag.None.i): Boolean = when {
+    fun isPopupOpen(id: ID, popupFlags: PopupFlags = emptyFlags()): Boolean = when {
         popupFlags has PopupFlag.AnyPopupId -> { // Return true if any popup is open at the current BeginPopup() level of the popup stack
             // This may be used to e.g. test for another popups already opened to handle popups priorities at the same level.
             assert(id == 0)
@@ -221,7 +220,7 @@ internal interface popupsModalsTooltips {
     /** Attention! BeginPopup() adds default flags which BeginPopupEx()! */
     fun beginPopupEx(id: ID, flags_: WindowFlags): Boolean {
 
-        if (!isPopupOpen(id, PopupFlag.None.i)) {
+        if (!isPopupOpen(id)) {
             g.nextWindowData.clearFlags() // We behave like Begin() and need to consume those values
             return false
         }
@@ -240,7 +239,7 @@ internal interface popupsModalsTooltips {
 
     /** Not exposed publicly as BeginTooltip() because bool parameters are evil. Let's see if other needs arise first.
      *  @param extraWindowFlags WindowFlag   */
-    fun beginTooltipEx(tooltipFlags_: TooltipFlags, extraWindowFlags: WindowFlags) {
+    fun beginTooltipEx(tooltipFlags_: TooltipFlags = emptyFlags(), extraWindowFlags: WindowFlags = emptyFlags()) {
         var tooltipFlags = tooltipFlags_
         if (g.dragDropWithinSource || g.dragDropWithinTarget) { // The default tooltip position is a little offset to give space to see the context menu (it's also clamped within the current viewport/monitor)
             // In the context of a dragging tooltip we try to reduce that offset and we enforce following the cursor.
@@ -249,7 +248,8 @@ internal interface popupsModalsTooltips {
             val tooltipPos = io.mousePos + Vec2(16 * style.mouseCursorScale, 8 * style.mouseCursorScale)
             setNextWindowPos(tooltipPos)
             setNextWindowBgAlpha(
-                style.colors[Col.PopupBg].w * 0.6f) //PushStyleVar(ImGuiStyleVar_Alpha, g.Style.Alpha * 0.60f); // This would be nice but e.g ColorButton with checkboard has issue with transparent colors :(
+                style.colors[Col.PopupBg].w * 0.6f
+            ) //PushStyleVar(ImGuiStyleVar_Alpha, g.Style.Alpha * 0.60f); // This would be nice but e.g ColorButton with checkboard has issue with transparent colors :(
             tooltipFlags = tooltipFlags or TooltipFlag.OverridePreviousTooltip
         }
 

--- a/core/src/main/kotlin/imgui/internal/api/popupsModalsTooltips.kt
+++ b/core/src/main/kotlin/imgui/internal/api/popupsModalsTooltips.kt
@@ -89,7 +89,7 @@ internal interface popupsModalsTooltips {
      *  level).
      *  One open popup per level of the popup hierarchy (NB: when assigning we reset the Window member of ImGuiPopupRef
      *  to NULL)    */
-    fun openPopupEx(id: ID, popupFlags: PopupFlags = emptyFlags()) {
+    fun openPopupEx(id: ID, popupFlags: PopupFlags = emptyFlags) {
 
         val parentWindow = g.currentWindow!!
         val currentStackSize = g.beginPopupStack.size
@@ -101,8 +101,8 @@ internal interface popupsModalsTooltips {
         // Tagged as new ref as Window will be set back to NULL if we write this into OpenPopupStack.
         val openPopupPos = navCalcPreferredRefPos()
         val popupRef = PopupData(popupId = id, window = null, backupNavWindow = g.navWindow, // When popup closes focus may be restored to NavWindow (depend on window type).
-                                 openFrameCount = g.frameCount, openParentId = parentWindow.idStack.last(), openPopupPos = openPopupPos,
-                                 openMousePos = if (isMousePosValid(io.mousePos)) Vec2(io.mousePos) else Vec2(openPopupPos))
+            openFrameCount = g.frameCount, openParentId = parentWindow.idStack.last(), openPopupPos = openPopupPos,
+            openMousePos = if (isMousePosValid(io.mousePos)) Vec2(io.mousePos) else Vec2(openPopupPos))
 
         IMGUI_DEBUG_LOG_POPUP("[popup] OpenPopupEx(0x%08X)", id)
         if (g.openPopupStack.size < currentStackSize + 1) g.openPopupStack += popupRef
@@ -204,7 +204,7 @@ internal interface popupsModalsTooltips {
     /** Supported flags: ImGuiPopupFlags_AnyPopupId, ImGuiPopupFlags_AnyPopupLevel
      *
      *  Test for id at the current BeginPopup() level of the popup stack (this doesn't scan the whole popup stack!) */
-    fun isPopupOpen(id: ID, popupFlags: PopupFlags = emptyFlags()): Boolean = when {
+    fun isPopupOpen(id: ID, popupFlags: PopupFlags = emptyFlags): Boolean = when {
         popupFlags has PopupFlag.AnyPopupId -> { // Return true if any popup is open at the current BeginPopup() level of the popup stack
             // This may be used to e.g. test for another popups already opened to handle popups priorities at the same level.
             assert(id == 0)
@@ -239,7 +239,7 @@ internal interface popupsModalsTooltips {
 
     /** Not exposed publicly as BeginTooltip() because bool parameters are evil. Let's see if other needs arise first.
      *  @param extraWindowFlags WindowFlag   */
-    fun beginTooltipEx(tooltipFlags_: TooltipFlags = emptyFlags(), extraWindowFlags: WindowFlags = emptyFlags()) {
+    fun beginTooltipEx(tooltipFlags_: TooltipFlags = emptyFlags, extraWindowFlags: WindowFlags = emptyFlags) {
         var tooltipFlags = tooltipFlags_
         if (g.dragDropWithinSource || g.dragDropWithinTarget) { // The default tooltip position is a little offset to give space to see the context menu (it's also clamped within the current viewport/monitor)
             // In the context of a dragging tooltip we try to reduce that offset and we enforce following the cursor.

--- a/core/src/main/kotlin/imgui/internal/api/renderHelpers.kt
+++ b/core/src/main/kotlin/imgui/internal/api/renderHelpers.kt
@@ -210,7 +210,7 @@ internal interface renderHelpers {
      * [JVM] safe passing Vec2 instances */
     fun renderColorRectWithAlphaCheckerboard(
         drawList: DrawList, pMin: Vec2, pMax: Vec2, col: Int, gridStep: Float,
-        gridOff: Vec2, rounding: Float = 0f, flags_: DrawFlags = emptyFlags()
+        gridOff: Vec2, rounding: Float = 0f, flags_: DrawFlags = emptyFlags
     ) {
         val flags = when {
             flags_ hasnt DrawFlag.RoundCornersMask -> DrawFlag.RoundCornersDefault
@@ -250,7 +250,7 @@ internal interface renderHelpers {
                     }
                     // Combine flags
                     cellFlags = when {
-                        flags eq DrawFlag.RoundCornersNone || cellFlags eq DrawFlag.RoundCornersNone -> DrawFlag.RoundCornersNone
+                        flags == DrawFlag.RoundCornersNone || cellFlags == DrawFlag.RoundCornersNone -> DrawFlag.RoundCornersNone
                         else -> cellFlags or flags
                     }
                     drawList.addRectFilled(Vec2(x1, y1), Vec2(x2, y2), colBg2, rounding, cellFlags)
@@ -446,19 +446,19 @@ internal interface renderHelpers {
         val fillD = inner.max.y < outer.max.y
         if (fillL) addRectFilled(
             Vec2(outer.min.x, inner.min.y), Vec2(inner.min.x, inner.max.y), col, rounding,
-            DrawFlag.RoundCornersNone or (if (fillU) emptyFlags() else DrawFlag.RoundCornersTopLeft) or if (fillD) emptyFlags() else DrawFlag.RoundCornersBottomLeft
+            DrawFlag.RoundCornersNone or (if (fillU) emptyFlags else DrawFlag.RoundCornersTopLeft) or if (fillD) emptyFlags else DrawFlag.RoundCornersBottomLeft
         )
         if (fillR) addRectFilled(
             Vec2(inner.max.x, inner.min.y), Vec2(outer.max.x, inner.max.y), col, rounding,
-            DrawFlag.RoundCornersNone or (if (fillU) emptyFlags() else DrawFlag.RoundCornersTopRight) or if (fillD) emptyFlags() else DrawFlag.RoundCornersBottomRight
+            DrawFlag.RoundCornersNone or (if (fillU) emptyFlags else DrawFlag.RoundCornersTopRight) or if (fillD) emptyFlags else DrawFlag.RoundCornersBottomRight
         )
         if (fillU) addRectFilled(
             Vec2(inner.min.x, outer.min.y), Vec2(inner.max.x, inner.min.y), col, rounding,
-            DrawFlag.RoundCornersNone or (if (fillL) emptyFlags() else DrawFlag.RoundCornersTopLeft) or if (fillR) emptyFlags() else DrawFlag.RoundCornersTopRight
+            DrawFlag.RoundCornersNone or (if (fillL) emptyFlags else DrawFlag.RoundCornersTopLeft) or if (fillR) emptyFlags else DrawFlag.RoundCornersTopRight
         )
         if (fillD) addRectFilled(
             Vec2(inner.min.x, inner.max.y), Vec2(inner.max.x, outer.max.y), col, rounding,
-            DrawFlag.RoundCornersNone or (if (fillL) emptyFlags() else DrawFlag.RoundCornersBottomLeft) or if (fillR) emptyFlags() else DrawFlag.RoundCornersBottomRight
+            DrawFlag.RoundCornersNone or (if (fillL) emptyFlags else DrawFlag.RoundCornersBottomLeft) or if (fillR) emptyFlags else DrawFlag.RoundCornersBottomRight
         )
         if (fillL && fillU) addRectFilled(Vec2(outer.min.x, outer.min.y), Vec2(inner.min.x, inner.min.y), col, rounding, DrawFlag.RoundCornersTopLeft)
         if (fillR && fillU) addRectFilled(Vec2(inner.max.x, outer.min.y), Vec2(outer.max.x, inner.min.y), col, rounding, DrawFlag.RoundCornersTopRight)

--- a/core/src/main/kotlin/imgui/internal/api/scrolling.kt
+++ b/core/src/main/kotlin/imgui/internal/api/scrolling.kt
@@ -1,14 +1,14 @@
 package imgui.internal.api
 
-import glm_.has
 import glm_.min
 import glm_.vec2.Vec2
-import imgui.*
+import imgui.ImGui
+import imgui.WindowFlag
 import imgui.api.g
+import imgui.emptyFlags
 import imgui.internal.classes.Rect
 import imgui.internal.classes.Window
 import imgui.internal.floor
-import imgui.internal.isPowerOfTwo
 import imgui.internal.sections.ScrollFlag
 import imgui.internal.sections.ScrollFlags
 import imgui.static.calcNextScrollFromScrollTargetAndClamp
@@ -60,14 +60,15 @@ internal interface scrolling {
     }
 
     // Early work-in-progress API (ScrollToItem() will become public)
-    fun scrollToItem(flags: ScrollFlags = ScrollFlag.None.i) {
+    fun scrollToItem(flags: ScrollFlags = emptyFlags()) {
         val window = g.currentWindow!!
         scrollToRectEx(window, g.lastItemData.navRect, flags)
     }
 
-    fun scrollToRect(window: Window, rect: Rect, flags: ScrollFlags = ScrollFlag.None.i): Vec2 = scrollToRectEx(window, rect, flags)
+    fun scrollToRect(window: Window, rect: Rect, flags: ScrollFlags = emptyFlags()): Vec2 =
+        scrollToRectEx(window, rect, flags)
 
-    fun scrollToRectEx(window: Window, itemRect: Rect, flags_: ScrollFlags = ScrollFlag.None.i): Vec2 {
+    fun scrollToRectEx(window: Window, itemRect: Rect, flags_: ScrollFlags = emptyFlags()): Vec2 {
 
         var flags = flags_
 
@@ -78,14 +79,14 @@ internal interface scrolling {
         //GetForegroundDrawList(window)->AddRect(scroll_rect.Min, scroll_rect.Max, IM_COL32_WHITE); // [DEBUG]
 
         // Check that only one behavior is selected per axis
-        assert(flags hasnt ScrollFlag.MaskX_ || (flags and ScrollFlag.MaskX_).isPowerOfTwo)
-        assert(flags hasnt ScrollFlag.MaskY_ || (flags and ScrollFlag.MaskY_).isPowerOfTwo)
+        assert(flags hasnt ScrollFlag.MaskX || (flags and ScrollFlag.MaskX).isPowerOfTwo)
+        assert(flags hasnt ScrollFlag.MaskY || (flags and ScrollFlag.MaskY).isPowerOfTwo)
 
         // Defaults
         var inFlags = flags
-        if (flags hasnt ScrollFlag.MaskX_ && window.scrollbar.x)
+        if (flags hasnt ScrollFlag.MaskX && window.scrollbar.x)
             flags /= ScrollFlag.KeepVisibleEdgeX
-        if (flags hasnt ScrollFlag.MaskY_)
+        if (flags hasnt ScrollFlag.MaskY)
             flags /= if (window.appearing) ScrollFlag.AlwaysCenterY else ScrollFlag.KeepVisibleEdgeY
 
         val fullyVisibleX = itemRect.min.x >= scrollRect.min.x && itemRect.max.x <= scrollRect.max.x
@@ -122,9 +123,9 @@ internal interface scrolling {
         if (flags hasnt ScrollFlag.NoScrollParent && window.flags has WindowFlag._ChildWindow) {
             // FIXME-SCROLL: May be an option?
             if (inFlags has (ScrollFlag.AlwaysCenterX or ScrollFlag.KeepVisibleCenterX))
-                inFlags = (inFlags wo ScrollFlag.MaskX_) or ScrollFlag.KeepVisibleEdgeX
+                inFlags = (inFlags wo ScrollFlag.MaskX) or ScrollFlag.KeepVisibleEdgeX
             if (inFlags has (ScrollFlag.AlwaysCenterY or ScrollFlag.KeepVisibleCenterY))
-                inFlags = (inFlags wo ScrollFlag.MaskY_) or ScrollFlag.KeepVisibleEdgeY
+                inFlags = (inFlags wo ScrollFlag.MaskY) or ScrollFlag.KeepVisibleEdgeY
             deltaScroll += scrollToRectEx(window.parentWindow!!, Rect(itemRect.min - deltaScroll, itemRect.max - deltaScroll), inFlags)
         }
 

--- a/core/src/main/kotlin/imgui/internal/api/scrolling.kt
+++ b/core/src/main/kotlin/imgui/internal/api/scrolling.kt
@@ -2,10 +2,8 @@ package imgui.internal.api
 
 import glm_.min
 import glm_.vec2.Vec2
-import imgui.ImGui
-import imgui.WindowFlag
+import imgui.*
 import imgui.api.g
-import imgui.emptyFlags
 import imgui.internal.classes.Rect
 import imgui.internal.classes.Window
 import imgui.internal.floor
@@ -60,15 +58,15 @@ internal interface scrolling {
     }
 
     // Early work-in-progress API (ScrollToItem() will become public)
-    fun scrollToItem(flags: ScrollFlags = emptyFlags()) {
+    fun scrollToItem(flags: ScrollFlags = emptyFlags) {
         val window = g.currentWindow!!
         scrollToRectEx(window, g.lastItemData.navRect, flags)
     }
 
-    fun scrollToRect(window: Window, rect: Rect, flags: ScrollFlags = emptyFlags()): Vec2 =
+    fun scrollToRect(window: Window, rect: Rect, flags: ScrollFlags = emptyFlags): Vec2 =
         scrollToRectEx(window, rect, flags)
 
-    fun scrollToRectEx(window: Window, itemRect: Rect, flags_: ScrollFlags = emptyFlags()): Vec2 {
+    fun scrollToRectEx(window: Window, itemRect: Rect, flags_: ScrollFlags = emptyFlags): Vec2 {
 
         var flags = flags_
 

--- a/core/src/main/kotlin/imgui/internal/api/settings.kt
+++ b/core/src/main/kotlin/imgui/internal/api/settings.kt
@@ -5,7 +5,6 @@ import imgui.IMGUI_DEBUG_INI_SETTINGS
 import imgui.ImGui.io
 import imgui.WindowFlag
 import imgui.api.g
-import imgui.hasnt
 import imgui.internal.classes.Window
 import imgui.internal.hashStr
 import imgui.internal.sections.SettingsHandler

--- a/core/src/main/kotlin/imgui/internal/api/settings.kt
+++ b/core/src/main/kotlin/imgui/internal/api/settings.kt
@@ -5,6 +5,7 @@ import imgui.IMGUI_DEBUG_INI_SETTINGS
 import imgui.ImGui.io
 import imgui.WindowFlag
 import imgui.api.g
+import imgui.hasnt
 import imgui.internal.classes.Window
 import imgui.internal.hashStr
 import imgui.internal.sections.SettingsHandler

--- a/core/src/main/kotlin/imgui/internal/api/tabBars.kt
+++ b/core/src/main/kotlin/imgui/internal/api/tabBars.kt
@@ -57,14 +57,14 @@ internal interface tabBars {
         }
 
         // Ensure correct ordering when toggling ImGuiTabBarFlags_Reorderable flag, ensure tabs are ordered based on their submission order.
-        if (flags and TabBarFlag.Reorderable != this.flags and TabBarFlag.Reorderable || (tabsAddedNew && flags hasnt TabBarFlag.Reorderable))
+        if ((flags and TabBarFlag.Reorderable) notEq (this.flags and TabBarFlag.Reorderable) || (tabsAddedNew && flags hasnt TabBarFlag.Reorderable))
             if (tabs.size > 1)
                 tabs.sortBy(TabItem::beginOrder)
         tabsAddedNew = false
 
         // Flags
-        if (flags hasnt TabBarFlag.FittingPolicyMask_)
-            flags /= TabBarFlag.FittingPolicyDefault_
+        if (flags hasnt TabBarFlag.FittingPolicyMask)
+            flags /= TabBarFlag.FittingPolicyDefault
 
         this.flags = flags
         barRect put bb
@@ -140,7 +140,7 @@ internal interface tabBars {
         if (flags hasnt TabBarFlag.Reorderable)
             return
 
-        val isCentralSection = srcTab.flags hasnt TabItemFlag._SectionMask_
+        val isCentralSection = srcTab.flags hasnt TabItemFlag._SectionMask
         val barOffset = barRect.min.x - if (isCentralSection) scrollingTarget else 0f
 
         // Count number of contiguous tabs we are crossing over
@@ -155,7 +155,7 @@ internal interface tabBars {
                 i += dir
                 break
             }
-            if (dstTab.flags and TabItemFlag._SectionMask_ != srcTab.flags and TabItemFlag._SectionMask_) {
+            if ((dstTab.flags and TabItemFlag._SectionMask) notEq (srcTab.flags and TabItemFlag._SectionMask)) {
                 i += dir
                 break
             }
@@ -192,7 +192,7 @@ internal interface tabBars {
         val tab2 = tabs[tab2Order]
         if (tab2.flags has TabItemFlag.NoReorder)
             return false
-        if (tab1.flags and TabItemFlag._SectionMask_ != tab2.flags and TabItemFlag._SectionMask_)
+        if ((tab1.flags and TabItemFlag._SectionMask) notEq (tab2.flags and TabItemFlag._SectionMask))
             return false
 
 //        ImGuiTabItem item_tmp = * tab1;
@@ -228,12 +228,12 @@ internal interface tabBars {
         // We make a call to ItemAdd() so that attempts to use a contextual popup menu with an implicit ID won't use an older ID.
         IMGUI_TEST_ENGINE_ITEM_INFO(id, label, g.lastItemData.statusFlags)
         if (pOpen?.get() == false) {
-            ImGui.itemAdd(Rect(), id, null, ItemFlag.NoNav.i)
+            ImGui.itemAdd(Rect(), id, null, ItemFlag.NoNav)
             return false
         }
 
         assert(pOpen == null || flags hasnt TabItemFlag._Button)
-        assert((flags and (TabItemFlag.Leading or TabItemFlag.Trailing)) != (TabItemFlag.Leading or TabItemFlag.Trailing)) { "Can't use both Leading and Trailing" }
+        assert((flags and (TabItemFlag.Leading or TabItemFlag.Trailing)) notEq (TabItemFlag.Leading or TabItemFlag.Trailing)) { "Can't use both Leading and Trailing" }
 
         // Store into ImGuiTabItemFlags_NoCloseButton, also honor ImGuiTabItemFlags_NoCloseButton passed by user (although not documented)
         if (flags has TabItemFlag._NoCloseButton)
@@ -300,7 +300,7 @@ internal interface tabBars {
         // Note that tab_is_new is not necessarily the same as tab_appearing! When a tab bar stops being submitted
         // and then gets submitted again, the tabs will have 'tab_appearing=true' but 'tab_is_new=false'.
         if (tabAppearing && (!tabBarAppearing || tabIsNew)) {
-            ImGui.itemAdd(Rect(), id, null, ItemFlag.NoNav.i)
+            ImGui.itemAdd(Rect(), id, null, ItemFlag.NoNav)
             if (isTabButton)
                 return false
             return tabContentsVisible
@@ -313,7 +313,7 @@ internal interface tabBars {
         val backupMainCursorPos = Vec2(window.dc.cursorPos)
 
         // Layout
-        val isCentralSection = tab.flags hasnt TabItemFlag._SectionMask_
+        val isCentralSection = tab.flags hasnt TabItemFlag._SectionMask
         size.x = tab.width
         val x = if (isCentralSection) floor(tab.offset - scrollingAnim) else tab.offset
         window.dc.cursorPos = barRect.min + Vec2(x, 0f)
@@ -454,7 +454,7 @@ internal interface tabBars {
                 pathArcToFast(Vec2(bb.min.x + rounding + 0.5f, y1 + rounding + 0.5f), rounding, 6, 9)
                 pathArcToFast(Vec2(bb.max.x - rounding - 0.5f, y1 + rounding + 0.5f), rounding, 9, 12)
                 pathLineTo(Vec2(bb.max.x - 0.5f, y2))
-                pathStroke(Col.Border.u32, 0, style.tabBorderSize)
+                pathStroke(Col.Border.u32, thickness = style.tabBorderSize)
             }
         }
     }

--- a/core/src/main/kotlin/imgui/internal/api/tabBars.kt
+++ b/core/src/main/kotlin/imgui/internal/api/tabBars.kt
@@ -57,7 +57,7 @@ internal interface tabBars {
         }
 
         // Ensure correct ordering when toggling ImGuiTabBarFlags_Reorderable flag, ensure tabs are ordered based on their submission order.
-        if ((flags and TabBarFlag.Reorderable) notEq (this.flags and TabBarFlag.Reorderable) || (tabsAddedNew && flags hasnt TabBarFlag.Reorderable))
+        if ((flags and TabBarFlag.Reorderable) != (this.flags and TabBarFlag.Reorderable) || (tabsAddedNew && flags hasnt TabBarFlag.Reorderable))
             if (tabs.size > 1)
                 tabs.sortBy(TabItem::beginOrder)
         tabsAddedNew = false
@@ -155,7 +155,7 @@ internal interface tabBars {
                 i += dir
                 break
             }
-            if ((dstTab.flags and TabItemFlag._SectionMask) notEq (srcTab.flags and TabItemFlag._SectionMask)) {
+            if ((dstTab.flags and TabItemFlag._SectionMask) != (srcTab.flags and TabItemFlag._SectionMask)) {
                 i += dir
                 break
             }
@@ -192,7 +192,7 @@ internal interface tabBars {
         val tab2 = tabs[tab2Order]
         if (tab2.flags has TabItemFlag.NoReorder)
             return false
-        if ((tab1.flags and TabItemFlag._SectionMask) notEq (tab2.flags and TabItemFlag._SectionMask))
+        if ((tab1.flags and TabItemFlag._SectionMask) != (tab2.flags and TabItemFlag._SectionMask))
             return false
 
 //        ImGuiTabItem item_tmp = * tab1;
@@ -233,7 +233,7 @@ internal interface tabBars {
         }
 
         assert(pOpen == null || flags hasnt TabItemFlag._Button)
-        assert((flags and (TabItemFlag.Leading or TabItemFlag.Trailing)) notEq (TabItemFlag.Leading or TabItemFlag.Trailing)) { "Can't use both Leading and Trailing" }
+        assert((TabItemFlag.Leading or TabItemFlag.Trailing) !in flags) { "Can't use both Leading and Trailing" }
 
         // Store into ImGuiTabItemFlags_NoCloseButton, also honor ImGuiTabItemFlags_NoCloseButton passed by user (although not documented)
         if (flags has TabItemFlag._NoCloseButton)

--- a/core/src/main/kotlin/imgui/internal/api/tableSettings.kt
+++ b/core/src/main/kotlin/imgui/internal/api/tableSettings.kt
@@ -94,7 +94,7 @@ interface tableSettings {
         assert(settings.columnsCount == columnsCount && settings.columnsCountMax >= settings.columnsCount)
 
         var saveRefScale = false
-        settings.saveFlags = emptyFlags()
+        settings.saveFlags = emptyFlags
         for (n in 0 until columnsCount) {
             val column = columns[n]
             val columnSettings = settings.columnSettings[n]
@@ -133,7 +133,7 @@ interface tableSettings {
         isInitializing = true; isSettingsDirty = true
         isResetAllRequest = false
         isSettingsRequestLoad = false                   // Don't reload from ini
-        settingsLoadedFlags = emptyFlags()      // Mark as nothing loaded so our initialized data becomes authoritative
+        settingsLoadedFlags = emptyFlags      // Mark as nothing loaded so our initialized data becomes authoritative
     }
 
     /** Get settings for a given table, NULL if none

--- a/core/src/main/kotlin/imgui/internal/api/tableSettings.kt
+++ b/core/src/main/kotlin/imgui/internal/api/tableSettings.kt
@@ -94,7 +94,7 @@ interface tableSettings {
         assert(settings.columnsCount == columnsCount && settings.columnsCountMax >= settings.columnsCount)
 
         var saveRefScale = false
-        settings.saveFlags = TableFlag.None.i
+        settings.saveFlags = emptyFlags()
         for (n in 0 until columnsCount) {
             val column = columns[n]
             val columnSettings = settings.columnSettings[n]
@@ -133,7 +133,7 @@ interface tableSettings {
         isInitializing = true; isSettingsDirty = true
         isResetAllRequest = false
         isSettingsRequestLoad = false                   // Don't reload from ini
-        settingsLoadedFlags = TableFlag.None.i      // Mark as nothing loaded so our initialized data becomes authoritative
+        settingsLoadedFlags = emptyFlags()      // Mark as nothing loaded so our initialized data becomes authoritative
     }
 
     /** Get settings for a given table, NULL if none

--- a/core/src/main/kotlin/imgui/internal/api/tablesCandidatesForPublicAPI.kt
+++ b/core/src/main/kotlin/imgui/internal/api/tablesCandidatesForPublicAPI.kt
@@ -1,7 +1,7 @@
 package imgui.internal.api
 
 import glm_.max
-import imgui.ImGui
+import imgui.*
 import imgui.ImGui.calcTextSize
 import imgui.ImGui.fixColumnSortDirection
 import imgui.ImGui.getMaxColumnWidth
@@ -12,9 +12,7 @@ import imgui.ImGui.tableGetColumnCount
 import imgui.ImGui.tableGetColumnFlags
 import imgui.ImGui.tableGetColumnName
 import imgui.ImGui.updateColumnsWeightFromWidth
-import imgui.SortDirection
 import imgui.api.g
-import imgui.clamp
 import imgui.internal.classes.TableColumnIdx
 import imgui.internal.hashStr
 import imgui.TableColumnFlag as Tcf

--- a/core/src/main/kotlin/imgui/internal/api/tablesCandidatesForPublicAPI.kt
+++ b/core/src/main/kotlin/imgui/internal/api/tablesCandidatesForPublicAPI.kt
@@ -1,13 +1,10 @@
 package imgui.internal.api
 
-import glm_.has
 import glm_.max
-import imgui.*
+import imgui.ImGui
 import imgui.ImGui.calcTextSize
 import imgui.ImGui.fixColumnSortDirection
 import imgui.ImGui.getMaxColumnWidth
-import imgui.api.g
-import imgui.internal.hashStr
 import imgui.ImGui.openPopupEx
 import imgui.ImGui.setWindowClipRectBeforeSetChannel
 import imgui.ImGui.style
@@ -15,7 +12,11 @@ import imgui.ImGui.tableGetColumnCount
 import imgui.ImGui.tableGetColumnFlags
 import imgui.ImGui.tableGetColumnName
 import imgui.ImGui.updateColumnsWeightFromWidth
+import imgui.SortDirection
+import imgui.api.g
+import imgui.clamp
 import imgui.internal.classes.TableColumnIdx
+import imgui.internal.hashStr
 import imgui.TableColumnFlag as Tcf
 import imgui.TableFlag as Tf
 
@@ -43,7 +44,7 @@ interface tablesCandidatesForPublicAPI {
             table.contextPopupColumn = columnN
             table.instanceInteracted = table.instanceCurrent
             val contextMenuId = hashStr("##ContextMenu", 0, table.id)
-            openPopupEx(contextMenuId, PopupFlag.None.i)
+            openPopupEx(contextMenuId)
         }
     }
 

--- a/core/src/main/kotlin/imgui/internal/api/tablesInternal.kt
+++ b/core/src/main/kotlin/imgui/internal/api/tablesInternal.kt
@@ -36,7 +36,7 @@ interface tablesInternal {
     fun tableFindByID(id: ID): Table? = g.tables.getByKey(id)
 
     fun beginTableEx(
-        name: String, id: ID, columnsCount: Int, flags_: TableFlags = emptyFlags(), outerSize: Vec2 = Vec2(),
+        name: String, id: ID, columnsCount: Int, flags_: TableFlags = emptyFlags, outerSize: Vec2 = Vec2(),
         innerWidth: Float = 0f
     ): Boolean {
 
@@ -119,7 +119,7 @@ interface tablesInternal {
                 setNextWindowScroll(Vec2())
 
             // Create scrolling region (without border and zero window padding)
-            val childFlags = if (flags has Tf.ScrollX) Wf.HorizontalScrollbar else emptyFlags()
+            val childFlags = if (flags has Tf.ScrollX) Wf.HorizontalScrollbar else emptyFlags
             beginChildEx(name, instanceId, outerRect.size, false, childFlags)
             table.innerWindow = g.currentWindow
             val inner = table.innerWindow!!
@@ -189,7 +189,7 @@ interface tablesInternal {
         table.currentColumn = -1
         table.currentRow = -1
         table.rowBgColorCounter = 0
-        table.lastRowFlags = emptyFlags()
+        table.lastRowFlags = emptyFlags
         table.innerClipRect put if (innerWindow === outerWindow) table.workRect else innerWindow.clipRect
         table.innerClipRect clipWith table.workRect     // We need this to honor inner_width
         table.innerClipRect clipWithFull table.hostClipRect
@@ -595,7 +595,7 @@ interface tablesInternal {
             if (column.flags has TableColumnFlag.WidthFixed) {
                 // Apply same widths policy
                 var widthAuto = column.widthAuto
-                if (tableSizingPolicy eq Tf.SizingFixedSame && (column.autoFitQueue != 0x00 || !columnIsResizable))
+                if (tableSizingPolicy == Tf.SizingFixedSame && (column.autoFitQueue != 0x00 || !columnIsResizable))
                     widthAuto = fixedMaxWidthAuto
 
                 // Apply automatic width
@@ -619,7 +619,7 @@ interface tablesInternal {
                 if (column.autoFitQueue != 0x00 || column.stretchWeight < 0f || !columnIsResizable)
                     column.stretchWeight = when {
                         column.initStretchWeightOrWidth > 0f -> column.initStretchWeightOrWidth
-                        tableSizingPolicy eq Tf.SizingStretchProp -> (column.widthAuto / stretchSumWidthAuto) * countStretch
+                        tableSizingPolicy == Tf.SizingStretchProp -> (column.widthAuto / stretchSumWidthAuto) * countStretch
                         else -> 1f
                     }
 
@@ -1019,7 +1019,7 @@ interface tablesInternal {
 
                 // Decide whether right-most column is visible
                 if (column.nextEnabledColumn == -1 && !isResizable)
-                    if (flags and Tf._SizingMask notEq Tf.SizingFixedSame || flags has Tf.NoHostExtendX)
+                    if (flags and Tf._SizingMask != Tf.SizingFixedSame || flags has Tf.NoHostExtendX)
                         continue
                 if (column.maxX <= column.clipRect.min.x) // FIXME-TABLE FIXME-STYLE: Assume BorderSize==1, this is problematic if we want to increase the border size..
                     continue
@@ -1092,7 +1092,7 @@ interface tablesInternal {
             }
 
             val sizeAllDesc = when {
-                columnsEnabledFixedCount == columnsEnabledCount && flags and Tf._SizingMask notEq Tf.SizingFixedSame -> LocKey.TableSizeAllFit.msg // "###SizeAll" All fixed
+                columnsEnabledFixedCount == columnsEnabledCount && flags and Tf._SizingMask != Tf.SizingFixedSame -> LocKey.TableSizeAllFit.msg // "###SizeAll" All fixed
                 else -> LocKey.TableSizeAllDefault.msg // "###SizeAll" All stretch or mixed
             }
             if (menuItem(sizeAllDesc, ""))
@@ -1728,7 +1728,7 @@ interface tablesInternal {
         window.skipItems = column.isSkipItems
         if (column.isSkipItems) {
             g.lastItemData.id = 0
-            g.lastItemData.statusFlags = emptyFlags()
+            g.lastItemData.statusFlags = emptyFlags
         }
 
         if (flags has Tf.NoClip) {

--- a/core/src/main/kotlin/imgui/internal/api/templateFunctions.kt
+++ b/core/src/main/kotlin/imgui/internal/api/templateFunctions.kt
@@ -16,7 +16,10 @@ import imgui.ImGui.style
 import imgui.api.g
 import imgui.internal.*
 import imgui.internal.classes.Rect
-import imgui.internal.sections.*
+import imgui.internal.sections.Axis
+import imgui.internal.sections.InputSource
+import imgui.internal.sections.ItemFlag
+import imgui.internal.sections.get
 import imgui.static.DRAG_MOUSE_THRESHOLD_FACTOR
 import imgui.static.getMinimumStepAtDecimalPrecision
 import unsigned.Uint
@@ -2319,9 +2322,9 @@ internal interface templateFunctions {
         return vStr.replace(',', '.').d
     }
 
-    fun checkboxFlagsT(label: String, flagsPtr: KMutableProperty0<Int>, flagsValue: Int): Boolean {
+    fun <F: Flag<F>> checkboxFlagsT(label: String, flagsPtr: KMutableProperty0<Flag<F>>, flagsValue: Flag<F>): Boolean {
         var flags by flagsPtr
-        var allOn = (flags and flagsValue) == flagsValue
+        var allOn = flagsValue in flags
         _b = allOn
         val anyOn = flags has flagsValue
         val pressed = when {
@@ -2340,56 +2343,6 @@ internal interface templateFunctions {
             flags = when {
                 allOn -> flags or flagsValue
                 else -> flags wo flagsValue
-            }
-        return pressed
-    }
-
-    fun checkboxFlagsT(label: String, flagsPtr: KMutableProperty0<Long>, flagsValue: Long): Boolean {
-        var flags by flagsPtr
-        var allOn = (flags and flagsValue) == flagsValue
-        _b = allOn
-        val anyOn = flags has flagsValue
-        val pressed = when {
-            !allOn && anyOn -> {
-                val window = currentWindow
-                val backupItemFlags = g.currentItemFlags
-                g.currentItemFlags = g.currentItemFlags or ItemFlag.MixedValue
-                checkbox(label, ::_b).also {
-                    g.currentItemFlags = backupItemFlags
-                }
-            }
-            else -> checkbox(label, ::_b)
-        }
-        allOn = _b
-        if (pressed)
-            flags = when {
-                allOn -> flags or flagsValue
-                else -> flags wo flagsValue
-            }
-        return pressed
-    }
-
-    fun checkboxFlagsT(label: String, flagsPtr: KMutableProperty0<Ulong>, flagsValue: Ulong): Boolean {
-        val flags by flagsPtr
-        var allOn = (flags.v and flagsValue.v) == flagsValue.v
-        _b = allOn
-        val anyOn = flags.v has flagsValue.v
-        val pressed = when {
-            !allOn && anyOn -> {
-                val window = currentWindow
-                val backupItemFlags = g.currentItemFlags
-                g.currentItemFlags = g.currentItemFlags or ItemFlag.MixedValue
-                checkbox(label, ::_b).also {
-                    g.currentItemFlags = backupItemFlags
-                }
-            }
-            else -> checkbox(label, ::_b)
-        }
-        allOn = _b
-        if (pressed)
-            flags.v = when {
-                allOn -> flags.v or flagsValue.v
-                else -> flags.v wo flagsValue.v
             }
         return pressed
     }

--- a/core/src/main/kotlin/imgui/internal/api/widgets.kt
+++ b/core/src/main/kotlin/imgui/internal/api/widgets.kt
@@ -9,7 +9,6 @@ import imgui.ImGui.buttonBehavior
 import imgui.ImGui.calcItemSize
 import imgui.ImGui.calcTextSize
 import imgui.ImGui.calcWrapWidthForPos
-import imgui.ImGui.checkboxFlagsT
 import imgui.ImGui.currentWindow
 import imgui.ImGui.frameHeight
 import imgui.ImGui.getColorU32
@@ -31,7 +30,6 @@ import imgui.api.g
 import imgui.internal.classes.Rect
 import imgui.internal.sections.*
 import kotlin.math.max
-import kotlin.reflect.KMutableProperty0
 
 /** Widgets */
 internal interface widgets {
@@ -39,7 +37,7 @@ internal interface widgets {
     /** Raw text without formatting. Roughly equivalent to text("%s", text) but:
      *  A) doesn't require null terminated string if 'textEnd' is specified
      *  B) it's faster, no memory copy is done, no buffer size limits, recommended for long chunks of text. */
-    fun textEx(text: String, textEnd: Int = -1, flags: TextFlags = emptyFlags()) {
+    fun textEx(text: String, textEnd: Int = -1, flags: TextFlags = emptyFlags) {
         val bytes = text.toByteArray()
         textEx(bytes, if (textEnd != -1) textEnd else bytes.strlen(), flags)
     }
@@ -47,7 +45,7 @@ internal interface widgets {
     /** Raw text without formatting. Roughly equivalent to text("%s", text) but:
      *  A) doesn't require null terminated string if 'textEnd' is specified
      *  B) it's faster, no memory copy is done, no buffer size limits, recommended for long chunks of text. */
-    fun textEx(text: ByteArray, textEnd: Int = text.strlen(), flags: TextFlags = emptyFlags()) {
+    fun textEx(text: ByteArray, textEnd: Int = text.strlen(), flags: TextFlags = emptyFlags) {
 
         val window = currentWindow
         if (window.skipItems)
@@ -143,7 +141,7 @@ internal interface widgets {
         }
     }
 
-    fun buttonEx(label: String, sizeArg: Vec2 = Vec2(), flags_: ButtonFlags = emptyFlags()): Boolean {
+    fun buttonEx(label: String, sizeArg: Vec2 = Vec2(), flags_: ButtonFlags = emptyFlags): Boolean {
 
         val window = currentWindow
         if (window.skipItems) return false
@@ -188,7 +186,7 @@ internal interface widgets {
     }
 
     /** square button with an arrow shape */
-    fun arrowButtonEx(strId: String, dir: Dir, size: Vec2, flags_: ButtonFlags = emptyFlags()): Boolean {
+    fun arrowButtonEx(strId: String, dir: Dir, size: Vec2, flags_: ButtonFlags = emptyFlags): Boolean {
 
         var flags = flags_
 

--- a/core/src/main/kotlin/imgui/internal/api/widgets.kt
+++ b/core/src/main/kotlin/imgui/internal/api/widgets.kt
@@ -29,9 +29,7 @@ import imgui.ImGui.renderTextWrapped
 import imgui.ImGui.style
 import imgui.api.g
 import imgui.internal.classes.Rect
-import imgui.internal.isPowerOfTwo
 import imgui.internal.sections.*
-import unsigned.Ulong
 import kotlin.math.max
 import kotlin.reflect.KMutableProperty0
 
@@ -41,15 +39,15 @@ internal interface widgets {
     /** Raw text without formatting. Roughly equivalent to text("%s", text) but:
      *  A) doesn't require null terminated string if 'textEnd' is specified
      *  B) it's faster, no memory copy is done, no buffer size limits, recommended for long chunks of text. */
-    fun textEx(text: String, textEnd: Int = -1, flag: TextFlag = TextFlag.None) {
+    fun textEx(text: String, textEnd: Int = -1, flags: TextFlags = emptyFlags()) {
         val bytes = text.toByteArray()
-        textEx(bytes, if (textEnd != -1) textEnd else bytes.strlen())
+        textEx(bytes, if (textEnd != -1) textEnd else bytes.strlen(), flags)
     }
 
     /** Raw text without formatting. Roughly equivalent to text("%s", text) but:
      *  A) doesn't require null terminated string if 'textEnd' is specified
      *  B) it's faster, no memory copy is done, no buffer size limits, recommended for long chunks of text. */
-    fun textEx(text: ByteArray, textEnd: Int = text.strlen(), flags: TextFlags = TextFlag.None.i) {
+    fun textEx(text: ByteArray, textEnd: Int = text.strlen(), flags: TextFlags = emptyFlags()) {
 
         val window = currentWindow
         if (window.skipItems)
@@ -145,7 +143,7 @@ internal interface widgets {
         }
     }
 
-    fun buttonEx(label: String, sizeArg: Vec2 = Vec2(), flags_: Int = 0): Boolean {
+    fun buttonEx(label: String, sizeArg: Vec2 = Vec2(), flags_: ButtonFlags = emptyFlags()): Boolean {
 
         val window = currentWindow
         if (window.skipItems) return false
@@ -190,7 +188,7 @@ internal interface widgets {
     }
 
     /** square button with an arrow shape */
-    fun arrowButtonEx(strId: String, dir: Dir, size: Vec2, flags_: ButtonFlags = ButtonFlag.None.i): Boolean {
+    fun arrowButtonEx(strId: String, dir: Dir, size: Vec2, flags_: ButtonFlags = emptyFlags()): Boolean {
 
         var flags = flags_
 
@@ -307,12 +305,6 @@ internal interface widgets {
             }
         }
     }
-
-    fun checkboxFlags(label: String, flags: KMutableProperty0<Long>, flagsValue: Long): Boolean =
-            checkboxFlagsT(label, flags, flagsValue)
-
-    fun checkboxFlags(label: String, flags: KMutableProperty0<Ulong>, flagsValue: Ulong): Boolean =
-            checkboxFlagsT(label, flags, flagsValue)
 
     companion object {
         val isRootOfOpenMenuSet: Boolean

--- a/core/src/main/kotlin/imgui/internal/api/widgetsLowLevelBehaviors.kt
+++ b/core/src/main/kotlin/imgui/internal/api/widgetsLowLevelBehaviors.kt
@@ -122,7 +122,7 @@ internal interface widgetsLowLevelBehaviors {
      *  -------------------------------------------------------------------------------------------------------------------------------------------------
      *
      *  @return [pressed, hovered, held] */
-    fun buttonBehavior(bb: Rect, id: ID, flags_: ButtonFlags = emptyFlags()): BooleanArray {
+    fun buttonBehavior(bb: Rect, id: ID, flags_: ButtonFlags = emptyFlags): BooleanArray {
 
         val window = currentWindow
         var flags = flags_
@@ -539,10 +539,10 @@ internal interface widgetsLowLevelBehaviors {
         return held
     }
 
-    fun treeNodeBehavior(id: ID, flags: TreeNodeFlags = emptyFlags(), label: String): Boolean =
+    fun treeNodeBehavior(id: ID, flags: TreeNodeFlags = emptyFlags, label: String): Boolean =
         treeNodeBehavior(id, flags, label.toByteArray())
 
-    fun treeNodeBehavior(id: ID, flags: TreeNodeFlags = emptyFlags(), label: ByteArray, labelEnd_: Int = -1): Boolean {
+    fun treeNodeBehavior(id: ID, flags: TreeNodeFlags = emptyFlags, label: ByteArray, labelEnd_: Int = -1): Boolean {
 
         val window = currentWindow
         if (window.skipItems)
@@ -597,13 +597,13 @@ internal interface widgetsLowLevelBehaviors {
         if (!itemAdd) {
             if (isOpen && flags hasnt Tnf.NoTreePushOnOpen)
                 treePushOverrideID(id)
-            val f = if (isLeaf) emptyFlags() else ItemStatusFlag.Openable
-            val f2 = if (isOpen) ItemStatusFlag.Opened else emptyFlags()
+            val f = if (isLeaf) emptyFlags else ItemStatusFlag.Openable
+            val f2 = if (isOpen) ItemStatusFlag.Opened else emptyFlags
             IMGUI_TEST_ENGINE_ITEM_INFO(g.lastItemData.id, label.cStr, g.lastItemData.statusFlags or f or f2)
             return isOpen
         }
 
-        var buttonFlags: ButtonFlags = emptyFlags()
+        var buttonFlags: ButtonFlags = emptyFlags
         if (flags has Tnf.AllowItemOverlap)
             buttonFlags = buttonFlags or Bf.AllowItemOverlap
         if (!isLeaf)
@@ -717,8 +717,8 @@ internal interface widgetsLowLevelBehaviors {
 
         if (isOpen && flags hasnt Tnf.NoTreePushOnOpen)
             treePushOverrideID(id)
-        val f = if (isLeaf) emptyFlags() else ItemStatusFlag.Openable
-        val f2 = if (isOpen) ItemStatusFlag.Opened else emptyFlags()
+        val f = if (isLeaf) emptyFlags else ItemStatusFlag.Openable
+        val f2 = if (isOpen) ItemStatusFlag.Opened else emptyFlags
         IMGUI_TEST_ENGINE_ITEM_INFO(id, label.cStr, g.lastItemData.statusFlags or f or f2)
         return isOpen
     }

--- a/core/src/main/kotlin/imgui/internal/api/widgetsWindowDecorations.kt
+++ b/core/src/main/kotlin/imgui/internal/api/widgetsWindowDecorations.kt
@@ -60,7 +60,7 @@ internal interface widgetsWindowDecorations {
         val window = g.currentWindow!!
         val bb = Rect(pos, pos + g.fontSize + ImGui.style.framePadding * 2f)
         ImGui.itemAdd(bb, id)
-        val (pressed, hovered, held) = ImGui.buttonBehavior(bb, id, ButtonFlag.None)
+        val (pressed, hovered, held) = ImGui.buttonBehavior(bb, id)
 
         // Render
         val bgCol = if (held && hovered) Col.ButtonActive else if (hovered) Col.ButtonHovered else Col.Button
@@ -90,7 +90,7 @@ internal interface widgetsWindowDecorations {
 
         // Calculate scrollbar bounding box
         val bb = window getScrollbarRect axis
-        var roundingCorners = DrawFlag.RoundCornersNone.i
+        var roundingCorners: DrawFlags = DrawFlag.RoundCornersNone
         if (axis == Axis.X) {
             roundingCorners = roundingCorners or DrawFlag.RoundCornersBottomLeft
             if (!window.scrollbar.y)
@@ -150,7 +150,7 @@ internal interface widgetsWindowDecorations {
         val grabHNorm = grabHPixels / scrollbarSizeV
 
         // Handle input right away. None of the code of Begin() is relying on scrolling position before calling Scrollbar().
-        ImGui.itemAdd(bbFrame, id, null, ItemFlag.NoNav.i)
+        ImGui.itemAdd(bbFrame, id, null, ItemFlag.NoNav)
         val (_, hovered, held) = ImGui.buttonBehavior(bb, id, ButtonFlag.NoNavFocus)
 
         val scrollMax = max(1L, sizeContentsV - sizeAvailV)

--- a/core/src/main/kotlin/imgui/internal/api/windows.kt
+++ b/core/src/main/kotlin/imgui/internal/api/windows.kt
@@ -1,10 +1,8 @@
 package imgui.internal.api
 
 import glm_.vec2.Vec2
-import imgui.Cond
-import imgui.ID
+import imgui.*
 import imgui.ImGui.markIniSettingsDirty
-import imgui.WindowFlags
 import imgui.api.g
 import imgui.internal.classes.Rect
 import imgui.internal.classes.ShrinkWidthItem
@@ -13,8 +11,6 @@ import imgui.internal.floor
 import imgui.internal.hashStr
 import imgui.WindowFlag as Wf
 
-
-@Suppress("UNCHECKED_CAST")
 
 internal interface windows {
 

--- a/core/src/main/kotlin/imgui/internal/api/windows.kt
+++ b/core/src/main/kotlin/imgui/internal/api/windows.kt
@@ -1,10 +1,10 @@
 package imgui.internal.api
 
-import gli_.has
 import glm_.vec2.Vec2
-import glm_.wo
-import imgui.*
+import imgui.Cond
+import imgui.ID
 import imgui.ImGui.markIniSettingsDirty
+import imgui.WindowFlags
 import imgui.api.g
 import imgui.internal.classes.Rect
 import imgui.internal.classes.ShrinkWidthItem
@@ -144,7 +144,7 @@ internal interface windows {
 
         //        JVM, useless
         //        assert(cond == Cond.None || cond.isPowerOfTwo) { "Make sure the user doesn't attempt to combine multiple condition flags." }
-        setWindowSizeAllowFlags = setWindowSizeAllowFlags and (Cond.Once or Cond.FirstUseEver or Cond.Appearing).inv()
+        setWindowSizeAllowFlags = setWindowSizeAllowFlags wo (Cond.Once or Cond.FirstUseEver or Cond.Appearing)
 
         // Set
         val oldSize = Vec2(sizeFull)
@@ -165,7 +165,7 @@ internal interface windows {
     /** ~SetWindowCollapsed(ImGuiWindow* window, bool collapsed, ImGuiCond cond) */
     fun Window.setCollapsed(collapsed: Boolean, cond: Cond = Cond.None) { // Test condition (NB: bit 0 is always true) and clear flags for next time
         if (cond != Cond.None && setWindowCollapsedAllowFlags hasnt cond) return
-        setWindowCollapsedAllowFlags = setWindowCollapsedAllowFlags and (Cond.Once or Cond.FirstUseEver or Cond.Appearing).inv() // Set
+        setWindowCollapsedAllowFlags = setWindowCollapsedAllowFlags wo (Cond.Once or Cond.FirstUseEver or Cond.Appearing) // Set
         this.collapsed = collapsed
     }
 

--- a/core/src/main/kotlin/imgui/internal/api/windowsDisplayAndFocusOrder.kt
+++ b/core/src/main/kotlin/imgui/internal/api/windowsDisplayAndFocusOrder.kt
@@ -4,8 +4,6 @@ import imgui.ImGui
 import imgui.ImGui.isWithinBeginStackOf
 import imgui.WindowFlag
 import imgui.api.g
-import imgui.has
-import imgui.hasnt
 import imgui.internal.classes.Window
 import imgui.internal.sections.NavLayer
 import imgui.static.findWindowFocusIndex
@@ -69,7 +67,7 @@ internal interface windowsDisplayAndFocusOrder {
             val window = g.windowsFocusOrder[i]
             assert(window === window.rootWindow)
             if (window !== ignoreWindow && window.wasActive)
-                if ((window.flags and (WindowFlag.NoMouseInputs or WindowFlag.NoNavInputs)) != (WindowFlag.NoMouseInputs or WindowFlag.NoNavInputs)) {
+                if ((window.flags and (WindowFlag.NoMouseInputs or WindowFlag.NoNavInputs)) notEq (WindowFlag.NoMouseInputs or WindowFlag.NoNavInputs)) {
                     focusWindow(navRestoreLastChildNavWindow(window))
                     return
                 }

--- a/core/src/main/kotlin/imgui/internal/api/windowsDisplayAndFocusOrder.kt
+++ b/core/src/main/kotlin/imgui/internal/api/windowsDisplayAndFocusOrder.kt
@@ -1,8 +1,7 @@
 package imgui.internal.api
 
-import imgui.ImGui
+import imgui.*
 import imgui.ImGui.isWithinBeginStackOf
-import imgui.WindowFlag
 import imgui.api.g
 import imgui.internal.classes.Window
 import imgui.internal.sections.NavLayer
@@ -67,7 +66,7 @@ internal interface windowsDisplayAndFocusOrder {
             val window = g.windowsFocusOrder[i]
             assert(window === window.rootWindow)
             if (window !== ignoreWindow && window.wasActive)
-                if ((window.flags and (WindowFlag.NoMouseInputs or WindowFlag.NoNavInputs)) notEq (WindowFlag.NoMouseInputs or WindowFlag.NoNavInputs)) {
+                if ((WindowFlag.NoMouseInputs or WindowFlag.NoNavInputs) !in window.flags) {
                     focusWindow(navRestoreLastChildNavWindow(window))
                     return
                 }

--- a/core/src/main/kotlin/imgui/internal/classes/InputTextState.kt
+++ b/core/src/main/kotlin/imgui/internal/classes/InputTextState.kt
@@ -2,8 +2,11 @@ package imgui.internal.classes
 
 import glm_.glm
 import glm_.max
-import imgui.*
+import imgui.ID
+import imgui.InputTextFlag
+import imgui.InputTextFlags
 import imgui.classes.Context
+import imgui.emptyFlags
 import imgui.internal.isBlankW
 import imgui.internal.textCountUtf8BytesFromStr
 import imgui.static.inputTextCalcTextSizeW
@@ -57,7 +60,7 @@ class InputTextState(
     var edited = false
 
     /** copy of InputText() flags. may be used to check if e.g. ImGuiInputTextFlags_Password is set. */
-    var flags: InputTextFlags = 0
+    var flags: InputTextFlags = emptyFlags()
 
     fun clearText() {
         curLenW = 0

--- a/core/src/main/kotlin/imgui/internal/classes/InputTextState.kt
+++ b/core/src/main/kotlin/imgui/internal/classes/InputTextState.kt
@@ -2,11 +2,8 @@ package imgui.internal.classes
 
 import glm_.glm
 import glm_.max
-import imgui.ID
-import imgui.InputTextFlag
-import imgui.InputTextFlags
+import imgui.*
 import imgui.classes.Context
-import imgui.emptyFlags
 import imgui.internal.isBlankW
 import imgui.internal.textCountUtf8BytesFromStr
 import imgui.static.inputTextCalcTextSizeW
@@ -60,7 +57,7 @@ class InputTextState(
     var edited = false
 
     /** copy of InputText() flags. may be used to check if e.g. ImGuiInputTextFlags_Password is set. */
-    var flags: InputTextFlags = emptyFlags()
+    var flags: InputTextFlags = emptyFlags
 
     fun clearText() {
         curLenW = 0

--- a/core/src/main/kotlin/imgui/internal/classes/TabBar.kt
+++ b/core/src/main/kotlin/imgui/internal/classes/TabBar.kt
@@ -2,8 +2,8 @@ package imgui.internal.classes
 
 import glm_.vec2.Vec2
 import imgui.ID
-import imgui.TabBarFlag
 import imgui.TabBarFlags
+import imgui.emptyFlags
 
 class TabBarSection {
     /** Number of tabs in this section. */
@@ -21,7 +21,7 @@ class TabBar {
 
     val tabs = ArrayList<TabItem>()
 
-    var flags: TabBarFlags = TabBarFlag.None.i
+    var flags: TabBarFlags = emptyFlags()
 
     /** Zero for tab-bars used by docking */
     var id: ID = 0

--- a/core/src/main/kotlin/imgui/internal/classes/TabBar.kt
+++ b/core/src/main/kotlin/imgui/internal/classes/TabBar.kt
@@ -21,7 +21,7 @@ class TabBar {
 
     val tabs = ArrayList<TabItem>()
 
-    var flags: TabBarFlags = emptyFlags()
+    var flags: TabBarFlags = emptyFlags
 
     /** Zero for tab-bars used by docking */
     var id: ID = 0

--- a/core/src/main/kotlin/imgui/internal/classes/Table.kt
+++ b/core/src/main/kotlin/imgui/internal/classes/Table.kt
@@ -1,14 +1,12 @@
 package imgui.internal.classes
 
-import glm_.*
-import imgui.*
-import imgui.ImGui.fixColumnSortDirection
+import imgui.ID
+import imgui.TableFlags
+import imgui.TableRowFlags
 import imgui.classes.TableColumnSortSpecs
 import imgui.classes.TableSortSpecs
-import imgui.internal.*
-import imgui.TableColumnFlag as Tcf
-import imgui.TableFlag as Tf
-import imgui.TableRowFlag as Trf
+import imgui.emptyFlags
+import imgui.internal.DrawListSplitter
 
 
 /** FIXME-TABLE: more transient data could be stored in a stacked ImGuiTableTempData: e.g. SortSpecs, incoming RowData */
@@ -16,7 +14,7 @@ class Table {
 
     var id: ID = 0
 
-    var flags = Tf.None.i
+    var flags: TableFlags = emptyFlags()
 
     /** Single allocation to hold Columns[], DisplayOrderToIndex[] and RowCellData[] */
     //    var rawData: Any? = null
@@ -46,7 +44,7 @@ class Table {
     var requestOutputMaskByIndex = 0L
 
     /** Which data were loaded from the .ini file (e.g. when order is not altered we won't save order) */
-    var settingsLoadedFlags = Tf.None.i
+    var settingsLoadedFlags: TableFlags = emptyFlags()
 
     /** Offset in g.SettingsTables */
     var settingsOffset = 0
@@ -78,9 +76,9 @@ class Table {
     var rowIndentOffsetX = 0f
 
     /** Current row flags, see ImGuiTableRowFlags_ */
-    var rowFlags = Trf.None.i
+    var rowFlags: TableRowFlags = emptyFlags()
 
-    var lastRowFlags = Trf.None.i
+    var lastRowFlags: TableRowFlags = emptyFlags()
 
     /** Counter for alternating background colors (can be fast-forwarded by e.g clipper), not same as CurrentRow because header rows typically don't increase this. */
     var rowBgColorCounter = 0

--- a/core/src/main/kotlin/imgui/internal/classes/Table.kt
+++ b/core/src/main/kotlin/imgui/internal/classes/Table.kt
@@ -14,7 +14,7 @@ class Table {
 
     var id: ID = 0
 
-    var flags: TableFlags = emptyFlags()
+    var flags: TableFlags = emptyFlags
 
     /** Single allocation to hold Columns[], DisplayOrderToIndex[] and RowCellData[] */
     //    var rawData: Any? = null
@@ -44,7 +44,7 @@ class Table {
     var requestOutputMaskByIndex = 0L
 
     /** Which data were loaded from the .ini file (e.g. when order is not altered we won't save order) */
-    var settingsLoadedFlags: TableFlags = emptyFlags()
+    var settingsLoadedFlags: TableFlags = emptyFlags
 
     /** Offset in g.SettingsTables */
     var settingsOffset = 0
@@ -76,9 +76,9 @@ class Table {
     var rowIndentOffsetX = 0f
 
     /** Current row flags, see ImGuiTableRowFlags_ */
-    var rowFlags: TableRowFlags = emptyFlags()
+    var rowFlags: TableRowFlags = emptyFlags
 
-    var lastRowFlags: TableRowFlags = emptyFlags()
+    var lastRowFlags: TableRowFlags = emptyFlags
 
     /** Counter for alternating background colors (can be fast-forwarded by e.g clipper), not same as CurrentRow because header rows typically don't increase this. */
     var rowBgColorCounter = 0

--- a/core/src/main/kotlin/imgui/internal/classes/Window.kt
+++ b/core/src/main/kotlin/imgui/internal/classes/Window.kt
@@ -30,7 +30,7 @@ class Window(var context: Context,
     val id: ID = hashStr(name)
 
     /** See enum ImGuiWindowFlags_ */
-    var flags: WindowFlags = emptyFlags()
+    var flags: WindowFlags = emptyFlags
 
     /** Always set in Begin(). Inactive windows may have a NULL value here if their viewport was discarded. */
     var viewport: ViewportP? = null
@@ -421,7 +421,7 @@ class Window(var context: Context,
     }
 
     val isContentHoverable: Boolean
-        get() = isContentHoverable(emptyFlags())
+        get() = isContentHoverable(emptyFlags)
 
     /** ~CalcWindowAutoFitSize */
     fun calcAutoFitSize(sizeContents: Vec2): Vec2 {
@@ -516,9 +516,9 @@ class Window(var context: Context,
             newSize.x = if (cr.min.x >= 0 && cr.max.x >= 0) glm.clamp(newSize.x, cr.min.x, cr.max.x) else sizeFull.x
             newSize.y = if (cr.min.y >= 0 && cr.max.y >= 0) glm.clamp(newSize.y, cr.min.y, cr.max.y) else sizeFull.y
             g.nextWindowData.sizeCallback?.invoke(SizeCallbackData(userData = g.nextWindowData.sizeCallbackUserData,
-                                                                   pos = Vec2(this@Window.pos),
-                                                                   currentSize = sizeFull,
-                                                                   desiredSize = newSize))
+                pos = Vec2(this@Window.pos),
+                currentSize = sizeFull,
+                desiredSize = newSize))
             newSize.x = floor(newSize.x)
             newSize.y = floor(newSize.y)
         }

--- a/core/src/main/kotlin/imgui/internal/classes/Window.kt
+++ b/core/src/main/kotlin/imgui/internal/classes/Window.kt
@@ -1,6 +1,5 @@
 package imgui.internal.classes
 
-import gli_.hasnt
 import glm_.*
 import glm_.vec2.Vec2
 import glm_.vec2.Vec2bool
@@ -31,7 +30,7 @@ class Window(var context: Context,
     val id: ID = hashStr(name)
 
     /** See enum ImGuiWindowFlags_ */
-    var flags = Wf.None.i
+    var flags: WindowFlags = emptyFlags()
 
     /** Always set in Begin(). Inactive windows may have a NULL value here if their viewport was discarded. */
     var viewport: ViewportP? = null
@@ -176,13 +175,13 @@ class Window(var context: Context,
     var disableInputsFrames = 0
 
     /** store acceptable condition flags for SetNextWindowPos() use. */
-    var setWindowPosAllowFlags = Cond.Always or Cond.Once or Cond.FirstUseEver or Cond.Appearing
+    var setWindowPosAllowFlags: CondFlags = Cond.Always or Cond.Once or Cond.FirstUseEver or Cond.Appearing
 
     /** store acceptable condition flags for SetNextWindowSize() use.    */
-    var setWindowSizeAllowFlags = Cond.Always or Cond.Once or Cond.FirstUseEver or Cond.Appearing
+    var setWindowSizeAllowFlags: CondFlags = Cond.Always or Cond.Once or Cond.FirstUseEver or Cond.Appearing
 
     /** store acceptable condition flags for SetNextWindowCollapsed() use.   */
-    var setWindowCollapsedAllowFlags = Cond.Always or Cond.Once or Cond.FirstUseEver or Cond.Appearing
+    var setWindowCollapsedAllowFlags: CondFlags = Cond.Always or Cond.Once or Cond.FirstUseEver or Cond.Appearing
 
     /** store window position when using a non-zero Pivot (position set needs to be processed when we know the window size) */
     var setWindowPosVal = Vec2(Float.MAX_VALUE)
@@ -400,10 +399,6 @@ class Window(var context: Context,
 
     // sparse static methods
 
-
-    /** ~IsWindowContentHoverable */
-    infix fun isContentHoverable(flag: HoveredFlag): Boolean = isContentHoverable(flag.i)
-
     /** ~IsWindowContentHoverable */
     infix fun isContentHoverable(flags: HoveredFlags): Boolean { // An active popup disable hovering on other windows (apart from its own children)
         // FIXME-OPT: This could be cached/stored within the window.
@@ -424,6 +419,9 @@ class Window(var context: Context,
         }
         return true
     }
+
+    val isContentHoverable: Boolean
+        get() = isContentHoverable(emptyFlags())
 
     /** ~CalcWindowAutoFitSize */
     fun calcAutoFitSize(sizeContents: Vec2): Vec2 {
@@ -476,7 +474,7 @@ class Window(var context: Context,
     }
 
     /** ~SetWindowConditionAllowFlags */
-    fun setConditionAllowFlags(flags: Int, enabled: Boolean) = if (enabled) {
+    fun setConditionAllowFlags(flags: CondFlags, enabled: Boolean) = if (enabled) {
         setWindowPosAllowFlags = setWindowPosAllowFlags or flags
         setWindowSizeAllowFlags = setWindowSizeAllowFlags or flags
         setWindowCollapsedAllowFlags = setWindowCollapsedAllowFlags or flags

--- a/core/src/main/kotlin/imgui/internal/classes/misc.kt
+++ b/core/src/main/kotlin/imgui/internal/classes/misc.kt
@@ -1,5 +1,6 @@
 package imgui.internal.classes
 
+import com.livefront.sealedenum.GenSealedEnum
 import glm_.*
 import glm_.vec2.Vec2
 import glm_.vec4.Vec4
@@ -124,23 +125,25 @@ class LocEntry(val key: LocKey, val text: String)
 
 typealias DebugLogFlags = Flag<DebugLogFlag>
 
-enum class DebugLogFlag(i: Int? = null) : Flag<DebugLogFlag> {
+sealed class DebugLogFlag(val int: Int? = null) : FlagBase<DebugLogFlag>() {
     // Event types
-    EventActiveId,
-    EventFocus,
-    EventPopup,
-    EventNav,
-    EventClipper,
-    EventIO,
+    object EventActiveId : DebugLogFlag()
+
+    object EventFocus : DebugLogFlag()
+    object EventPopup : DebugLogFlag()
+    object EventNav : DebugLogFlag()
+    object EventClipper : DebugLogFlag()
+    object EventIO : DebugLogFlag()
 
     /** Also send output to TTY */
-    OutputToTTY(1 shl 10);
+    object OutputToTTY : DebugLogFlag(1 shl 10)
 
+    @GenSealedEnum
     companion object {
-        val EventMask: DebugLogFlags = EventActiveId or EventFocus or EventPopup or EventNav or EventClipper or EventIO
+        val EventMask: DebugLogFlags get() = EventActiveId or EventFocus or EventPopup or EventNav or EventClipper or EventIO
     }
 
-    override val i: Int = i ?: (1 shl ordinal)
+    override val i: Int = int ?: (1 shl ordinal)
 }
 
 // (+ for upcoming advanced versions of IsKeyPressed()/IsMouseClicked()/SetKeyOwner()/SetItemKeyOwner() that are currently in imgui_internal.h)
@@ -149,27 +152,27 @@ typealias InputFlags = Flag<InputFlag>
 
 /** Flags for extended versions of IsKeyPressed(), IsMouseClicked(), Shortcut(), SetKeyOwner(), SetItemKeyOwner()
  *  Don't mistake with ImGuiInputTextFlags! (for ImGui::InputText() function) */
-enum class InputFlag : Flag<InputFlag> {
+sealed class InputFlag : FlagBase<InputFlag>() {
     /** Return true on successive repeats. Default for legacy IsKeyPressed(). NOT Default for legacy IsMouseClicked(). MUST BE == 1. */
-    Repeat,
+    object Repeat : InputFlag()
 
     // Repeat rate
-    RepeatRateDefault,   // Repeat rate: Regular (default)
-    RepeatRateNavMove,   // Repeat rate: Fast
-    RepeatRateNavTweak,   // Repeat rate: Faster
+    object RepeatRateDefault : InputFlag()   // Repeat rate: Regular (default)
+    object RepeatRateNavMove : InputFlag()   // Repeat rate: Fast
+    object RepeatRateNavTweak : InputFlag()   // Repeat rate: Faster
 
 
     // Flags for SetItemKeyOwner()
-    CondHovered,   // Only set if item is hovered (default to both)
-    CondActive,   // Only set if item is active (default to both)
+    object CondHovered : InputFlag()   // Only set if item is hovered (default to both)
+    object CondActive : InputFlag()   // Only set if item is active (default to both)
 
     // Flags for SetKeyOwner(), SetItemKeyOwner()
 
     /** Access to key data will require EXPLICIT owner ID (ImGuiKeyOwner_Any/0 will NOT accepted for polling). Cleared at end of frame. This is useful to make input-owner-aware code steal keys from non-input-owner-aware code. */
-    LockThisFrame,
+    object LockThisFrame : InputFlag()
 
     /** Access to key data will require EXPLICIT owner ID (ImGuiKeyOwner_Any/0 will NOT accepted for polling). Cleared when the key is released or at end of each frame if key is released. This is useful to make input-owner-aware code steal keys from non-input-owner-aware code. */
-    LockUntilRelease,
+    object LockUntilRelease : InputFlag()
 
     // Routing policies for Shortcut() + low-level SetShortcutRouting()
     // - The general idea is that several callers register interest in a shortcut, and only one owner gets it.
@@ -183,42 +186,42 @@ enum class InputFlag : Flag<InputFlag> {
     // - Can select only 1 policy among all available.
 
     /** (Default) Register focused route: Accept inputs if window is in focus stack. Deep-most focused window takes inputs. ActiveId takes inputs over deep-most focused window. */
-    RouteFocused,
+    object RouteFocused : InputFlag()
 
     /** Register route globally (lowest priority: unless a focused window or active item registered the route) -> recommended Global priority. */
-    RouteGlobalLow,
+    object RouteGlobalLow : InputFlag()
 
     /** Register route globally (medium priority: unless an active item registered the route, e.g. CTRL+A registered by InputText). */
-    RouteGlobal,
+    object RouteGlobal : InputFlag()
 
     /** Register route globally (highest priority: unlikely you need to use that: will interfere with every active items) */
-    RouteGlobalHigh,
-
+    object RouteGlobalHigh : InputFlag()
 
     /** Do not register route, poll keys directly. */
-    RouteAlways,
+    object RouteAlways : InputFlag()
 
     /** Global routes will not be applied if underlying background/void is focused (== no Dear ImGui windows are focused). Useful for overlay applications. */
-    RouteUnlessBgFocused;
+    object RouteUnlessBgFocused : InputFlag()
 
     override val i: Int = 1 shl ordinal
 
+    @GenSealedEnum
     companion object {
-        val RepeatRateMask = RepeatRateDefault or RepeatRateNavMove or RepeatRateNavTweak
-        val CondDefault = CondHovered or CondActive
-        val CondMask = CondHovered or CondActive
+        val RepeatRateMask get() = RepeatRateDefault or RepeatRateNavMove or RepeatRateNavTweak
+        val CondDefault get() = CondHovered or CondActive
+        val CondMask get() = CondHovered or CondActive
 
         /** _Always not part of this! */
-        val RouteMask = RouteFocused or RouteGlobal or RouteGlobalLow or RouteGlobalHigh
+        val RouteMask get() = RouteFocused or RouteGlobal or RouteGlobalLow or RouteGlobalHigh
 
         // [Internal] Mask of which function support which flags
-        val RouteExtraMask = RouteAlways or RouteUnlessBgFocused
+        val RouteExtraMask get() = RouteAlways or RouteUnlessBgFocused
 
         // [Internal] Mask of which function support which flags
-        val SupportedByIsKeyPressed = Repeat or RepeatRateMask
-        val SupportedByShortcut = Repeat or RepeatRateMask or RouteMask or RouteExtraMask
-        val SupportedBySetKeyOwner = LockThisFrame or LockUntilRelease
-        val SupportedBySetItemKeyOwner = SupportedBySetKeyOwner or CondMask
+        val SupportedByIsKeyPressed get() = Repeat or RepeatRateMask
+        val SupportedByShortcut get() = Repeat or RepeatRateMask or RouteMask or RouteExtraMask
+        val SupportedBySetKeyOwner get() = LockThisFrame or LockUntilRelease
+        val SupportedBySetItemKeyOwner get() = SupportedBySetKeyOwner or CondMask
     }
 }
 
@@ -255,10 +258,10 @@ class StackTool {
 
 /** Storage for SetNextWindow** functions    */
 class NextWindowData {
-    var flags: NextWindowDataFlags = emptyFlags()
-    var posCond = Cond.None
-    var sizeCond = Cond.None
-    var collapsedCond = Cond.None
+    var flags: NextWindowDataFlags = emptyFlags
+    var posCond: Cond = Cond.None
+    var sizeCond: Cond = Cond.None
+    var collapsedCond: Cond = Cond.None
     val posVal = Vec2()
     val posPivotVal = Vec2()
     val sizeVal = Vec2()
@@ -278,12 +281,12 @@ class NextWindowData {
     var menuBarOffsetMinVal = Vec2()
 
     fun clearFlags() {
-        flags = emptyFlags()
+        flags = emptyFlags
     }
 }
 
 data class NextItemData(
-    var flags: NextItemDataFlags = emptyFlags(),
+    var flags: NextItemDataFlags = emptyFlags,
 
     /** Set by SetNextItemWidth() */
     var width: Float = 0f,
@@ -298,7 +301,7 @@ data class NextItemData(
 
     /** Also cleared manually by ItemAdd()! */
     fun clearFlags() {
-        flags = emptyFlags()
+        flags = emptyFlags
     }
 }
 
@@ -306,8 +309,8 @@ data class NextItemData(
 // TODO -> data class?
 class LastItemData {
     var id: ID = 0
-    var inFlags: ItemFlags = emptyFlags() // See ImGuiItemFlags_
-    var statusFlags: ItemStatusFlags = emptyFlags() // See ImGuiItemStatusFlags_
+    var inFlags: ItemFlags = emptyFlags // See ImGuiItemFlags_
+    var statusFlags: ItemStatusFlags = emptyFlags // See ImGuiItemStatusFlags_
     val rect = Rect() // Full rectangle
     val navRect = Rect() // Navigation scoring rectangle (not displayed)
     val displayRect = Rect() // Display rectangle (only if ImGuiItemStatusFlags_HasDisplayRect is set)
@@ -480,7 +483,7 @@ class ComboPreviewData {
 /** Storage for one active tab item (sizeof() 40 bytes) */
 class TabItem {
     var id: ID = 0
-    var flags: TabItemFlags = emptyFlags()
+    var flags: TabItemFlags = emptyFlags
     var lastFrameVisible = -1
 
     /** This allows us to infer an ordered list of the last activated tabs with little maintenance */

--- a/core/src/main/kotlin/imgui/internal/classes/tables.kt
+++ b/core/src/main/kotlin/imgui/internal/classes/tables.kt
@@ -4,11 +4,8 @@ import glm_.*
 import glm_.vec2.Vec2
 import imgui.*
 import imgui.api.g
-import imgui.classes.TableColumnSortSpecs
 import imgui.internal.*
 import imgui.internal.sections.NavLayer
-import imgui.TableColumnFlag as Tcf
-import imgui.TableFlag as Tf
 
 /** Special sentinel code which cannot be used as a regular color. */
 val COL32_DISABLE = COL32(0, 0, 0, 1)
@@ -30,7 +27,7 @@ typealias TableDrawChannelIdx = Int
 class TableColumn {
 
     /** Flags after some patching (not directly same as provided by user). See ImGuiTableColumnFlags_ */
-    var flags = Tcf.None.i
+    var flags: TableColumnFlags = emptyFlags()
 
     /** Final/actual width visible == (MaxX - MinX), locked in TableUpdateLayout(). May be > WidthRequest to honor minimum width, may be < WidthRequest to honor shrinking columns down in tight space. */
     var widthGiven = 0f
@@ -236,7 +233,7 @@ class TableSettings(
         var columnsCount: TableColumnIdx = 0) {
 
     /** Indicate data we want to save using the Resizable/Reorderable/Sortable/Hideable flags (could be using its own flags..) */
-    var saveFlags = Tf.None.i
+    var saveFlags: TableFlags = emptyFlags()
 
     /** Reference scale to be able to rescale columns on font/dpi changes. */
     var refScale = 0f

--- a/core/src/main/kotlin/imgui/internal/classes/tables.kt
+++ b/core/src/main/kotlin/imgui/internal/classes/tables.kt
@@ -27,7 +27,7 @@ typealias TableDrawChannelIdx = Int
 class TableColumn {
 
     /** Flags after some patching (not directly same as provided by user). See ImGuiTableColumnFlags_ */
-    var flags: TableColumnFlags = emptyFlags()
+    var flags: TableColumnFlags = emptyFlags
 
     /** Final/actual width visible == (MaxX - MinX), locked in TableUpdateLayout(). May be > WidthRequest to honor minimum width, may be < WidthRequest to honor shrinking columns down in tight space. */
     var widthGiven = 0f
@@ -233,7 +233,7 @@ class TableSettings(
         var columnsCount: TableColumnIdx = 0) {
 
     /** Indicate data we want to save using the Resizable/Reorderable/Sortable/Hideable flags (could be using its own flags..) */
-    var saveFlags: TableFlags = emptyFlags()
+    var saveFlags: TableFlags = emptyFlags
 
     /** Reference scale to be able to rescale columns on font/dpi changes. */
     var refScale = 0f

--- a/core/src/main/kotlin/imgui/internal/sections/Columns support.kt
+++ b/core/src/main/kotlin/imgui/internal/sections/Columns support.kt
@@ -1,6 +1,8 @@
 package imgui.internal.sections
 
+import com.livefront.sealedenum.GenSealedEnum
 import imgui.Flag
+import imgui.FlagBase
 import imgui.ID
 import imgui.emptyFlags
 import imgui.internal.DrawListSplitter
@@ -15,24 +17,28 @@ import imgui.internal.classes.Rect
 typealias OldColumnsFlags = Flag<OldColumnsFlag>
 
 /** Flags: for Columns(), BeginColumns() */
-enum class OldColumnsFlag : Flag<OldColumnsFlag> {
+sealed class OldColumnsFlag : FlagBase<OldColumnsFlag>() {
+
     /** Disable column dividers */
-    NoBorder,
+    object NoBorder : OldColumnsFlag()
 
     /** Disable resizing columns when clicking on the dividers  */
-    NoResize,
+    object NoResize : OldColumnsFlag()
 
     /** Disable column width preservation when adjusting columns    */
-    NoPreserveWidths,
+    object NoPreserveWidths : OldColumnsFlag()
 
     /** Disable forcing columns to fit within window    */
-    NoForceWithinWindow,
+    object NoForceWithinWindow : OldColumnsFlag()
 
     /** (WIP) Restore pre-1.51 behavior of extending the parent window contents size but _without affecting the columns
      *  width at all_. Will eventually remove.  */
-    GrowParentContentsSize;
+    object GrowParentContentsSize : OldColumnsFlag()
 
     override val i: Int = 1 shl ordinal
+
+    @GenSealedEnum
+    companion object
 }
 
 /** Storage data for a single column for legacy Columns() api */
@@ -42,14 +48,14 @@ class OldColumnData {
     var offsetNormBeforeResize = 0f
 
     /** Not exposed */
-    var flags: OldColumnsFlags = emptyFlags()
+    var flags: OldColumnsFlags = emptyFlags
     var clipRect = Rect()
 }
 
 /** Storage data for a columns set for legacy Columns() api */
 class OldColumns {
     var id: ID = 0
-    var flags: OldColumnsFlags = emptyFlags()
+    var flags: OldColumnsFlags = emptyFlags
     var isFirstFrame = false
     var isBeingResized = false
     var current = 0

--- a/core/src/main/kotlin/imgui/internal/sections/Columns support.kt
+++ b/core/src/main/kotlin/imgui/internal/sections/Columns support.kt
@@ -2,6 +2,7 @@ package imgui.internal.sections
 
 import imgui.Flag
 import imgui.ID
+import imgui.emptyFlags
 import imgui.internal.DrawListSplitter
 import imgui.internal.classes.Rect
 
@@ -11,13 +12,10 @@ import imgui.internal.classes.Rect
 //-----------------------------------------------------------------------------
 
 
-typealias OldColumnsFlags = Int
+typealias OldColumnsFlags = Flag<OldColumnsFlag>
 
 /** Flags: for Columns(), BeginColumns() */
 enum class OldColumnsFlag : Flag<OldColumnsFlag> {
-
-    None,
-
     /** Disable column dividers */
     NoBorder,
 
@@ -34,7 +32,7 @@ enum class OldColumnsFlag : Flag<OldColumnsFlag> {
      *  width at all_. Will eventually remove.  */
     GrowParentContentsSize;
 
-    override val i: OldColumnsFlags = if (ordinal == 0) 0 else 1 shl (ordinal - 1)
+    override val i: Int = 1 shl ordinal
 }
 
 /** Storage data for a single column for legacy Columns() api */
@@ -44,14 +42,14 @@ class OldColumnData {
     var offsetNormBeforeResize = 0f
 
     /** Not exposed */
-    var flags: OldColumnsFlags = 0
+    var flags: OldColumnsFlags = emptyFlags()
     var clipRect = Rect()
 }
 
 /** Storage data for a columns set for legacy Columns() api */
 class OldColumns {
     var id: ID = 0
-    var flags: OldColumnsFlags = OldColumnsFlag.None.i
+    var flags: OldColumnsFlags = emptyFlags()
     var isFirstFrame = false
     var isBeingResized = false
     var current = 0

--- a/core/src/main/kotlin/imgui/internal/sections/Input support.kt
+++ b/core/src/main/kotlin/imgui/internal/sections/Input support.kt
@@ -69,7 +69,7 @@ class KeyRoutingData {
     var nextEntryIndex: KeyRoutingIndex = -1
 
     /** Technically we'd only need 4-bits but for simplify we store ImGuiMod_ values which need 16-bits. ImGuiMod_Shortcut is already translated to Ctrl/Super. */
-    var mods: KeyChord = emptyFlags()
+    var mods: KeyChord = emptyFlags
     var routingNextScore = 255               // Lower is better (0: perfect score)
     var routingCurr: ID = KeyOwner_None
     var routingNext: ID = KeyOwner_None

--- a/core/src/main/kotlin/imgui/internal/sections/Input support.kt
+++ b/core/src/main/kotlin/imgui/internal/sections/Input support.kt
@@ -1,6 +1,9 @@
 package imgui.internal.sections
 
-import imgui.*
+import imgui.ID
+import imgui.Key
+import imgui.KeyChord
+import imgui.emptyFlags
 
 
 enum class InputSource {
@@ -30,8 +33,10 @@ sealed class InputEvent {
         override val source: InputSource = InputSource.Mouse
     }
 
-    class MouseButton(val button: Int,
-                      val down: Boolean) : InputEvent() {
+    class MouseButton(
+        val button: imgui.MouseButton,
+        val down: Boolean
+    ) : InputEvent() {
         override val source: InputSource = InputSource.Mouse
     }
 
@@ -62,8 +67,9 @@ typealias KeyRoutingIndex = Int
 // Routing table entry (sizeof() == 16 bytes)
 class KeyRoutingData {
     var nextEntryIndex: KeyRoutingIndex = -1
+
     /** Technically we'd only need 4-bits but for simplify we store ImGuiMod_ values which need 16-bits. ImGuiMod_Shortcut is already translated to Ctrl/Super. */
-    var mods = 0
+    var mods: KeyChord = emptyFlags()
     var routingNextScore = 255               // Lower is better (0: perfect score)
     var routingCurr: ID = KeyOwner_None
     var routingNext: ID = KeyOwner_None

--- a/core/src/main/kotlin/imgui/internal/sections/Macros.kt
+++ b/core/src/main/kotlin/imgui/internal/sections/Macros.kt
@@ -2,7 +2,6 @@ package imgui.internal.sections
 
 import imgui.ImGui
 import imgui.api.g
-import imgui.has
 import imgui.internal.classes.DebugLogFlag
 
 

--- a/core/src/main/kotlin/imgui/internal/sections/Macros.kt
+++ b/core/src/main/kotlin/imgui/internal/sections/Macros.kt
@@ -2,6 +2,7 @@ package imgui.internal.sections
 
 import imgui.ImGui
 import imgui.api.g
+import imgui.has
 import imgui.internal.classes.DebugLogFlag
 
 

--- a/core/src/main/kotlin/imgui/internal/sections/Navigation support.kt
+++ b/core/src/main/kotlin/imgui/internal/sections/Navigation support.kt
@@ -2,17 +2,14 @@ package imgui.internal.sections
 
 import imgui.Flag
 import imgui.internal.classes.Rect
-import imgui.or
 
 //-----------------------------------------------------------------------------
 // [SECTION] Navigation support
 //-----------------------------------------------------------------------------
 
-typealias ActivateFlags = Int
+typealias ActivateFlags = Flag<ActivateFlag>
 
 enum class ActivateFlag : Flag<ActivateFlag> {
-  None,
-
   /** Favor activation that requires keyboard text input (e.g. for Slider/Drag). Default if keyboard is available. */
   PreferInput,
 
@@ -22,56 +19,57 @@ enum class ActivateFlag : Flag<ActivateFlag> {
   /** Request widget to preserve state if it can (e.g. InputText will try to preserve cursor/selection) */
   TryToPreserveState;
 
-  override val i: ActivateFlags = if (ordinal == 0) 0 else 1 shl (ordinal - 1)
+  override val i: Int = 1 shl ordinal
 }
 
-typealias ScrollFlags = Int
+typealias ScrollFlags = Flag<ScrollFlag>
 
-enum class ScrollFlag(override val i: ScrollFlags) : Flag<ScrollFlag> {
-  None(0),
-
+enum class ScrollFlag : Flag<ScrollFlag> {
   /** If item is not visible: scroll as little as possible on X axis to bring item back into view [default for X axis] */
-  KeepVisibleEdgeX(1 shl 0),
+  KeepVisibleEdgeX,
 
   /** If item is not visible: scroll as little as possible on Y axis to bring item back into view [default for Y axis for windows that are already visible] */
-  KeepVisibleEdgeY(1 shl 1),
+  KeepVisibleEdgeY,
 
   /** If item is not visible: scroll to make the item centered on X axis [rarely used] */
-  KeepVisibleCenterX(1 shl 2),
+  KeepVisibleCenterX,
 
-    /** If item is not visible: scroll to make the item centered on Y axis */
-    KeepVisibleCenterY(1 shl 3),
+  /** If item is not visible: scroll to make the item centered on Y axis */
+  KeepVisibleCenterY,
 
-    /** Always center the result item on X axis [rarely used] */
-    AlwaysCenterX(1 shl 4),
+  /** Always center the result item on X axis [rarely used] */
+  AlwaysCenterX,
 
-    /** Always center the result item on Y axis [default for Y axis for appearing window) */
-    AlwaysCenterY(1 shl 5),
+  /** Always center the result item on Y axis [default for Y axis for appearing window) */
+  AlwaysCenterY,
 
-    /** Disable forwarding scrolling to parent window if required to keep item/rect visible (only scroll window the function was applied to). */
-    NoScrollParent(1 shl 6),
-  MaskX_(KeepVisibleEdgeX or KeepVisibleCenterX or AlwaysCenterX),
-  MaskY_(KeepVisibleEdgeY or KeepVisibleCenterY or AlwaysCenterY)
+  /** Disable forwarding scrolling to parent window if required to keep item/rect visible (only scroll window the function was applied to). */
+  NoScrollParent;
+
+  override val i: Int = 1 shl ordinal
+
+  companion object {
+    val MaskX = KeepVisibleEdgeX or KeepVisibleCenterX or AlwaysCenterX
+    val MaskY = KeepVisibleEdgeY or KeepVisibleCenterY or AlwaysCenterY
+  }
 }
 
 
-typealias NavHighlightFlags = Int
+typealias NavHighlightFlags = Flag<NavHighlightFlag>
 
 enum class NavHighlightFlag : Flag<NavHighlightFlag> {
-  None, TypeDefault, TypeThin,
+  TypeDefault, TypeThin,
 
   /** Draw rectangular highlight if (g.NavId == id) _even_ when using the mouse. */
   AlwaysDraw,
   NoRounding;
 
-  override val i: NavHighlightFlags = if (ordinal == 0) 0 else 1 shl (ordinal - 1)
+  override val i: Int = 1 shl ordinal
 }
 
-typealias NavMoveFlags = Int
+typealias NavMoveFlags = Flag<NavMoveFlag>
 
 enum class NavMoveFlag : Flag<NavMoveFlag> {
-  None,
-
   /** On failed request, restart from opposite side */
   LoopX,
   LoopY,
@@ -103,7 +101,7 @@ enum class NavMoveFlag : Flag<NavMoveFlag> {
     /** Do not alter the visible state of keyboard vs mouse nav highlight */
     DontSetNavHighlight;
 
-  override val i: NavMoveFlags = if (ordinal == 0) 0 else 1 shl (ordinal - 1)
+  override val i: Int = 1 shl ordinal
 }
 
 enum class NavForward(val i: Int) {

--- a/core/src/main/kotlin/imgui/internal/sections/Navigation support.kt
+++ b/core/src/main/kotlin/imgui/internal/sections/Navigation support.kt
@@ -1,7 +1,10 @@
 package imgui.internal.sections
 
+import com.livefront.sealedenum.GenSealedEnum
 import imgui.Flag
+import imgui.FlagBase
 import imgui.internal.classes.Rect
+import imgui.or
 
 //-----------------------------------------------------------------------------
 // [SECTION] Navigation support
@@ -9,99 +12,120 @@ import imgui.internal.classes.Rect
 
 typealias ActivateFlags = Flag<ActivateFlag>
 
-enum class ActivateFlag : Flag<ActivateFlag> {
-  /** Favor activation that requires keyboard text input (e.g. for Slider/Drag). Default if keyboard is available. */
-  PreferInput,
+sealed class ActivateFlag : FlagBase<ActivateFlag>() {
 
-  /** Favor activation for tweaking with arrows or gamepad (e.g. for Slider/Drag). Default if keyboard is not available. */
-  PreferTweak,
+    /** Favor activation that requires keyboard text input (e.g. for Slider/Drag). Default if keyboard is available. */
+    object PreferInput : ActivateFlag()
 
-  /** Request widget to preserve state if it can (e.g. InputText will try to preserve cursor/selection) */
-  TryToPreserveState;
+    /** Favor activation for tweaking with arrows or gamepad (e.g. for Slider/Drag). Default if keyboard is not available. */
+    object PreferTweak : ActivateFlag()
 
-  override val i: Int = 1 shl ordinal
+    /** Request widget to preserve state if it can (e.g. InputText will try to preserve cursor/selection) */
+    object TryToPreserveState : ActivateFlag()
+
+    override val i: Int = 1 shl ordinal
+
+    @GenSealedEnum
+    companion object
 }
 
 typealias ScrollFlags = Flag<ScrollFlag>
 
-enum class ScrollFlag : Flag<ScrollFlag> {
-  /** If item is not visible: scroll as little as possible on X axis to bring item back into view [default for X axis] */
-  KeepVisibleEdgeX,
+sealed class ScrollFlag : FlagBase<ScrollFlag>() {
 
-  /** If item is not visible: scroll as little as possible on Y axis to bring item back into view [default for Y axis for windows that are already visible] */
-  KeepVisibleEdgeY,
+    /** If item is not visible: scroll as little as possible on X axis to bring item back into view [default for X axis] */
+    object KeepVisibleEdgeX : ScrollFlag()
 
-  /** If item is not visible: scroll to make the item centered on X axis [rarely used] */
-  KeepVisibleCenterX,
+    /** If item is not visible: scroll as little as possible on Y axis to bring item back into view [default for Y axis for windows that are already visible] */
+    object KeepVisibleEdgeY : ScrollFlag()
 
-  /** If item is not visible: scroll to make the item centered on Y axis */
-  KeepVisibleCenterY,
+    /** If item is not visible: scroll to make the item centered on X axis [rarely used] */
+    object KeepVisibleCenterX : ScrollFlag()
 
-  /** Always center the result item on X axis [rarely used] */
-  AlwaysCenterX,
+    /** If item is not visible: scroll to make the item centered on Y axis */
+    object KeepVisibleCenterY : ScrollFlag()
 
-  /** Always center the result item on Y axis [default for Y axis for appearing window) */
-  AlwaysCenterY,
+    /** Always center the result item on X axis [rarely used] */
+    object AlwaysCenterX : ScrollFlag()
 
-  /** Disable forwarding scrolling to parent window if required to keep item/rect visible (only scroll window the function was applied to). */
-  NoScrollParent;
+    /** Always center the result item on Y axis [default for Y axis for appearing window) */
+    object AlwaysCenterY : ScrollFlag()
 
-  override val i: Int = 1 shl ordinal
+    /** Disable forwarding scrolling to parent window if required to keep item/rect visible (only scroll window the function was applied to). */
+    object NoScrollParent : ScrollFlag()
 
-  companion object {
-    val MaskX = KeepVisibleEdgeX or KeepVisibleCenterX or AlwaysCenterX
-    val MaskY = KeepVisibleEdgeY or KeepVisibleCenterY or AlwaysCenterY
-  }
+    override val i: Int = 1 shl ordinal
+
+    @GenSealedEnum
+    companion object {
+        val MaskX get() = KeepVisibleEdgeX or KeepVisibleCenterX or AlwaysCenterX
+        val MaskY get() = KeepVisibleEdgeY or KeepVisibleCenterY or AlwaysCenterY
+    }
 }
 
 
 typealias NavHighlightFlags = Flag<NavHighlightFlag>
 
-enum class NavHighlightFlag : Flag<NavHighlightFlag> {
-  TypeDefault, TypeThin,
+sealed class NavHighlightFlag : FlagBase<NavHighlightFlag>() {
+    object TypeDefault : NavHighlightFlag()
+    object TypeThin : NavHighlightFlag()
 
-  /** Draw rectangular highlight if (g.NavId == id) _even_ when using the mouse. */
-  AlwaysDraw,
-  NoRounding;
+    /** Draw rectangular highlight if (g.NavId == id) _even_ when using the mouse. */
+    object AlwaysDraw : NavHighlightFlag()
 
-  override val i: Int = 1 shl ordinal
+    object NoRounding : NavHighlightFlag()
+
+    override val i: Int = 1 shl ordinal
+
+    @GenSealedEnum
+    companion object
 }
 
 typealias NavMoveFlags = Flag<NavMoveFlag>
 
-enum class NavMoveFlag : Flag<NavMoveFlag> {
-  /** On failed request, restart from opposite side */
-  LoopX,
-  LoopY,
+sealed class NavMoveFlag : FlagBase<NavMoveFlag>() {
 
-  /** On failed request, request from opposite side one line down (when NavDir==right) or one line up (when NavDir==left) */
-  WrapX,
+    /** On failed request, restart from opposite side */
+    object LoopX : NavMoveFlag()
 
-  /** This is not super useful for provided but completeness */
-    WrapY,
+    object LoopY : NavMoveFlag()
+
+    /** On failed request, request from opposite side one line down (when NavDir==right) or one line up (when NavDir==left) */
+    object WrapX : NavMoveFlag()
+
+    /** This is not super useful for provided but completeness */
+    object WrapY : NavMoveFlag()
 
     /** Allow scoring and considering the current NavId as a move target candidate.
      *  This is used when the move source is offset (e.g. pressing PageDown actually needs to send a Up move request,
      *  if we are pressing PageDown from the bottom-most item we need to stay in place) */
-    AllowCurrentNavId,
+    object AllowCurrentNavId : NavMoveFlag()
 
     /** Store alternate result in NavMoveResultLocalVisible that only comprise elements that are already fully visible (used by PageUp/PageDown) */
-    AlsoScoreVisibleSet,
+    object AlsoScoreVisibleSet : NavMoveFlag()
 
     /** Force scrolling to min/max (used by Home/End) // FIXME-NAV: Aim to remove or reword, probably unnecessary */
-    ScrollToEdgeY,
-    Forwarded,
+    object ScrollToEdgeY : NavMoveFlag()
+
+    object Forwarded : NavMoveFlag()
 
     /** Dummy scoring for debug purpose, don't apply result */
-    DebugNoResult,
-    FocusApi,
-    /** == Focus + Activate if item is Inputable + DontChangeNavHighlight */
-    Tabbing,
-    Activate,
-    /** Do not alter the visible state of keyboard vs mouse nav highlight */
-    DontSetNavHighlight;
+    object DebugNoResult : NavMoveFlag()
 
-  override val i: Int = 1 shl ordinal
+    object FocusApi : NavMoveFlag()
+
+    /** == Focus + Activate if item is Inputable + DontChangeNavHighlight */
+    object Tabbing : NavMoveFlag()
+
+    object Activate : NavMoveFlag()
+
+    /** Do not alter the visible state of keyboard vs mouse nav highlight */
+    object DontSetNavHighlight : NavMoveFlag()
+
+    override val i: Int = 1 shl ordinal
+
+    @GenSealedEnum
+    companion object
 }
 
 enum class NavForward(val i: Int) {

--- a/core/src/main/kotlin/imgui/internal/sections/Widgets support flags, enums, data structures.kt
+++ b/core/src/main/kotlin/imgui/internal/sections/Widgets support flags, enums, data structures.kt
@@ -1,5 +1,6 @@
 package imgui.internal.sections
 
+import com.livefront.sealedenum.GenSealedEnum
 import glm_.vec2.Vec2
 import imgui.*
 import imgui.internal.classes.Rect
@@ -20,40 +21,43 @@ typealias ItemFlags = Flag<ItemFlag>
 
 /** Transient per-window flags, reset at the beginning of the frame. For child window, inherited from parent on first Begin().
  *  This is going to be exposed in imgui.h when stabilized enough. */
-enum class ItemFlag(override val i: Int) : Flag<ItemFlag> {
+sealed class ItemFlag(override val i: Int) : FlagBase<ItemFlag>() {
     // Controlled by user
     /** Disable keyboard tabbing (FIXME: should merge with _NoNav) */
-    NoTabStop(1 shl 0),  // false
+    object NoTabStop : ItemFlag(1 shl 0)  // false
 
     /** Button() will return true multiple times based on io.KeyRepeatDelay and io.KeyRepeatRate settings. */
-    ButtonRepeat(1 shl 1),  // false
+    object ButtonRepeat : ItemFlag(1 shl 1)  // false
 
     /** Disable interactions but doesn't affect visuals. See BeginDisabled()/EndDisabled(). See github.com/ocornut/imgui/issues/211 */
-    Disabled(1 shl 2),  // false
+    object Disabled : ItemFlag(1 shl 2)  // false
 
     /** Disable keyboard/gamepad directional navigation (FIXME: should merge with _NoTabStop) */
-    NoNav(1 shl 3),  // false
+    object NoNav : ItemFlag(1 shl 3)  // false
 
     /** Disable item being a candidate for default focus (e.g. used by title bar items) */
-    NoNavDefaultFocus(1 shl 4),  // false
+    object NoNavDefaultFocus : ItemFlag(1 shl 4)  // false
 
     /** Disable MenuItem/Selectable() automatically closing their popup window */
-    SelectableDontClosePopup(1 shl 5),  // false
+    object SelectableDontClosePopup : ItemFlag(1 shl 5)  // false
 
     /** [BETA] Represent a mixed/indeterminate value, generally multi-selection where values differ. Currently only supported by Checkbox() (later should support all sorts of widgets) */
-    MixedValue(1 shl 6),  // false
+    object MixedValue : ItemFlag(1 shl 6)  // false
 
     /** [ALPHA] Allow hovering interactions but underlying value is not changed. */
-    ReadOnly(1 shl 7),  // false
+    object ReadOnly : ItemFlag(1 shl 7)  // false
 
     /** Disable hoverable check in ItemHoverable() */
-    NoWindowHoverableCheck(1 shl 8),  // false
+    object NoWindowHoverableCheck : ItemFlag(1 shl 8)  // false
 
 
     // Controlled by widget code
 
     /** [WIP] Auto-activate input mode when tab focused. Currently only used and supported by a few items before it becomes a generic feature. */
-    Inputable(1 shl 10);   // false
+    object Inputable : ItemFlag(1 shl 10)   // false
+
+    @GenSealedEnum
+    companion object
 }
 
 
@@ -62,121 +66,126 @@ typealias ItemStatusFlags = Flag<ItemStatusFlag>
 
 /** Status flags for an already submitted item
  *  - output: stored in g.LastItemData.StatusFlags   */
-enum class ItemStatusFlag(override val i: Int) : Flag<ItemStatusFlag> {
+sealed class ItemStatusFlag(override val i: Int) : FlagBase<ItemStatusFlag>() {
     /** Mouse position is within item rectangle (does NOT mean that the window is in correct z-order and can be hovered!, this is only one part of the most-common IsItemHovered test) */
-    HoveredRect(1 shl 0),
+    object HoveredRect : ItemStatusFlag(1 shl 0)
 
     /** g.LastItemData.DisplayRect is valid */
-    HasDisplayRect(1 shl 1),
+    object HasDisplayRect : ItemStatusFlag(1 shl 1)
 
     /** Value exposed by item was edited in the current frame (should match the bool return value of most widgets) */
-    Edited(1 shl 2),
+    object Edited : ItemStatusFlag(1 shl 2)
 
     /** Set when Selectable(), TreeNode() reports toggling a selection. We can't report "Selected", only state changes, in order to easily handle clipping with less issues. */
-    ToggledSelection(1 shl 3),
+    object ToggledSelection : ItemStatusFlag(1 shl 3)
 
     /** Set when TreeNode() reports toggling their open state. */
-    ToggledOpen(1 shl 4),
+    object ToggledOpen : ItemStatusFlag(1 shl 4)
 
     /** Set if the widget/group is able to provide data for the ImGuiItemStatusFlags_Deactivated flag. */
-    HasDeactivated(1 shl 5),
+    object HasDeactivated : ItemStatusFlag(1 shl 5)
 
     /** Only valid if ImGuiItemStatusFlags_HasDeactivated is set. */
-    Deactivated(1 shl 6),
+    object Deactivated : ItemStatusFlag(1 shl 6)
 
     /** Override the HoveredWindow test to allow cross-window hover testing. */
-    HoveredWindow(1 shl 7),
+    object HoveredWindow : ItemStatusFlag(1 shl 7)
 
     /** Set when the Focusable item just got focused by Tabbing (FIXME: to be removed soon) */
-    FocusedByTabbing(1 shl 8),
+    object FocusedByTabbing : ItemStatusFlag(1 shl 8)
 
     /** [WIP] Set when item is overlapping the current clipping rectangle (Used internally. Please don't use yet: API/system will change as we refactor Itemadd()). */
-    Visible(1 shl 9),
+    object Visible : ItemStatusFlag(1 shl 9)
 
     //  #ifdef IMGUI_ENABLE_TEST_ENGINE
     //  [imgui-test only]
 
     /** Item is an openable (e.g. TreeNode) */
-    Openable(1 shl 20),
-    Opened(1 shl 21),
+    object Openable : ItemStatusFlag(1 shl 20)
+    object Opened : ItemStatusFlag(1 shl 21)
 
     /** Item is a checkable (e.g. CheckBox, MenuItem) */
-    Checkable(1 shl 22),
-    Checked(1 shl 23)
+    object Checkable : ItemStatusFlag(1 shl 22)
+    object Checked : ItemStatusFlag(1 shl 23)
+
+    @GenSealedEnum
+    companion object
 }
 
 typealias ButtonFlags = Flag<ButtonFlag>
 
-enum class ButtonFlag(override val i: Int) : Flag<ButtonFlag> {
+sealed class ButtonFlag(override val i: Int) : FlagBase<ButtonFlag>() {
     /** React on left mouse button (default) */
-    MouseButtonLeft(1 shl 0),
+    object MouseButtonLeft : ButtonFlag(1 shl 0)
 
     /** React on right mouse button */
-    MouseButtonRight(1 shl 1),
+    object MouseButtonRight : ButtonFlag(1 shl 1)
 
     /** React on center mouse button */
-    MouseButtonMiddle(1 shl 2),
+    object MouseButtonMiddle : ButtonFlag(1 shl 2)
 
     /** return true on click (mouse down event) */
-    PressedOnClick(1 shl 4),
+    object PressedOnClick : ButtonFlag(1 shl 4)
 
     /** [Default] return true on click + release on same item <-- this is what the majority of Button are using */
-    PressedOnClickRelease(1 shl 5),
+    object PressedOnClickRelease : ButtonFlag(1 shl 5)
 
     /** return true on click + release even if the release event is not done while hovering the item */
-    PressedOnClickReleaseAnywhere(1 shl 6),
+    object PressedOnClickReleaseAnywhere : ButtonFlag(1 shl 6)
 
     /** return true on release (default requires click+release) */
-    PressedOnRelease(1 shl 7),
+    object PressedOnRelease : ButtonFlag(1 shl 7)
 
     /** return true on double-click (default requires click+release) */
-    PressedOnDoubleClick(1 shl 8),
+    object PressedOnDoubleClick : ButtonFlag(1 shl 8)
 
     /** return true when held into while we are drag and dropping another item (used by e.g. tree nodes, collapsing headers) */
-    PressedOnDragDropHold(1 shl 9),
+    object PressedOnDragDropHold : ButtonFlag(1 shl 9)
 
     /** hold to repeat  */
-    Repeat(1 shl 10),
+    object Repeat : ButtonFlag(1 shl 10)
 
     /** allow interactions even if a child window is overlapping */
-    FlattenChildren(1 shl 11),
+    object FlattenChildren : ButtonFlag(1 shl 11)
 
     /** require previous frame HoveredId to either match id or be null before being usable, use along with SetItemAllowOverlap() */
-    AllowItemOverlap(1 shl 12),
+    object AllowItemOverlap : ButtonFlag(1 shl 12)
 
     /** disable automatically closing parent popup on press // [UNUSED] */
-    DontClosePopups(1 shl 13),
+    object DontClosePopups : ButtonFlag(1 shl 13)
 
     /** disable interactions -> use BeginDisabled() or ImGuiItemFlags_Disabled */
     //    Disabled(1 shl 14),
 
     /** vertically align button to match text baseline - ButtonEx() only // FIXME: Should be removed and handled by SmallButton(), not possible currently because of DC.CursorPosPrevLine */
-    AlignTextBaseLine(1 shl 15),
+    object AlignTextBaseLine : ButtonFlag(1 shl 15)
 
     /** disable mouse interaction if a key modifier is held */
-    NoKeyModifiers(1 shl 16),
+    object NoKeyModifiers : ButtonFlag(1 shl 16)
 
     /** don't set ActiveId while holding the mouse (ImGuiButtonFlags_PressedOnClick only) */
-    NoHoldingActiveId(1 shl 17),
+    object NoHoldingActiveId : ButtonFlag(1 shl 17)
 
     /** don't override navigation focus when activated (FIXME: this is essentially used everytime an item uses ImGuiItemFlags_NoNav, but because legacy specs don't requires LastItemData to be set ButtonBehavior(), we can't poll g.LastItemData.InFlags) */
-    NoNavFocus(1 shl 18),
+    object NoNavFocus : ButtonFlag(1 shl 18)
 
     /** don't report as hovered when nav focus is on this item */
-    NoHoveredOnFocus(1 shl 19),
+    object NoHoveredOnFocus : ButtonFlag(1 shl 19)
 
     /** don't set key/input owner on the initial click (note: mouse buttons are keys! often, the key in question will be ImGuiKey_MouseLeft!) */
-    NoSetKeyOwner(1 shl 20),
+    object NoSetKeyOwner : ButtonFlag(1 shl 20)
 
     /** don't test key/input owner when polling the key (note: mouse buttons are keys! often, the key in question will be ImGuiKey_MouseLeft!) */
-    NoTestKeyOwner(1 shl 21);
+    object NoTestKeyOwner : ButtonFlag(1 shl 21)
 
+    @GenSealedEnum
     companion object {
-        val MouseButtonMask: ButtonFlags = MouseButtonLeft or MouseButtonRight or MouseButtonMiddle
-        val PressedOnMask: ButtonFlags =
-            PressedOnClick or PressedOnClickRelease or PressedOnClickReleaseAnywhere or PressedOnRelease or PressedOnDoubleClick or PressedOnDragDropHold
-        val MouseButtonDefault = MouseButtonLeft
-        val PressedOnDefault = PressedOnClickRelease
+        val MouseButtonMask: ButtonFlags get() = MouseButtonLeft or MouseButtonRight or MouseButtonMiddle
+        val PressedOnMask: ButtonFlags
+            get() =
+                PressedOnClick or PressedOnClickRelease or PressedOnClickReleaseAnywhere or PressedOnRelease or PressedOnDoubleClick or PressedOnDragDropHold
+        val MouseButtonDefault get() = MouseButtonLeft
+        val PressedOnDefault get() = PressedOnClickRelease
     }
 }
 
@@ -185,35 +194,45 @@ val MouseButton.buttonFlags: ButtonFlags
         MouseButton.Left -> MouseButtonLeft
         MouseButton.Right -> MouseButtonRight
         MouseButton.Middle -> MouseButtonMiddle
-        else -> emptyFlags()
+        else -> emptyFlags
     }
 
 typealias SeparatorFlags = Flag<SeparatorFlag>
 
-enum class SeparatorFlag : Flag<SeparatorFlag> {
+sealed class SeparatorFlag : FlagBase<SeparatorFlag>() {
+
     /** Axis default to current layout type, so generally Horizontal unless e.g. in a menu bar  */
-    Horizontal,
-    Vertical,
-    SpanAllColumns;
+    object Horizontal : SeparatorFlag()
+    object Vertical : SeparatorFlag()
+    object SpanAllColumns : SeparatorFlag()
 
     override val i: Int = 1 shl ordinal
+
+    @GenSealedEnum
+    companion object
 }
 
 typealias TextFlags = Flag<TextFlag>
 
-enum class TextFlag : Flag<TextFlag> {
-    NoWidthForLargeClippedText;
+sealed class TextFlag : FlagBase<TextFlag>() {
+    object NoWidthForLargeClippedText : TextFlag()
 
     override val i: Int = 1 shl ordinal
+
+    @GenSealedEnum
+    companion object
 }
 
 typealias TooltipFlags = Flag<TooltipFlag>
 
-enum class TooltipFlag : Flag<TooltipFlag> {
+sealed class TooltipFlag : FlagBase<TooltipFlag>() {
     /** Override will clear/ignore previously submitted tooltip (defaults to append) */
-    OverridePreviousTooltip;
+    object OverridePreviousTooltip : TooltipFlag()
 
     override val i: Int = 1 shl ordinal
+
+    @GenSealedEnum
+    companion object
 }
 
 /** FIXME: this is in development, not exposed/functional as a generic feature yet.
@@ -263,38 +282,40 @@ typealias DrawFlags = Flag<DrawFlag>
 
 /** Flags for ImDrawList functions
  *  (Legacy: bit 0 must always correspond to ImDrawFlags_Closed to be backward compatible with old API using a bool. Bits 1..3 must be unused) */
-enum class DrawFlag(override val i: Int) : Flag<DrawFlag> {
+sealed class DrawFlag(override val i: Int) : FlagBase<DrawFlag>() {
     /** PathStroke(), AddPolyline(): specify that shape should be closed (Important: this is always == 1 for legacy reason) */
-    Closed(1 shl 0),
+    object Closed : DrawFlag(1 shl 0)
 
     // (bits 1..3 unused to facilitate handling of legacy behavior and detection of Flags = 0x0F)
 
     /** AddRect(), AddRectFilled(), PathRect(): enable rounding top-left corner only (when rounding > 0.0f, we default to all corners). Was 0x01. */
-    RoundCornersTopLeft(1 shl 4),
+    object RoundCornersTopLeft : DrawFlag(1 shl 4)
 
     /** AddRect(), AddRectFilled(), PathRect(): enable rounding top-right corner only (when rounding > 0.0f, we default to all corners). Was 0x02. */
-    RoundCornersTopRight(1 shl 5),
+    object RoundCornersTopRight : DrawFlag(1 shl 5)
 
     /** AddRect(), AddRectFilled(), PathRect(): enable rounding bottom-left corner only (when rounding > 0.0f, we default to all corners). Was 0x04. */
-    RoundCornersBottomLeft(1 shl 6),
+    object RoundCornersBottomLeft : DrawFlag(1 shl 6)
 
     /** AddRect(), AddRectFilled(), PathRect(): enable rounding bottom-right corner only (when rounding > 0.0f, we default to all corners). Wax 0x08. */
-    RoundCornersBottomRight(1 shl 7),
+    object RoundCornersBottomRight : DrawFlag(1 shl 7)
 
     /** AddRect(), AddRectFilled(), PathRect(): disable rounding on all corners (when rounding > 0.0f). This is NOT zero, NOT an implicit flag! */
-    RoundCornersNone(1 shl 8);
+    object RoundCornersNone : DrawFlag(1 shl 8)
 
+    @GenSealedEnum
     companion object {
-        val RoundCornersAll: DrawFlags =
-            RoundCornersTopLeft or RoundCornersTopRight or RoundCornersBottomLeft or RoundCornersBottomRight
+        val RoundCornersAll: DrawFlags
+            get() =
+                RoundCornersTopLeft or RoundCornersTopRight or RoundCornersBottomLeft or RoundCornersBottomRight
 
         /** Default to ALL corners if none of the _RoundCornersXX flags are specified. */
-        val RoundCornersDefault: DrawFlags = RoundCornersAll
-        val RoundCornersMask: DrawFlags = RoundCornersAll or RoundCornersNone
-        val RoundCornersTop: DrawFlags = RoundCornersTopLeft or RoundCornersTopRight
-        val RoundCornersBottom: DrawFlags = RoundCornersBottomLeft or RoundCornersBottomRight
-        val RoundCornersLeft: DrawFlags = RoundCornersBottomLeft or RoundCornersTopLeft
-        val RoundCornersRight: DrawFlags = RoundCornersBottomRight or RoundCornersTopRight
+        val RoundCornersDefault: DrawFlags get() = RoundCornersAll
+        val RoundCornersMask: DrawFlags get() = RoundCornersAll or RoundCornersNone
+        val RoundCornersTop: DrawFlags get() = RoundCornersTopLeft or RoundCornersTopRight
+        val RoundCornersBottom: DrawFlags get() = RoundCornersBottomLeft or RoundCornersBottomRight
+        val RoundCornersLeft: DrawFlags get() = RoundCornersBottomLeft or RoundCornersTopLeft
+        val RoundCornersRight: DrawFlags get() = RoundCornersBottomRight or RoundCornersTopRight
     }
 }
 
@@ -302,37 +323,56 @@ typealias DrawListFlags = Flag<DrawListFlag>
 
 /** Flags: for ImDrawList instance. Those are set automatically by ImGui:: functions from ImGuiIO settings, and generally not
  *  manipulated directly. It is however possible to temporarily alter flags between calls to ImDrawList:: functions. */
-enum class DrawListFlag : Flag<DrawListFlag> {
+sealed class DrawListFlag : FlagBase<DrawListFlag>() {
+
     /** Enable anti-aliased lines/borders (*2 the number of triangles for 1.0f wide line or lines thin enough to be
      *  drawn using textures, otherwise *3 the number of triangles) */
-    AntiAliasedLines,
+    object AntiAliasedLines : DrawListFlag()
 
     /** Enable anti-aliased lines/borders using textures when possible. Require backend to render with bilinear filtering (NOT point/nearest filtering). */
-    AntiAliasedLinesUseTex,
+    object AntiAliasedLinesUseTex : DrawListFlag()
 
     /** Enable anti-aliased edge around filled shapes (rounded rectangles, circles). */
-    AntiAliasedFill,
+    object AntiAliasedFill : DrawListFlag()
 
     /** Can emit 'VtxOffset > 0' to allow large meshes. Set when 'ImGuiBackendFlags_RendererHasVtxOffset' is enabled. */
-    AllowVtxOffset;
+    object AllowVtxOffset : DrawListFlag()
 
     override val i: Int = 1 shl ordinal
+
+    @GenSealedEnum
+    companion object
 }
 
 typealias NextWindowDataFlags = Flag<NextWindowDataFlag>
 
-enum class NextWindowDataFlag : Flag<NextWindowDataFlag> {
-    HasPos, HasSize, HasContentSize, HasCollapsed, HasSizeConstraint, HasFocus, HasBgAlpha, HasScroll;
+sealed class NextWindowDataFlag : FlagBase<NextWindowDataFlag>() {
+
+    object HasPos : NextWindowDataFlag()
+    object HasSize : NextWindowDataFlag()
+    object HasContentSize : NextWindowDataFlag()
+    object HasCollapsed : NextWindowDataFlag()
+    object HasSizeConstraint : NextWindowDataFlag()
+    object HasFocus : NextWindowDataFlag()
+    object HasBgAlpha : NextWindowDataFlag()
+    object HasScroll : NextWindowDataFlag()
 
     override val i: Int = 1 shl ordinal
+
+    @GenSealedEnum
+    companion object
 }
 
 typealias NextItemDataFlags = Flag<NextItemDataFlag>
 
-enum class NextItemDataFlag : Flag<NextItemDataFlag> {
-    HasWidth, HasOpen;
+sealed class NextItemDataFlag : FlagBase<NextItemDataFlag>() {
+    object HasWidth : NextItemDataFlag()
+    object HasOpen : NextItemDataFlag()
 
     override val i: Int = 1 shl ordinal
+
+    @GenSealedEnum
+    companion object
 }
 
 /** Result of a gamepad/keyboard directional navigation move query result */
@@ -350,7 +390,7 @@ class NavItemData {
     lateinit var rectRel: Rect
 
     /** ????,Move    // Best candidate item flags */
-    var inFlags: ItemFlags = emptyFlags()
+    var inFlags: ItemFlags = emptyFlags
 
     /**      Move    // Best candidate box distance to current NavId */
     var distBox = Float.MAX_VALUE

--- a/core/src/main/kotlin/imgui/internal/sections/Widgets support flags, enums, data structures.kt
+++ b/core/src/main/kotlin/imgui/internal/sections/Widgets support flags, enums, data structures.kt
@@ -1,11 +1,10 @@
 package imgui.internal.sections
 
 import glm_.vec2.Vec2
-import imgui.Flag
-import imgui.ID
+import imgui.*
 import imgui.internal.classes.Rect
 import imgui.internal.classes.Window
-import imgui.or
+import imgui.internal.sections.ButtonFlag.*
 
 
 //-----------------------------------------------------------------------------
@@ -17,21 +16,16 @@ import imgui.or
 // - output: stored in g.LastItemData.InFlags
 // Current window shared by all windows.
 /** Flags: for PushItemFlag(), g.LastItemData.InFlags */
-typealias ItemFlags = Int
+typealias ItemFlags = Flag<ItemFlag>
 
 /** Transient per-window flags, reset at the beginning of the frame. For child window, inherited from parent on first Begin().
  *  This is going to be exposed in imgui.h when stabilized enough. */
-enum class ItemFlag(override val i: ItemFlags) : Flag<ItemFlag> {
+enum class ItemFlag(override val i: Int) : Flag<ItemFlag> {
+    // Controlled by user
+    /** Disable keyboard tabbing (FIXME: should merge with _NoNav) */
+    NoTabStop(1 shl 0),  // false
 
-
-  // Controlled by user
-
-  None(0),
-
-  /** Disable keyboard tabbing (FIXME: should merge with _NoNav) */
-  NoTabStop(1 shl 0),  // false
-
-  /** Button() will return true multiple times based on io.KeyRepeatDelay and io.KeyRepeatRate settings. */
+    /** Button() will return true multiple times based on io.KeyRepeatDelay and io.KeyRepeatRate settings. */
     ButtonRepeat(1 shl 1),  // false
 
     /** Disable interactions but doesn't affect visuals. See BeginDisabled()/EndDisabled(). See github.com/ocornut/imgui/issues/211 */
@@ -64,21 +58,19 @@ enum class ItemFlag(override val i: ItemFlags) : Flag<ItemFlag> {
 
 
 /** Flags: for g.LastItemData.StatusFlags */
-typealias ItemStatusFlags = Int
+typealias ItemStatusFlags = Flag<ItemStatusFlag>
 
 /** Status flags for an already submitted item
  *  - output: stored in g.LastItemData.StatusFlags   */
-enum class ItemStatusFlag(override val i: ItemStatusFlags) : Flag<ItemStatusFlag> {
-  None(0),
+enum class ItemStatusFlag(override val i: Int) : Flag<ItemStatusFlag> {
+    /** Mouse position is within item rectangle (does NOT mean that the window is in correct z-order and can be hovered!, this is only one part of the most-common IsItemHovered test) */
+    HoveredRect(1 shl 0),
 
-  /** Mouse position is within item rectangle (does NOT mean that the window is in correct z-order and can be hovered!, this is only one part of the most-common IsItemHovered test) */
-  HoveredRect(1 shl 0),
+    /** g.LastItemData.DisplayRect is valid */
+    HasDisplayRect(1 shl 1),
 
-  /** g.LastItemData.DisplayRect is valid */
-  HasDisplayRect(1 shl 1),
-
-  /** Value exposed by item was edited in the current frame (should match the bool return value of most widgets) */
-  Edited(1 shl 2),
+    /** Value exposed by item was edited in the current frame (should match the bool return value of most widgets) */
+    Edited(1 shl 2),
 
     /** Set when Selectable(), TreeNode() reports toggling a selection. We can't report "Selected", only state changes, in order to easily handle clipping with less issues. */
     ToggledSelection(1 shl 3),
@@ -108,24 +100,21 @@ enum class ItemStatusFlag(override val i: ItemStatusFlags) : Flag<ItemStatusFlag
     Openable(1 shl 20),
     Opened(1 shl 21),
 
-  /** Item is a checkable (e.g. CheckBox, MenuItem) */
-  Checkable(1 shl 22),
-  Checked(1 shl 23)
+    /** Item is a checkable (e.g. CheckBox, MenuItem) */
+    Checkable(1 shl 22),
+    Checked(1 shl 23)
 }
 
-typealias ButtonFlags = Int
+typealias ButtonFlags = Flag<ButtonFlag>
 
-enum class ButtonFlag(override val i: ButtonFlags) : Flag<ButtonFlag> {
+enum class ButtonFlag(override val i: Int) : Flag<ButtonFlag> {
+    /** React on left mouse button (default) */
+    MouseButtonLeft(1 shl 0),
 
-  None(0),
+    /** React on right mouse button */
+    MouseButtonRight(1 shl 1),
 
-  /** React on left mouse button (default) */
-  MouseButtonLeft(1 shl 0),
-
-  /** React on right mouse button */
-  MouseButtonRight(1 shl 1),
-
-  /** React on center mouse button */
+    /** React on center mouse button */
     MouseButtonMiddle(1 shl 2),
 
     /** return true on click (mouse down event) */
@@ -180,43 +169,51 @@ enum class ButtonFlag(override val i: ButtonFlags) : Flag<ButtonFlag> {
     NoSetKeyOwner(1 shl 20),
 
     /** don't test key/input owner when polling the key (note: mouse buttons are keys! often, the key in question will be ImGuiKey_MouseLeft!) */
-    NoTestKeyOwner(1 shl 21),
+    NoTestKeyOwner(1 shl 21);
 
-    MouseButtonMask_(MouseButtonLeft or MouseButtonRight or MouseButtonMiddle),
-    MouseButtonShift_(16),
-    MouseButtonDefault_(MouseButtonLeft.i),
-  PressedOnMask_(PressedOnClick or PressedOnClickRelease or PressedOnClickReleaseAnywhere or PressedOnRelease or PressedOnDoubleClick or PressedOnDragDropHold),
-  PressedOnDefault_(PressedOnClickRelease.i)
+    companion object {
+        val MouseButtonMask: ButtonFlags = MouseButtonLeft or MouseButtonRight or MouseButtonMiddle
+        val PressedOnMask: ButtonFlags =
+            PressedOnClick or PressedOnClickRelease or PressedOnClickReleaseAnywhere or PressedOnRelease or PressedOnDoubleClick or PressedOnDragDropHold
+        val MouseButtonDefault = MouseButtonLeft
+        val PressedOnDefault = PressedOnClickRelease
+    }
 }
 
-typealias SeparatorFlags = Int
+val MouseButton.buttonFlags: ButtonFlags
+    get() = when (this) {
+        MouseButton.Left -> MouseButtonLeft
+        MouseButton.Right -> MouseButtonRight
+        MouseButton.Middle -> MouseButtonMiddle
+        else -> emptyFlags()
+    }
+
+typealias SeparatorFlags = Flag<SeparatorFlag>
 
 enum class SeparatorFlag : Flag<SeparatorFlag> {
-  None,
+    /** Axis default to current layout type, so generally Horizontal unless e.g. in a menu bar  */
+    Horizontal,
+    Vertical,
+    SpanAllColumns;
 
-  /** Axis default to current layout type, so generally Horizontal unless e.g. in a menu bar  */
-  Horizontal,
-  Vertical,
-  SpanAllColumns;
-
-  override val i: SeparatorFlags = if (ordinal == 0) 0 else 1 shl (ordinal - 1)
+    override val i: Int = 1 shl ordinal
 }
 
-typealias TextFlags = Int
+typealias TextFlags = Flag<TextFlag>
 
 enum class TextFlag : Flag<TextFlag> {
-  None, NoWidthForLargeClippedText;
+    NoWidthForLargeClippedText;
 
-  override val i: TextFlags = ordinal
+    override val i: Int = 1 shl ordinal
 }
 
-typealias TooltipFlags = Int
+typealias TooltipFlags = Flag<TooltipFlag>
 
-enum class TooltipFlag(override val i: TooltipFlags) : Flag<TooltipFlag> {
-  None(0),
+enum class TooltipFlag : Flag<TooltipFlag> {
+    /** Override will clear/ignore previously submitted tooltip (defaults to append) */
+    OverridePreviousTooltip;
 
-  /** Override will clear/ignore previously submitted tooltip (defaults to append) */
-  OverridePreviousTooltip(1 shl 0)
+    override val i: Int = 1 shl ordinal
 }
 
 /** FIXME: this is in development, not exposed/functional as a generic feature yet.
@@ -262,22 +259,20 @@ enum class PlotType { Lines, Histogram }
 enum class PopupPositionPolicy { Default, ComboBox, Tooltip }
 
 
-typealias DrawFlags = Int
+typealias DrawFlags = Flag<DrawFlag>
 
 /** Flags for ImDrawList functions
  *  (Legacy: bit 0 must always correspond to ImDrawFlags_Closed to be backward compatible with old API using a bool. Bits 1..3 must be unused) */
-enum class DrawFlag(override val i: DrawFlags) : Flag<DrawFlag> {
-  None(0),
+enum class DrawFlag(override val i: Int) : Flag<DrawFlag> {
+    /** PathStroke(), AddPolyline(): specify that shape should be closed (Important: this is always == 1 for legacy reason) */
+    Closed(1 shl 0),
 
-  /** PathStroke(), AddPolyline(): specify that shape should be closed (Important: this is always == 1 for legacy reason) */
-  Closed(1 shl 0),
+    // (bits 1..3 unused to facilitate handling of legacy behavior and detection of Flags = 0x0F)
 
-  // (bits 1..3 unused to facilitate handling of legacy behavior and detection of Flags = 0x0F)
+    /** AddRect(), AddRectFilled(), PathRect(): enable rounding top-left corner only (when rounding > 0.0f, we default to all corners). Was 0x01. */
+    RoundCornersTopLeft(1 shl 4),
 
-  /** AddRect(), AddRectFilled(), PathRect(): enable rounding top-left corner only (when rounding > 0.0f, we default to all corners). Was 0x01. */
-  RoundCornersTopLeft(1 shl 4),
-
-  /** AddRect(), AddRectFilled(), PathRect(): enable rounding top-right corner only (when rounding > 0.0f, we default to all corners). Was 0x02. */
+    /** AddRect(), AddRectFilled(), PathRect(): enable rounding top-right corner only (when rounding > 0.0f, we default to all corners). Was 0x02. */
     RoundCornersTopRight(1 shl 5),
 
     /** AddRect(), AddRectFilled(), PathRect(): enable rounding bottom-left corner only (when rounding > 0.0f, we default to all corners). Was 0x04. */
@@ -287,53 +282,57 @@ enum class DrawFlag(override val i: DrawFlags) : Flag<DrawFlag> {
     RoundCornersBottomRight(1 shl 7),
 
     /** AddRect(), AddRectFilled(), PathRect(): disable rounding on all corners (when rounding > 0.0f). This is NOT zero, NOT an implicit flag! */
-    RoundCornersNone(1 shl 8),
-    RoundCornersTop(RoundCornersTopLeft or RoundCornersTopRight),
-    RoundCornersBottom(RoundCornersBottomLeft or RoundCornersBottomRight),
-    RoundCornersLeft(RoundCornersBottomLeft or RoundCornersTopLeft),
-    RoundCornersRight(RoundCornersBottomRight or RoundCornersTopRight),
-    RoundCornersAll(RoundCornersTopLeft or RoundCornersTopRight or RoundCornersBottomLeft or RoundCornersBottomRight),
+    RoundCornersNone(1 shl 8);
 
-  /** Default to ALL corners if none of the _RoundCornersXX flags are specified. */
-  RoundCornersDefault_(RoundCornersAll.i),
-  RoundCornersMask_(RoundCornersAll or RoundCornersNone)
+    companion object {
+        val RoundCornersAll: DrawFlags =
+            RoundCornersTopLeft or RoundCornersTopRight or RoundCornersBottomLeft or RoundCornersBottomRight
+
+        /** Default to ALL corners if none of the _RoundCornersXX flags are specified. */
+        val RoundCornersDefault: DrawFlags = RoundCornersAll
+        val RoundCornersMask: DrawFlags = RoundCornersAll or RoundCornersNone
+        val RoundCornersTop: DrawFlags = RoundCornersTopLeft or RoundCornersTopRight
+        val RoundCornersBottom: DrawFlags = RoundCornersBottomLeft or RoundCornersBottomRight
+        val RoundCornersLeft: DrawFlags = RoundCornersBottomLeft or RoundCornersTopLeft
+        val RoundCornersRight: DrawFlags = RoundCornersBottomRight or RoundCornersTopRight
+    }
 }
 
-typealias DrawListFlags = Int
+typealias DrawListFlags = Flag<DrawListFlag>
 
 /** Flags: for ImDrawList instance. Those are set automatically by ImGui:: functions from ImGuiIO settings, and generally not
  *  manipulated directly. It is however possible to temporarily alter flags between calls to ImDrawList:: functions. */
-enum class DrawListFlag(override val i: DrawListFlags) : Flag<DrawListFlag> {
-  None(0),
+enum class DrawListFlag : Flag<DrawListFlag> {
+    /** Enable anti-aliased lines/borders (*2 the number of triangles for 1.0f wide line or lines thin enough to be
+     *  drawn using textures, otherwise *3 the number of triangles) */
+    AntiAliasedLines,
 
-  /** Enable anti-aliased lines/borders (*2 the number of triangles for 1.0f wide line or lines thin enough to be
-   *  drawn using textures, otherwise *3 the number of triangles) */
-  AntiAliasedLines(1 shl 0),
+    /** Enable anti-aliased lines/borders using textures when possible. Require backend to render with bilinear filtering (NOT point/nearest filtering). */
+    AntiAliasedLinesUseTex,
 
-  /** Enable anti-aliased lines/borders using textures when possible. Require backend to render with bilinear filtering (NOT point/nearest filtering). */
-  AntiAliasedLinesUseTex(1 shl 1),
+    /** Enable anti-aliased edge around filled shapes (rounded rectangles, circles). */
+    AntiAliasedFill,
 
-  /** Enable anti-aliased edge around filled shapes (rounded rectangles, circles). */
-    AntiAliasedFill(1 shl 2),
+    /** Can emit 'VtxOffset > 0' to allow large meshes. Set when 'ImGuiBackendFlags_RendererHasVtxOffset' is enabled. */
+    AllowVtxOffset;
 
-  /** Can emit 'VtxOffset > 0' to allow large meshes. Set when 'ImGuiBackendFlags_RendererHasVtxOffset' is enabled. */
-  AllowVtxOffset(1 shl 3)
+    override val i: Int = 1 shl ordinal
 }
 
-typealias NextWindowDataFlags = Int
+typealias NextWindowDataFlags = Flag<NextWindowDataFlag>
 
 enum class NextWindowDataFlag : Flag<NextWindowDataFlag> {
-  None, HasPos, HasSize, HasContentSize, HasCollapsed, HasSizeConstraint, HasFocus, HasBgAlpha, HasScroll;
+    HasPos, HasSize, HasContentSize, HasCollapsed, HasSizeConstraint, HasFocus, HasBgAlpha, HasScroll;
 
-  override val i: NextWindowDataFlags = if (ordinal == 0) 0 else 1 shl (ordinal - 1)
+    override val i: Int = 1 shl ordinal
 }
 
-typealias NextItemDataFlags = Int
+typealias NextItemDataFlags = Flag<NextItemDataFlag>
 
-enum class NextItemDataFlag(override val i: NextItemDataFlags) : Flag<NextItemDataFlag> {
-  None(0),
-  HasWidth(1 shl 0),
-  HasOpen(1 shl 1)
+enum class NextItemDataFlag : Flag<NextItemDataFlag> {
+    HasWidth, HasOpen;
+
+    override val i: Int = 1 shl ordinal
 }
 
 /** Result of a gamepad/keyboard directional navigation move query result */
@@ -351,7 +350,7 @@ class NavItemData {
     lateinit var rectRel: Rect
 
     /** ????,Move    // Best candidate item flags */
-    var inFlags = ItemFlag.None.i
+    var inFlags: ItemFlags = emptyFlags()
 
     /**      Move    // Best candidate box distance to current NavId */
     var distBox = Float.MAX_VALUE

--- a/core/src/main/kotlin/imgui/internal/sections/drawList support.kt
+++ b/core/src/main/kotlin/imgui/internal/sections/drawList support.kt
@@ -5,6 +5,7 @@ import glm_.vec2.Vec2
 import glm_.vec4.Vec4
 import imgui.clamp
 import imgui.classes.DrawList
+import imgui.emptyFlags
 import imgui.font.Font
 import kotlin.math.acos
 import kotlin.math.ceil
@@ -67,7 +68,7 @@ class DrawListSharedData {
     var clipRectFullscreen = Vec4()
 
     /** Initial flags at the beginning of the frame (it is possible to alter flags on a per-drawlist basis afterwards) */
-    var initialFlags = DrawListFlag.None.i
+    var initialFlags: DrawListFlags = emptyFlags()
 
     /** [Internal] Temp write buffer */
     val tempBuffer = ArrayList<Vec2>()

--- a/core/src/main/kotlin/imgui/internal/sections/drawList support.kt
+++ b/core/src/main/kotlin/imgui/internal/sections/drawList support.kt
@@ -68,7 +68,7 @@ class DrawListSharedData {
     var clipRectFullscreen = Vec4()
 
     /** Initial flags at the beginning of the frame (it is possible to alter flags on a per-drawlist basis afterwards) */
-    var initialFlags: DrawListFlags = emptyFlags()
+    var initialFlags: DrawListFlags = emptyFlags
 
     /** [Internal] Temp write buffer */
     val tempBuffer = ArrayList<Vec2>()

--- a/core/src/main/kotlin/imgui/internal/sections/test engine specific hooks.kt
+++ b/core/src/main/kotlin/imgui/internal/sections/test engine specific hooks.kt
@@ -27,7 +27,7 @@ fun IMGUI_TEST_ENGINE_ITEM_ADD(bb: Rect, id: ID) {
 }
 
 /** Register item label and status flags (optional)} */
-fun IMGUI_TEST_ENGINE_ITEM_INFO(id: ID, label: String, flags: ItemFlags) {
+fun IMGUI_TEST_ENGINE_ITEM_INFO(id: ID, label: String, flags: ItemStatusFlags) {
     if (g.testEngineHookItems)
         testEngineHook_ItemInfo(g, id, label, flags)
 }

--- a/core/src/main/kotlin/imgui/static/errorCheckingAndDebugTools.kt
+++ b/core/src/main/kotlin/imgui/static/errorCheckingAndDebugTools.kt
@@ -57,7 +57,7 @@ fun errorCheckEndFrameSanityChecks() {
     // We silently accommodate for this case by ignoring the case where all io.KeyXXX modifiers were released (aka key_mod_flags == 0),
     // while still correctly asserting on mid-frame key press events.
     val keyMods = mergedModsFromKeys
-    assert(keyMods.isEmpty || g.io.keyMods eq keyMods) { "Mismatching io.KeyCtrl/io.KeyShift/io.KeyAlt/io.KeySuper vs io.KeyMods" }
+    assert(keyMods.isEmpty || g.io.keyMods == keyMods) { "Mismatching io.KeyCtrl/io.KeyShift/io.KeyAlt/io.KeySuper vs io.KeyMods" }
 
     // [EXPERIMENTAL] Recover from errors: You may call this yourself before EndFrame().
     //ErrorCheckEndFrameRecover();

--- a/core/src/main/kotlin/imgui/static/errorCheckingAndDebugTools.kt
+++ b/core/src/main/kotlin/imgui/static/errorCheckingAndDebugTools.kt
@@ -57,7 +57,7 @@ fun errorCheckEndFrameSanityChecks() {
     // We silently accommodate for this case by ignoring the case where all io.KeyXXX modifiers were released (aka key_mod_flags == 0),
     // while still correctly asserting on mid-frame key press events.
     val keyMods = mergedModsFromKeys
-    assert(keyMods == 0 || g.io.keyMods == keyMods) { "Mismatching io.KeyCtrl/io.KeyShift/io.KeyAlt/io.KeySuper vs io.KeyMods" }
+    assert(keyMods.isEmpty || g.io.keyMods eq keyMods) { "Mismatching io.KeyCtrl/io.KeyShift/io.KeyAlt/io.KeySuper vs io.KeyMods" }
 
     // [EXPERIMENTAL] Recover from errors: You may call this yourself before EndFrame().
     //ErrorCheckEndFrameRecover();

--- a/core/src/main/kotlin/imgui/static/forwardDeclarations.kt
+++ b/core/src/main/kotlin/imgui/static/forwardDeclarations.kt
@@ -1,6 +1,5 @@
 package imgui.static
 
-import gli_.has
 import glm_.i
 import glm_.max
 import glm_.min
@@ -139,7 +138,7 @@ fun createNewWindow(name: String, flags: WindowFlags) = Window(g, name).apply {
         findWindowSettings(id)?.let { settings ->
             //  Retrieve settings from .ini file
             settingsOffset = g.settingsWindows.indexOf(settings)
-            setConditionAllowFlags(Cond.FirstUseEver.i, false)
+            setConditionAllowFlags(Cond.FirstUseEver, false)
             applySettings(settings)
         }
     }

--- a/core/src/main/kotlin/imgui/static/misc.kt
+++ b/core/src/main/kotlin/imgui/static/misc.kt
@@ -67,7 +67,7 @@ fun updateAliasKey(key: Key, v: Boolean, analogValue: Float) {
 // [Internal] Do not use directly
 val mergedModsFromKeys: KeyChord
     get() {
-        var mods: KeyChord = emptyFlags()
+        var mods: KeyChord = emptyFlags
         if (Key.Mod_Ctrl.isDown) mods /= Key.Mod_Ctrl
         if (Key.Mod_Shift.isDown) mods /= Key.Mod_Shift
         if (Key.Mod_Alt.isDown) mods /= Key.Mod_Alt
@@ -332,7 +332,7 @@ fun Window.renderDecorations(titleBarRect: Rect, titleBarIsHighlight: Boolean, h
             if (overrideAlpha) bgCol = (bgCol and COL32_A_MASK.inv()) or (F32_TO_INT8_SAT(alpha) shl COL32_A_SHIFT)
             drawList.addRectFilled(
                 pos + Vec2(0f, titleBarHeight), pos + size, bgCol, windowRounding,
-                if (flags has WindowFlag.NoTitleBar) emptyFlags() else DrawFlag.RoundCornersBottom
+                if (flags has WindowFlag.NoTitleBar) emptyFlags else DrawFlag.RoundCornersBottom
             )
         }
 

--- a/core/src/main/kotlin/imgui/static/navigation.kt
+++ b/core/src/main/kotlin/imgui/static/navigation.kt
@@ -125,7 +125,7 @@ fun navUpdate() {
 
     // Process manual activation request
     g.navActivateId = 0; g.navActivateDownId = 0; g.navActivatePressedId = 0; g.navActivateInputId = 0
-    g.navActivateFlags = emptyFlags()
+    g.navActivateFlags = emptyFlags
     if (g.navId != 0 && !g.navDisableHighlight && g.navWindowingTarget == null && g.navWindow != null && g.navWindow!!.flags hasnt Wf.NoNavInputs) {
         val activateDown = (navKeyboardActive && Key.Space.isDown) || (navGamepadActive && Key._NavGamepadActivate.isDown)
         val activatePressed = activateDown && ((navKeyboardActive && Key.Space isPressed false) || (navGamepadActive && Key._NavGamepadActivate isPressed false))
@@ -291,7 +291,7 @@ fun navUpdateWindowing() {
                 g.navWindowingHighlightAlpha max saturate((g.navWindowingTimer - NAV_WINDOWING_HIGHLIGHT_DELAY) / 0.05f) // 1.0f
             if (keyboardNextWindow || keyboardPrevWindow)
                 navUpdateWindowingHighlightWindow(if (keyboardNextWindow) -1 else +1)
-            else if ((io.keyMods and sharedMods) != sharedMods)
+            else if (sharedMods !in io.keyMods)
                 applyFocusWindow = g.navWindowingTarget
         }
     }
@@ -483,8 +483,8 @@ fun navUpdateCreateMoveRequest() {
     } else {
         // Initiate directional inputs request
         g.navMoveDir = Dir.None
-        g.navMoveFlags = emptyFlags()
-        g.navMoveScrollFlags = emptyFlags()
+        g.navMoveFlags = emptyFlags
+        g.navMoveScrollFlags = emptyFlags
         if (window != null && g.navWindowingTarget == null && window.flags hasnt Wf.NoNavInputs) {
             val repeatMode = InputFlag.Repeat or InputFlag.RepeatRateNavMove
             if (!isActiveIdUsingNavDir(Dir.Left) && ((navGamepadActive && Key.GamepadDpadLeft.isPressed(KeyOwner_None, repeatMode)) || (navKeyboardActive && Key.LeftArrow.isPressed(KeyOwner_None, repeatMode))))

--- a/core/src/main/kotlin/imgui/static/navigation.kt
+++ b/core/src/main/kotlin/imgui/static/navigation.kt
@@ -2,7 +2,10 @@ package imgui.static
 
 import gli_.has
 import gli_.hasnt
-import glm_.*
+import glm_.glm
+import glm_.i
+import glm_.max
+import glm_.min
 import glm_.vec2.Vec2
 import imgui.*
 import imgui.ImGui.begin
@@ -122,7 +125,7 @@ fun navUpdate() {
 
     // Process manual activation request
     g.navActivateId = 0; g.navActivateDownId = 0; g.navActivatePressedId = 0; g.navActivateInputId = 0
-    g.navActivateFlags = ActivateFlag.None.i
+    g.navActivateFlags = emptyFlags()
     if (g.navId != 0 && !g.navDisableHighlight && g.navWindowingTarget == null && g.navWindow != null && g.navWindow!!.flags hasnt Wf.NoNavInputs) {
         val activateDown = (navKeyboardActive && Key.Space.isDown) || (navGamepadActive && Key._NavGamepadActivate.isDown)
         val activatePressed = activateDown && ((navKeyboardActive && Key.Space isPressed false) || (navGamepadActive && Key._NavGamepadActivate isPressed false))
@@ -130,11 +133,11 @@ fun navUpdate() {
         val inputPressed = inputDown && ((navKeyboardActive && Key.Enter isPressed false) || (navGamepadActive && Key._NavGamepadInput isPressed false))
         if (g.activeId == 0 && activatePressed) {
             g.navActivateId = g.navId
-            g.navActivateFlags = ActivateFlag.PreferTweak.i
+            g.navActivateFlags = ActivateFlag.PreferTweak
         }
         if ((g.activeId == 0 || g.activeId == g.navId) && inputPressed) {
             g.navActivateInputId = g.navId
-            g.navActivateFlags = ActivateFlag.PreferInput.i
+            g.navActivateFlags = ActivateFlag.PreferInput
         }
         if ((g.activeId == 0 || g.activeId == g.navId) && activateDown)
             g.navActivateDownId = g.navId
@@ -236,9 +239,9 @@ fun navUpdateWindowing() {
     // Start CTRL+TAB or Square+L/R window selection
     val navGamepadActive = io.configFlags has ConfigFlag.NavEnableGamepad && io.backendFlags has BackendFlag.HasGamepad
     val navKeyboardActive = io.configFlags has ConfigFlag.NavEnableKeyboard
-    val keyboardNextWindow = allowWindowing && g.configNavWindowingKeyNext != 0 && shortcut(g.configNavWindowingKeyNext, KeyOwner_None, InputFlag.Repeat or InputFlag.RouteAlways)
-    val keyboardPrevWindow = allowWindowing && g.configNavWindowingKeyPrev != 0 && shortcut(g.configNavWindowingKeyPrev, KeyOwner_None, InputFlag.Repeat or InputFlag.RouteAlways)
-    val startWindowingWithGamepad = allowWindowing && navGamepadActive && g.navWindowingTarget == null && Key._NavGamepadMenu.isPressed(0, InputFlag.None.i)
+    val keyboardNextWindow = allowWindowing && g.configNavWindowingKeyNext.isNotEmpty && shortcut(g.configNavWindowingKeyNext, KeyOwner_None, InputFlag.Repeat or InputFlag.RouteAlways)
+    val keyboardPrevWindow = allowWindowing && g.configNavWindowingKeyPrev.isNotEmpty && shortcut(g.configNavWindowingKeyPrev, KeyOwner_None, InputFlag.Repeat or InputFlag.RouteAlways)
+    val startWindowingWithGamepad = allowWindowing && navGamepadActive && g.navWindowingTarget == null && Key._NavGamepadMenu.isPressed(0)
     val startWindowingWithKeyboard = allowWindowing && g.navWindowingTarget == null && (keyboardNextWindow || keyboardPrevWindow) // Note: enabled even without NavEnableKeyboard!
     if (startWindowingWithGamepad || startWindowingWithKeyboard)
         (g.navWindow ?: findWindowNavFocusable(g.windowsFocusOrder.lastIndex, -Int.MAX_VALUE, -1))?.let {
@@ -280,11 +283,12 @@ fun navUpdateWindowing() {
     g.navWindowingTarget?.let {
         if (g.navInputSource == InputSource.Keyboard) {
             // Visuals only appears after a brief time after pressing TAB the first time, so that a fast CTRL+TAB doesn't add visual noise
-            val a = if (g.configNavWindowingKeyNext != 0) g.configNavWindowingKeyNext else Key.Mod_Mask_.i
-            val b = if (g.configNavWindowingKeyPrev != 0) g.configNavWindowingKeyPrev else Key.Mod_Mask_.i
-            val sharedMods = a and b and Key.Mod_Mask_
-            assert(sharedMods != 0) { "Next / Prev shortcut currently needs a shared modifier to \"hold\", otherwise Prev actions would keep cycling between two windows." }
-            g.navWindowingHighlightAlpha = g.navWindowingHighlightAlpha max saturate((g.navWindowingTimer - NAV_WINDOWING_HIGHLIGHT_DELAY) / 0.05f) // 1.0f
+            val a = if (g.configNavWindowingKeyNext.isNotEmpty) g.configNavWindowingKeyNext else Key.Mod_Mask
+            val b = if (g.configNavWindowingKeyPrev.isNotEmpty) g.configNavWindowingKeyPrev else Key.Mod_Mask
+            val sharedMods = a and b and Key.Mod_Mask
+            assert(sharedMods.isNotEmpty) { "Next / Prev shortcut currently needs a shared modifier to \"hold\", otherwise Prev actions would keep cycling between two windows." }
+            g.navWindowingHighlightAlpha =
+                g.navWindowingHighlightAlpha max saturate((g.navWindowingTimer - NAV_WINDOWING_HIGHLIGHT_DELAY) / 0.05f) // 1.0f
             if (keyboardNextWindow || keyboardPrevWindow)
                 navUpdateWindowingHighlightWindow(if (keyboardNextWindow) -1 else +1)
             else if ((io.keyMods and sharedMods) != sharedMods)
@@ -479,8 +483,8 @@ fun navUpdateCreateMoveRequest() {
     } else {
         // Initiate directional inputs request
         g.navMoveDir = Dir.None
-        g.navMoveFlags = NavMoveFlag.None.i
-        g.navMoveScrollFlags = ScrollFlag.None.i
+        g.navMoveFlags = emptyFlags()
+        g.navMoveScrollFlags = emptyFlags()
         if (window != null && g.navWindowingTarget == null && window.flags hasnt Wf.NoNavInputs) {
             val repeatMode = InputFlag.Repeat or InputFlag.RepeatRateNavMove
             if (!isActiveIdUsingNavDir(Dir.Left) && ((navGamepadActive && Key.GamepadDpadLeft.isPressed(KeyOwner_None, repeatMode)) || (navKeyboardActive && Key.LeftArrow.isPressed(KeyOwner_None, repeatMode))))
@@ -574,7 +578,7 @@ fun navUpdateCreateTabbingRequest() {
     if (window == null || g.navWindowingTarget != null || window.flags has Wf.NoNavInputs)
         return
 
-    val tabPressed = Key.Tab.isPressed(KeyOwner_None, InputFlag.Repeat.i) && !g.io.keyCtrl && !g.io.keyAlt
+    val tabPressed = Key.Tab.isPressed(KeyOwner_None, InputFlag.Repeat) && !g.io.keyCtrl && !g.io.keyAlt
     if (!tabPressed)
         return
 
@@ -586,7 +590,7 @@ fun navUpdateCreateTabbingRequest() {
     g.navTabbingDir = if (g.io.keyShift) -1 else if (g.activeId == 0) 0 else +1
     val scrollFlags = if (window.appearing) ScrollFlag.KeepVisibleEdgeX or ScrollFlag.AlwaysCenterY else ScrollFlag.KeepVisibleEdgeX or ScrollFlag.KeepVisibleEdgeY
     val clipDir = if (g.navTabbingDir < 0) Dir.Up else Dir.Down
-    navMoveRequestSubmit(Dir.None, clipDir, NavMoveFlag.Tabbing.i, scrollFlags) // FIXME-NAV: Once we refactor tabbing, add LegacyApi flag to not activate non-inputable.
+    navMoveRequestSubmit(Dir.None, clipDir, NavMoveFlag.Tabbing, scrollFlags) // FIXME-NAV: Once we refactor tabbing, add LegacyApi flag to not activate non-inputable.
     g.navTabbingCounter = -1
 }
 
@@ -602,8 +606,8 @@ fun navUpdatePageUpPageDown(): Float {
 
     val pageUpHeld = Key.PageUp isDown KeyOwner_None
     val pageDownHeld = Key.PageDown isDown KeyOwner_None
-    val homePressed = Key.Home.isPressed(KeyOwner_None, InputFlag.Repeat.i)
-    val endPressed = Key.End.isPressed(KeyOwner_None, InputFlag.Repeat.i)
+    val homePressed = Key.Home.isPressed(KeyOwner_None, InputFlag.Repeat)
+    val endPressed = Key.End.isPressed(KeyOwner_None, InputFlag.Repeat)
     if (pageUpHeld == pageDownHeld && homePressed == endPressed) // Proceed if either (not both) are pressed, otherwise early out
         return 0f
 
@@ -613,8 +617,8 @@ fun navUpdatePageUpPageDown(): Float {
     if (window.dc.navLayersActiveMask == 0x00 && window.dc.navHasScroll) {
         // Fallback manual-scroll when window has no navigable item
         when {
-            Key.PageUp.isPressed(KeyOwner_None, InputFlag.Repeat.i) -> window.setScrollY(window.scroll.y - window.innerRect.height)
-            Key.PageDown.isPressed(KeyOwner_None, InputFlag.Repeat.i) -> window.setScrollY(window.scroll.y + window.innerRect.height)
+            Key.PageUp.isPressed(KeyOwner_None, InputFlag.Repeat) -> window.setScrollY(window.scroll.y - window.innerRect.height)
+            Key.PageDown.isPressed(KeyOwner_None, InputFlag.Repeat) -> window.setScrollY(window.scroll.y + window.innerRect.height)
             homePressed -> window setScrollY 0f
             endPressed -> window setScrollY window.scrollMax.y
         }

--- a/core/src/main/kotlin/imgui/static/tables.kt
+++ b/core/src/main/kotlin/imgui/static/tables.kt
@@ -27,15 +27,15 @@ val TABLE_RESIZE_SEPARATOR_FEEDBACK_TIMER = 0.06f
 /** Adjust flags: default width mode + stretch columns are not allowed when auto extending
  *
  *  ~static void TableSetupColumnFlags(ImGuiTable* table, ImGuiTableColumn* column, ImGuiTableColumnFlags flags_in) */
-fun Table.setupColumnFlags(column: TableColumn, flagsIn: TableColumnFlags = emptyFlags()) {
+fun Table.setupColumnFlags(column: TableColumn, flagsIn: TableColumnSetupFlags = emptyFlags) {
 
     var flags = flagsIn
 
     // Sizing Policy
     if (flags hasnt TableColumnFlag.WidthMask) {
         val tableSizingPolicy = this.flags and TableFlag._SizingMask
-        flags = flags or when {
-            tableSizingPolicy eq TableFlag.SizingFixedFit || tableSizingPolicy eq TableFlag.SizingFixedSame -> TableColumnFlag.WidthFixed
+        flags = flags or when (tableSizingPolicy) {
+            TableFlag.SizingFixedFit, TableFlag.SizingFixedSame -> TableColumnFlag.WidthFixed
             else -> TableColumnFlag.WidthStretch
         }
     } else
@@ -119,7 +119,7 @@ fun tableFixFlags(flags_: TableFlags, outerWindow: Window): TableFlags {
         }
 
     // Adjust flags: enable NoKeepColumnsVisible when using ImGuiTableFlags_SizingFixedSame
-    if (flags and TableFlag._SizingMask eq TableFlag.SizingFixedSame)
+    if (flags and TableFlag._SizingMask == TableFlag.SizingFixedSame)
         flags = flags or TableFlag.NoKeepColumnsVisible
 
     // Adjust flags: enforce borders when resizable

--- a/core/src/main/kotlin/imgui/static/tables.kt
+++ b/core/src/main/kotlin/imgui/static/tables.kt
@@ -1,14 +1,10 @@
 package imgui.static
 
-import glm_.has
-import glm_.hasnt
-import glm_.wo
 import imgui.*
 import imgui.ImGui.fixColumnSortDirection
 import imgui.internal.classes.Table
 import imgui.internal.classes.TableColumn
 import imgui.internal.classes.Window
-import imgui.internal.isPowerOfTwo
 
 // Configuration
 
@@ -31,18 +27,19 @@ val TABLE_RESIZE_SEPARATOR_FEEDBACK_TIMER = 0.06f
 /** Adjust flags: default width mode + stretch columns are not allowed when auto extending
  *
  *  ~static void TableSetupColumnFlags(ImGuiTable* table, ImGuiTableColumn* column, ImGuiTableColumnFlags flags_in) */
-fun Table.setupColumnFlags(column: TableColumn, flagsIn: TableColumnFlags) {
+fun Table.setupColumnFlags(column: TableColumn, flagsIn: TableColumnFlags = emptyFlags()) {
 
     var flags = flagsIn
 
     // Sizing Policy
-    if (flags hasnt TableColumnFlag.WidthMask_) {
-        flags = flags or when (val tableSizingPolicy = this.flags and TableFlag._SizingMask) {
-            TableFlag.SizingFixedFit.i, TableFlag.SizingFixedSame.i -> TableColumnFlag.WidthFixed
+    if (flags hasnt TableColumnFlag.WidthMask) {
+        val tableSizingPolicy = this.flags and TableFlag._SizingMask
+        flags = flags or when {
+            tableSizingPolicy eq TableFlag.SizingFixedFit || tableSizingPolicy eq TableFlag.SizingFixedSame -> TableColumnFlag.WidthFixed
             else -> TableColumnFlag.WidthStretch
         }
     } else
-        assert((flags and TableColumnFlag.WidthMask_).isPowerOfTwo) { "Check that only 1 of each set is used." }
+        assert((flags and TableColumnFlag.WidthMask).isPowerOfTwo) { "Check that only 1 of each set is used." }
 
     // Resize
     if (this.flags hasnt TableFlag.Resizable)
@@ -53,7 +50,7 @@ fun Table.setupColumnFlags(column: TableColumn, flagsIn: TableColumnFlags) {
         flags = flags or TableColumnFlag.NoSort
 
     // Indentation
-    if (flags hasnt TableColumnFlag.IndentMask_)
+    if (flags hasnt TableColumnFlag.IndentMask)
         flags = flags or if (columns.indexOf(column) == 0) TableColumnFlag.IndentEnable else TableColumnFlag.IndentDisable
 
     // Alignment
@@ -62,7 +59,7 @@ fun Table.setupColumnFlags(column: TableColumn, flagsIn: TableColumnFlags) {
     //IM_ASSERT(ImIsPowerOfTwo(flags & ImGuiTableColumnFlags_AlignMask_)); // Check that only 1 of each set is used.
 
     // Preserve status flags
-    column.flags = flags or (column.flags and TableColumnFlag.StatusMask_)
+    column.flags = flags or (column.flags and TableColumnFlag.StatusMask)
 
     // Build an ordered list of available sort directions
     column.sortDirectionsAvailCount = 0
@@ -122,7 +119,7 @@ fun tableFixFlags(flags_: TableFlags, outerWindow: Window): TableFlags {
         }
 
     // Adjust flags: enable NoKeepColumnsVisible when using ImGuiTableFlags_SizingFixedSame
-    if (flags and TableFlag._SizingMask == TableFlag.SizingFixedSame.i)
+    if (flags and TableFlag._SizingMask eq TableFlag.SizingFixedSame)
         flags = flags or TableFlag.NoKeepColumnsVisible
 
     // Adjust flags: enforce borders when resizable

--- a/core/src/main/kotlin/imgui/static/viewports.kt
+++ b/core/src/main/kotlin/imgui/static/viewports.kt
@@ -2,6 +2,7 @@ package imgui.static
 
 import imgui.ViewportFlag
 import imgui.api.g
+import imgui.or
 
 // Viewports
 

--- a/core/src/main/kotlin/imgui/static/widgets.kt
+++ b/core/src/main/kotlin/imgui/static/widgets.kt
@@ -192,7 +192,7 @@ fun inputTextCalcTextSizeW(ctx: Context, text: CharArray, textBegin: Int, textEn
     return textSize
 }
 
-fun inputScalarDefaultCharsFilter(dataType: DataType, format: String): InputTextFlag {
+fun inputScalarDefaultCharsFilter(dataType: DataType, format: String): InputTextFlag.Single {
     if (dataType == DataType.Float || dataType == DataType.Double)
         return InputTextFlag.CharsScientific
     val formatLastChar = if (format.isNotEmpty()) format.last() else NUL

--- a/core/src/main/kotlin/imgui/static/widgets.kt
+++ b/core/src/main/kotlin/imgui/static/widgets.kt
@@ -1,6 +1,5 @@
 package imgui.static
 
-import gli_.has
 import glm_.*
 import glm_.vec2.Vec2
 import imgui.*
@@ -15,7 +14,6 @@ import imgui.internal.isBlankW
 import imgui.internal.sections.InputSource
 import imgui.internal.textCountCharsFromUtf8
 import imgui.internal.textStrFromUtf8
-import imgui.stb.te
 import uno.kotlin.NUL
 import uno.kotlin.getValue
 import uno.kotlin.isPrintable
@@ -119,7 +117,7 @@ fun inputTextFilterCharacter(char: KMutableProperty0<Char>, flags: InputTextFlag
     if (flags has InputTextFlag.CallbackCharFilter) {
         callback!! //callback is non-null from all calling functions
         val itcd = InputTextCallbackData()
-        itcd.eventFlag = InputTextFlag.CallbackCharFilter.i
+        itcd.eventFlag = InputTextFlag.CallbackCharFilter
         itcd.eventChar = c
         itcd.flags = flags
         itcd.userData = userData

--- a/core/src/main/kotlin/imgui/static/widgetsTabBar.kt
+++ b/core/src/main/kotlin/imgui/static/widgetsTabBar.kt
@@ -262,7 +262,7 @@ fun TabBar.scrollClamp(scrolling: Float): Float = (scrolling min (widthAllTabs -
 fun TabBar.scrollToTab(tabId: ID, sections: Array<TabBarSection>) {
 
     val tab = findTabByID(tabId) ?: return
-    if (tab.flags has TabItemFlag._SectionMask_)
+    if (tab.flags has TabItemFlag._SectionMask)
         return
 
     val margin = g.fontSize * 1f // When to scroll to make Tab N+1 visible always make a bit of N visible to suggest more scrolling area (since we don't have a scrollbar)

--- a/core/src/main/kotlin/imgui/tmp.kt
+++ b/core/src/main/kotlin/imgui/tmp.kt
@@ -69,6 +69,7 @@ class Property<V>(val get: () -> V) : KProperty0<V> {
 
 infix fun BooleanArray.mutablePropertyAt(index: Int) = MutableProperty({ this[index] }) { this[index] = it }
 infix fun <T> Array<T>.mutablePropertyAt(index: Int) = MutableProperty({ this[index] }) { this[index] = it }
+@JvmName("mutablePropertyAtFlagArray")
 infix fun <F: Flag<F>> FlagArray<F>.mutablePropertyAt(index: Int): MutableProperty<Flag<F>> = MutableProperty({ this[index] }) { this[index] = it }
 inline val <V> V.asMutableProperty
     get() = MutableProperty({ this })

--- a/core/src/main/kotlin/imgui/tmp.kt
+++ b/core/src/main/kotlin/imgui/tmp.kt
@@ -68,14 +68,18 @@ class Property<V>(val get: () -> V) : KProperty0<V> {
 }
 
 infix fun BooleanArray.mutablePropertyAt(index: Int) = MutableProperty({ this[index] }) { this[index] = it }
+infix fun <T> Array<T>.mutablePropertyAt(index: Int) = MutableProperty({ this[index] }) { this[index] = it }
+infix fun <F: Flag<F>> FlagArray<F>.mutablePropertyAt(index: Int): MutableProperty<Flag<F>> = MutableProperty({ this[index] }) { this[index] = it }
 inline val <V> V.asMutableProperty
     get() = MutableProperty({ this })
 
 infix fun <V> V.mutableProperty(set: (V) -> Unit) = MutableProperty({ this }, set)
+val <V> V.mutableReference: MutableReference<V>
+    get() = MutableReference(this)
 //fun <V> mutableProperty(get: () -> V, set: (V) -> Unit = {}) = MutableProperty(get, set)
 
 //fun <V> mutableProperty(get: () -> V) = MutableProperty(get)
-class MutableProperty<V>(val get: () -> V, val set: (V) -> Unit = {}) : KMutableProperty0<V> {
+abstract class MutablePropertyBase<V> : KMutableProperty0<V> {
     override val annotations: List<Annotation>
         get() = TODO("Not yet implemented")
     override val getter: KProperty0.Getter<V>
@@ -117,7 +121,7 @@ class MutableProperty<V>(val get: () -> V, val set: (V) -> Unit = {}) : KMutable
                 TODO("Not yet implemented")
             }
 
-            override fun invoke(): V = get.invoke()
+            override fun invoke(): V = get()
 
         }
     override val isAbstract: Boolean
@@ -147,8 +151,18 @@ class MutableProperty<V>(val get: () -> V, val set: (V) -> Unit = {}) : KMutable
 
     override fun call(vararg args: Any?): V = TODO("Not yet implemented")
     override fun callBy(args: Map<KParameter, Any?>): V = TODO("Not yet implemented")
-    override fun get(): V = get.invoke()
     override fun getDelegate(): Any = TODO("Not yet implemented")
     override fun invoke(): V = get()
-    override fun set(value: V): Unit = set.invoke(value)
+}
+
+class MutableProperty<V>(val get: () -> V, val set: (V) -> Unit = {}) : MutablePropertyBase<V>() {
+    override fun get(): V = get.invoke()
+    override fun set(value: V) = set.invoke(value)
+}
+
+class MutableReference<V>(var field: V) : MutablePropertyBase<V>() {
+    override fun get(): V = field
+    override fun set(value: V) {
+        field = value
+    }
 }

--- a/core/src/main/kotlin/imgui/viewport.kt
+++ b/core/src/main/kotlin/imgui/viewport.kt
@@ -8,20 +8,20 @@ import imgui.internal.sections.ViewportP
 // [SECTION] Viewports
 //-----------------------------------------------------------------------------
 
-typealias ViewportFlags = Int
+typealias ViewportFlags = Flag<ViewportFlag>
 
 /** Flags stored in ImGuiViewport::Flags, giving indications to the platform backends. */
-enum class ViewportFlag(override val i: ViewportFlags) : Flag<ViewportFlag> {
-  None(0),
+enum class ViewportFlag : Flag<ViewportFlag> {
+    /** Represent a Platform Window */
+    IsPlatformWindow,
 
-  /** Represent a Platform Window */
-  IsPlatformWindow(1 shl 0),
+    /** Represent a Platform Monitor (unused yet) */
+    IsPlatformMonitor,
 
-  /** Represent a Platform Monitor (unused yet) */
-  IsPlatformMonitor(1 shl 1),
+    /** Platform Window: is created/managed by the application (rather than a dear imgui backend) */
+    OwnedByApp;
 
-  /** Platform Window: is created/managed by the application (rather than a dear imgui backend) */
-  OwnedByApp(1 shl 2)
+    override val i: Int = 1 shl ordinal
 }
 
 // - Currently represents the Platform Window created by the application which is hosting our Dear ImGui windows.
@@ -33,7 +33,7 @@ enum class ViewportFlag(override val i: ViewportFlags) : Flag<ViewportFlag> {
 //   - Windows are generally trying to stay within the Work Area of their host viewport.
 open class Viewport {
     /** See ImGuiViewportFlags_ */
-    var flags: ViewportFlags = 0
+    var flags: ViewportFlags = emptyFlags()
 
     /** Main Area: Position of the viewport (Dear ImGui coordinates are the same as OS desktop/native coordinates) */
     val pos = Vec2()

--- a/core/src/main/kotlin/imgui/viewport.kt
+++ b/core/src/main/kotlin/imgui/viewport.kt
@@ -1,5 +1,6 @@
 package imgui
 
+import com.livefront.sealedenum.GenSealedEnum
 import glm_.vec2.Vec2
 import imgui.classes.DrawList
 import imgui.internal.sections.ViewportP
@@ -11,17 +12,20 @@ import imgui.internal.sections.ViewportP
 typealias ViewportFlags = Flag<ViewportFlag>
 
 /** Flags stored in ImGuiViewport::Flags, giving indications to the platform backends. */
-enum class ViewportFlag : Flag<ViewportFlag> {
+sealed class ViewportFlag : FlagBase<ViewportFlag>() {
     /** Represent a Platform Window */
-    IsPlatformWindow,
+    object IsPlatformWindow : ViewportFlag()
 
     /** Represent a Platform Monitor (unused yet) */
-    IsPlatformMonitor,
+    object IsPlatformMonitor : ViewportFlag()
 
     /** Platform Window: is created/managed by the application (rather than a dear imgui backend) */
-    OwnedByApp;
+    object OwnedByApp : ViewportFlag()
 
     override val i: Int = 1 shl ordinal
+
+    @GenSealedEnum
+    companion object
 }
 
 // - Currently represents the Platform Window created by the application which is hosting our Dear ImGui windows.
@@ -33,7 +37,7 @@ enum class ViewportFlag : Flag<ViewportFlag> {
 //   - Windows are generally trying to stay within the Work Area of their host viewport.
 open class Viewport {
     /** See ImGuiViewportFlags_ */
-    var flags: ViewportFlags = emptyFlags()
+    var flags: ViewportFlags = emptyFlags
 
     /** Main Area: Position of the viewport (Dear ImGui coordinates are the same as OS desktop/native coordinates) */
     val pos = Vec2()

--- a/core/src/main/kotlin/kotlin/internal/Annotations.kt
+++ b/core/src/main/kotlin/kotlin/internal/Annotations.kt
@@ -1,0 +1,8 @@
+package kotlin.internal
+
+/**
+ * Specifies that the corresponding type should be ignored during type inference.
+ */
+@Target(AnnotationTarget.TYPE)
+@Retention(AnnotationRetention.BINARY)
+internal annotation class NoInfer

--- a/core/src/test/kotlin/fontAtlasTest.kt
+++ b/core/src/test/kotlin/fontAtlasTest.kt
@@ -1,5 +1,5 @@
 
-''''import com.aayushatharva.brotli4j.Brotli4jLoader
+import com.aayushatharva.brotli4j.Brotli4jLoader
 import com.aayushatharva.brotli4j.decoder.Decoder
 import com.aayushatharva.brotli4j.decoder.DecoderJNI
 import glm_.i

--- a/gl/src/main/kotlin/imgui/impl/gl/ImplGL3.kt
+++ b/gl/src/main/kotlin/imgui/impl/gl/ImplGL3.kt
@@ -21,6 +21,7 @@ import imgui.ImGui.io
 import imgui.internal.DrawData
 import imgui.internal.DrawIdx
 import imgui.internal.DrawVert
+import imgui.or
 import kool.*
 import org.lwjgl.opengl.GL30C.*
 import org.lwjgl.opengl.GL31C.GL_PRIMITIVE_RESTART

--- a/gl/src/main/kotlin/imgui/impl/gl/ImplGL3.kt
+++ b/gl/src/main/kotlin/imgui/impl/gl/ImplGL3.kt
@@ -21,7 +21,6 @@ import imgui.ImGui.io
 import imgui.internal.DrawData
 import imgui.internal.DrawIdx
 import imgui.internal.DrawVert
-import imgui.or
 import kool.*
 import org.lwjgl.opengl.GL30C.*
 import org.lwjgl.opengl.GL31C.GL_PRIMITIVE_RESTART

--- a/gl/src/test/java/imgui/examples/OpenGL3.java
+++ b/gl/src/test/java/imgui/examples/OpenGL3.java
@@ -4,6 +4,7 @@ import glm_.vec2.Vec2;
 import glm_.vec2.Vec2i;
 import glm_.vec4.Vec4;
 import imgui.Cond;
+import imgui.Flag;
 import imgui.ImGui;
 import imgui.MutableProperty0;
 import imgui.classes.Context;
@@ -144,7 +145,7 @@ public class OpenGL3 {
         imgui.text("Hello, world!");                                // Display some text (you can use a format string too)
         // TODO
 //        imgui.sliderFloat("float", f, 0, 0f, 1f, "%.3f", 1f);       // Edit 1 float using a slider from 0.0f to 1.0f
-        imgui.colorEdit3("clear color", clearColor, 0);               // Edit 3 floats representing a color
+        imgui.colorEdit3("clear color", clearColor, Flag.empty());               // Edit 3 floats representing a color
 
         imgui.checkbox("Demo Window", showDemo);                 // Edit bools storing our windows open/close state
         imgui.checkbox("Another Window", showAnotherWindow);
@@ -159,7 +160,7 @@ public class OpenGL3 {
 
         // 2. Show another simple window. In most cases you will use an explicit begin/end pair to name the window.
         if (showAnotherWindow.get()) {
-            imgui.begin("Another Window", showAnotherWindow, 0);
+            imgui.begin("Another Window", showAnotherWindow, Flag.empty());
             imgui.text("Hello from another window!");
             if (imgui.button("Close Me", new Vec2()))
                 showAnotherWindow.set(false);

--- a/gl/src/test/java/imgui/examples/OpenGL3.java
+++ b/gl/src/test/java/imgui/examples/OpenGL3.java
@@ -172,7 +172,7 @@ public class OpenGL3 {
         if (showDemo[0]) {
             /*  Normally user code doesn't need/want to call this because positions are saved in .ini file anyway.
                     Here we just want to make the demo initial state a bit more friendly!                 */
-            imgui.setNextWindowPos(new Vec2(650, 20), Cond.FirstUseEver, new Vec2());
+            imgui.setNextWindowPos(new Vec2(650, 20), Cond.FirstUseEver.INSTANCE, new Vec2());
             imgui.showDemoWindow(showDemo);
         }
 

--- a/glfw/src/main/kotlin/imgui/impl/glfw/ImplGlfw.kt
+++ b/glfw/src/main/kotlin/imgui/impl/glfw/ImplGlfw.kt
@@ -1,6 +1,8 @@
 package imgui.impl.glfw
 
-import glm_.*
+import glm_.bool
+import glm_.c
+import glm_.f
 import glm_.vec2.Vec2
 import glm_.vec2.Vec2d
 import glm_.vec2.Vec2i
@@ -300,7 +302,7 @@ class ImplGlfw @JvmOverloads constructor(
 
             updateKeyModifiers()
             if (button >= 0 && button < MouseButton.COUNT)
-                io.addMouseButtonEvent(button, action == GLFW_PRESS)
+                io.addMouseButtonEvent(MouseButton of button, action == GLFW_PRESS)
         }
 
         // X11 does not include current pressed/released modifier key in 'mods' flags submitted by GLFW

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -27,5 +27,6 @@ dependencyResolutionManagement {
     repositories {
         mavenCentral()
         maven("https://raw.githubusercontent.com/kotlin-graphics/mary/master")
+        maven(url = "https://jitpack.io")
     }
 }


### PR DESCRIPTION
This is quite a big refactoring...

Building on the previous work of using a `Flag` interface, this PR changes all the `XFlags` type aliases from being `Int` to being `Flag<XFlags>`. That, combined with a `private value class Flags` and a `value class FlagArray`, allows using type-safe flag combinations everywhere, while still having the ever-useful `and`, `or`, `wo`, `has`, etc methods. 

While implementing this, I genuinely found multiple places where the code was using the wrong enum type of Flag or was checking if flags of totally separate types were equal. It was hence helpful in catching those bugs and remedying them quickly. This also removed a lot of unnecessary range checks we were doing on ints. 

**The only downside of using this PR is that checking flags for equality using `==`  and `!=` is broken**. This is because you can't override `equals` in enums nor in `value class`es. For now, I added `infix fun eq/notEq` to mitigate that problem. However, a more intrusive solution (that will fix `==` checks) is to convert **all** the Flag enums to `sealed class`es (This is simply an IDE intention and so it's very automatic) with a base class that has `equals` overridden, and change `value class Flags` to a non-value class. Note that in Kotlin 1.9.0 `value class`es **will** [be able to override `equals`](https://youtrack.jetbrains.com/issue/KT-24874/Support-custom-equals-and-hashCode-for-value-classes). I'm not sure whether the current `eq/notEq` approach is too finicky, but it surely is less error-prone than comparing raw `Int`s.

Finally, this PR also introduces a useful `MutableReference` type that extends KMutableProperty0. That type might be the beginning of relying less on global mutable vars like `_b` and friends, and instead created `MutableReference`s locally., but that shall come in another PR.